### PR TITLE
UI: SVG carets for log details, tooltip recon note, fix opening wrap,…

### DIFF
--- a/tally_migrator/tally_migration/doctype/tally_migration_error/tally_migration_error.json
+++ b/tally_migrator/tally_migration/doctype/tally_migration_error/tally_migration_error.json
@@ -8,12 +8,11 @@
   "engine": "InnoDB",
   "fields": [
     {
-      "fieldname": "status",
-      "fieldtype": "Select",
-      "label": "Status",
-      "options": "Failed\nSkipped",
+      "fieldname": "record_name",
+      "fieldtype": "Data",
+      "label": "Record",
       "in_list_view": 1,
-      "columns": 1,
+      "columns": 3,
       "read_only": 1
     },
     {
@@ -25,11 +24,12 @@
       "read_only": 1
     },
     {
-      "fieldname": "record_name",
-      "fieldtype": "Data",
-      "label": "Record",
+      "fieldname": "status",
+      "fieldtype": "Select",
+      "label": "Status",
+      "options": "Failed\nSkipped",
       "in_list_view": 1,
-      "columns": 3,
+      "columns": 1,
       "read_only": 1
     },
     {

--- a/tally_migrator/tally_migration/doctype/tally_migration_log/tally_migration_log.js
+++ b/tally_migrator/tally_migration/doctype/tally_migration_log/tally_migration_log.js
@@ -29,6 +29,16 @@ function apply_dark_mode_theme(frm) {
 			--red-100: #361515;    --red-200: #521515;
 			--gray-100: #232323;   --gray-200: #2b2b2b;   --gray-300: #343434;
 		}
+		/* Replace the browser's default <details> triangle with Frappe's SVG caret
+		   (a "right" icon that rotates to point down when open), so disclosure
+		   markers match the carets used elsewhere instead of a black glyph. */
+		.tally-migration-log details > summary { list-style: none; }
+		.tally-migration-log details > summary::-webkit-details-marker { display: none; }
+		.tally-migration-log details > summary .tm-caret {
+			display: inline-flex; align-items: center; vertical-align: middle;
+			color: ${MUTED}; transition: transform 0.15s ease;
+		}
+		.tally-migration-log details[open] > summary .tm-caret { transform: rotate(90deg); }
 	</style>`);
 }
 
@@ -74,6 +84,13 @@ function arrowIcon() {
 	return `<span style="display:inline-flex; align-items:center; vertical-align:middle; color:${MUTED};">${frappe.utils.icon("right", "sm")}</span>`;
 }
 
+// Disclosure caret for a native <details> summary - the CSS in
+// apply_dark_mode_theme() hides the browser triangle and rotates this to point
+// down when the section is open, matching the wizard's caret vocabulary.
+function caretMarker() {
+	return `<span class="tm-caret">${frappe.utils.icon("right", "sm")}</span>`;
+}
+
 // Icon + content, with the 16px icon optically centred on the first line of text
 // (a 1.5em flex box), so headings of any size sit level with their marker.
 function iconRow(kind, html) {
@@ -99,7 +116,7 @@ const COLLAPSE_AT = 8;
 function collapsible(count, summaryText, innerHtml) {
 	if (count <= COLLAPSE_AT) return innerHtml;
 	return `<details style="margin-top:4px;">
-		<summary style="cursor:pointer; user-select:none; color:${MUTED}; font-size:12px;"><span style="margin-left:6px;">${summaryText}</span></summary>
+		<summary style="cursor:pointer; user-select:none; color:${MUTED}; font-size:12px;">${caretMarker()}<span style="margin-left:6px;">${summaryText}</span></summary>
 		<div style="margin-top:8px;">${innerHtml}</div>
 	</details>`;
 }
@@ -540,7 +557,7 @@ function render_reconciliation(frm) {
 		.map((row) => {
 			const stat = !row.has_erpnext ? "" : row.match ? statusIcon("success") : statusIcon("error");
 			const note = row.is_opening_difference
-				? `<div class="text-muted small" style="font-weight:400;">The opening difference Tally could not balance on its own, plus any income/expense openings ERPNext cannot carry - a non-zero value here is faithful, not a gap.</div>`
+				? ` <span class="text-muted" style="display:inline-flex; vertical-align:middle; cursor:help;" title="The opening difference Tally could not balance on its own, plus any income/expense openings ERPNext cannot carry - a non-zero value here is faithful, not a gap.">${frappe.utils.icon("solid-info", "sm")}</span>`
 				: "";
 			const erpDr = avail && row.has_erpnext ? dr(row.erpnext) : "";
 			const erpCr = avail && row.has_erpnext ? cr(row.erpnext) : "";
@@ -663,7 +680,7 @@ function render_created(frm) {
 			return `
 				<details style="border-top:1px solid var(--gray-200, #f0f4f7); padding:8px 0;">
 					<summary style="cursor:pointer; user-select:none; font-weight:500;">
-						<span style="margin-left:6px;">${esc(label)} <span class="text-muted" style="font-weight:400;">(${names.length})</span></span>
+						${caretMarker()}<span style="margin-left:6px;">${esc(label)} <span class="text-muted" style="font-weight:400;">(${names.length})</span></span>
 					</summary>
 					<div class="small" style="line-height:1.8; margin:6px 0 0 14px;">${links}</div>
 				</details>`;

--- a/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
+++ b/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
@@ -1440,7 +1440,7 @@ class TallyMigratorPage {
 		// Opening balance cell: amount + Dr/Cr, muted when zero.
 		const ob = (r) =>
 			r.amount
-				? `${fmt(r.amount)} <span class="text-muted">${esc(r.dr_cr)}</span>`
+				? `<span style="white-space:nowrap;">${fmt(r.amount)} <span class="text-muted">${esc(r.dr_cr)}</span></span>`
 				: `<span class="text-muted">0</span>`;
 		const classifiedAs = (r) =>
 			esc(r.root_type) + (r.account_type ? ` · ${esc(r.account_type)}` : "");
@@ -1530,9 +1530,11 @@ class TallyMigratorPage {
 		// ── Full chart of accounts (collapsed) ─────────────────────────────────
 		const book = (m.groups || [])
 			.map((g) => {
+				// Each subtotal stays on its own line with the amount glued to its
+				// Dr/Cr suffix (nowrap), so a long mixed-sign group never orphans "Cr".
 				const sub = [];
-				if (g.subtotal_dr) sub.push(`${fmt(g.subtotal_dr)} Dr`);
-				if (g.subtotal_cr) sub.push(`${fmt(g.subtotal_cr)} Cr`);
+				if (g.subtotal_dr) sub.push(`<span style="white-space:nowrap;">${fmt(g.subtotal_dr)} Dr</span>`);
+				if (g.subtotal_cr) sub.push(`<span style="white-space:nowrap;">${fmt(g.subtotal_cr)} Cr</span>`);
 				const accRows = g.accounts
 					.map(
 						(r) => `
@@ -1551,7 +1553,7 @@ class TallyMigratorPage {
 				return `
 					<tr style="background:var(--fg-color, #f7fafc);">
 						<td colspan="3" style="padding:6px 10px; font-weight:600;">${esc(g.root_type)}</td>
-						<td style="padding:6px 10px; text-align:right; font-weight:600;">${sub.join(" · ")}</td>
+						<td style="padding:6px 10px; text-align:right; font-weight:600;">${sub.join("<br>")}</td>
 					</tr>
 					${accRows}`;
 			})


### PR DESCRIPTION
… reorder issues columns

- Log "Records Created"/collapsible: replace native <details> triangle with Frappe's SVG caret (rotates to point down when open)
- Reconciliation: move the long Temporary Opening description into a hover tooltip on a solid-info icon so the table row stays compact
- Review COA book: stack Dr/Cr subtotals and keep each amount glued to its suffix (nowrap) so long mixed-sign openings no longer orphan "Cr"
- Issues table: reorder columns to Record, Record Type, Status, Details