### PR TITLE
CI: bump Python to 3.14 to match Frappe version-16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          # Frappe version-16 sets requires-python ">=3.14,<3.15" and uses PEP 695
+          # `type X = ...` aliases (3.12+), so an older Python fails to even compile
+          # frappe at install time. Keep this in step with the FRAPPE_BRANCH above.
+          python-version: "3.14"
 
       - name: Set up Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
Frappe version-16 (v16.21.0) sets requires-python ">=3.14,<3.15" and uses PEP 695 `type X = ...` aliases (3.12+), so installing it under the previous Python 3.11 pin failed to compile frappe at install time with a SyntaxError (exit 167). Bump the CI interpreter to 3.14 to match Frappe's requires-python.