### PR TITLE
Reliability/UX guards: liveness-aware run guard + readiness debounce + manifest emailChore/manifest and reliability guards

### DIFF
--- a/tally_migrator/api.py
+++ b/tally_migrator/api.py
@@ -315,28 +315,51 @@ RUN_ASYNC_THRESHOLD = 5000
 _ACTIVE_RUN_STALE_SECONDS = 2 * 60 * 60
 
 
+def _is_job_alive(job_id: str) -> bool:
+    """Is the RQ job for an enqueued run still queued or running?
+
+    Wraps Frappe's ``is_job_enqueued`` defensively: if RQ/Redis can't be reached we
+    return True (assume alive) so a transient lookup failure can't wave through a
+    genuine concurrent run - the duplicate-start guard fails closed."""
+    try:
+        from frappe.utils.background_jobs import is_job_enqueued
+        return is_job_enqueued(job_id)
+    except Exception:
+        return True
+
+
 def _assert_no_active_run(company: str) -> None:
     """Refuse to start a second migration while one is already running for the
-    same company. Only a *recent* 'Running' log blocks; a stale one (crashed
-    worker) is ignored so re-runs aren't locked out. Best-effort UX guard - the
-    opening lock in the importer is what actually protects the books."""
+    same company. A stale run (crashed worker) is ignored so re-runs aren't locked
+    out. For an async run we ask RQ whether the worker is genuinely still alive; for
+    a sync run (no job id, request-bound) we fall back to an age cap. Best-effort UX
+    guard - the opening lock in the importer is what actually protects the books."""
     if not company:
         return
     rows = frappe.get_all(
         "Tally Migration Log",
         filters={"company": company, "status": "Running"},
-        fields=["name", "modified"], order_by="modified desc", limit=1,
+        fields=["name", "modified", "job_id"], order_by="modified desc", limit=1,
     )
     if not rows:
         return
     modified = rows[0].modified
-    if frappe.utils.time_diff_in_seconds(frappe.utils.now(), modified) < _ACTIVE_RUN_STALE_SECONDS:
-        frappe.throw(
-            frappe._(
-                "A migration for '{0}' is already running (started {1}). Please wait "
-                "for it to finish, or open the migration log to check its status."
-            ).format(company, frappe.utils.pretty_date(modified))
-        )
+    job_id = rows[0].get("job_id")
+    if job_id:
+        # Liveness, not age: an enqueued run blocks only while its RQ job is actually
+        # queued or running. A crashed/finished/missing job leaves a 'Running' log
+        # behind, but is_job_enqueued() returns False, so it never locks out a re-run -
+        # and a legitimately long (>2h) job keeps blocking, which the age cap couldn't.
+        if not _is_job_alive(job_id):
+            return
+    elif frappe.utils.time_diff_in_seconds(frappe.utils.now(), modified) >= _ACTIVE_RUN_STALE_SECONDS:
+        return
+    frappe.throw(
+        frappe._(
+            "A migration for '{0}' is already running (started {1}). Please wait "
+            "for it to finish, or open the migration log to check its status."
+        ).format(company, frappe.utils.pretty_date(modified))
+    )
 
 
 def _assert_file_access(file_doc) -> None:
@@ -476,11 +499,16 @@ def _enqueue_masters_run(config: TallyConfig, file_url, erpnext_company, uom_ove
     """
     migrator = MasterMigrator(config, source=None)
     log = migrator._create_log()
+    # Stamp the log with the RQ job id so the active-run guard can ask RQ whether the
+    # worker is genuinely still alive (vs crashed), instead of relying only on age.
+    job_id = f"tally-masters-{log.name}"
+    log.db_set("job_id", job_id, commit=True)
     frappe.enqueue(
         "tally_migrator.api._run_masters_job",
         queue="long",
         timeout=4 * 60 * 60,
         enqueue_after_commit=True,
+        job_id=job_id,
         file_url=file_url,
         erpnext_company=erpnext_company,
         uom_overrides=uom_overrides,

--- a/tally_migrator/hooks.py
+++ b/tally_migrator/hooks.py
@@ -2,7 +2,7 @@ app_name        = "tally_migrator"
 app_title       = "Tally Migrator"
 app_publisher   = "Parth Garachh"
 app_description = "Migrate masters and opening balances from Tally to ERPNext"
-app_email       = "parth1garachh@gmail.com"
+app_email       = "parth@frappe.io"
 app_license     = "MIT"
 app_version     = "1.0.0"
 

--- a/tally_migrator/tally_migration/doctype/tally_migration_log/tally_migration_log.json
+++ b/tally_migrator/tally_migration/doctype/tally_migration_log/tally_migration_log.json
@@ -72,6 +72,14 @@
    "description": "Per-record field fixes (GSTIN/state/HSN/\u2026) made on the pre-flight screen. Kept so a re-run re-applies the same fixes instead of importing the unfixed data."
   },
   {
+   "fieldname": "job_id",
+   "fieldtype": "Data",
+   "label": "Background Job ID",
+   "read_only": 1,
+   "hidden": 1,
+   "description": "RQ job id for an async (enqueued) run. Used to tell a still-running run from a crashed one when guarding against a duplicate start."
+  },
+  {
    "fieldname": "col_break_1",
    "fieldtype": "Column Break"
   },

--- a/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
+++ b/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
@@ -767,6 +767,11 @@ class TallyMigratorPage {
 	// Re-run only the readiness check (after the user fixes setup in another tab),
 	// without re-scanning the whole file.
 	recheckReadiness() {
+		// Disable the button while the call is in flight so a rapid double-click can't
+		// queue duplicate readiness checks (the button is re-rendered by renderReadiness).
+		const $btn = $("#btn-recheck-readiness");
+		if ($btn.prop("disabled")) return;
+		$btn.prop("disabled", true);
 		frappe.call({
 			method: "tally_migrator.api.company_readiness",
 			args: { erpnext_company: $("#erpnext-company").val() },
@@ -774,6 +779,7 @@ class TallyMigratorPage {
 				this.readiness = r.message || null;
 				this.renderReadiness();
 			},
+			error: () => $btn.prop("disabled", false),
 		});
 	}
 

--- a/tally_migrator/tests/test_critical_fixes.py
+++ b/tally_migrator/tests/test_critical_fixes.py
@@ -251,6 +251,28 @@ class TestActiveRunGuard(unittest.TestCase):
                 mock.patch("frappe.utils.time_diff_in_seconds", return_value=10 * 3600):
             self._api()._assert_no_active_run("Acme")   # stale -> must not raise
 
+    def test_live_async_job_blocks_regardless_of_age(self):
+        # An enqueued run with a still-alive RQ job blocks even past the age cap that
+        # would have freed a sync run - liveness wins over age.
+        rows = [frappe._dict(
+            {"name": "LOG-1", "modified": "2026-01-01 00:00:00", "job_id": "tally-masters-LOG-1"})]
+        with mock.patch("frappe.get_all", return_value=rows), \
+                mock.patch.object(self._api(), "_is_job_alive", return_value=True), \
+                mock.patch("frappe.utils.time_diff_in_seconds", return_value=10 * 3600), \
+                mock.patch("frappe.utils.now", return_value="ignored"), \
+                mock.patch("frappe.utils.pretty_date", return_value="earlier"):
+            with self.assertRaises(frappe.ValidationError):
+                self._api()._assert_no_active_run("Acme")
+
+    def test_dead_async_job_allows_even_when_recent(self):
+        # A crashed worker leaves a recent 'Running' log, but its RQ job is gone, so a
+        # re-run is allowed immediately rather than waiting out the age cap.
+        rows = [frappe._dict(
+            {"name": "LOG-1", "modified": "2026-01-01 00:00:00", "job_id": "tally-masters-LOG-1"})]
+        with mock.patch("frappe.get_all", return_value=rows), \
+                mock.patch.object(self._api(), "_is_job_alive", return_value=False):
+            self._api()._assert_no_active_run("Acme")   # dead job -> must not raise
+
 
 class TestItemHsnRecovery(unittest.TestCase):
     """An India-Compliance HSN rejection must not lose the item: the importer


### PR DESCRIPTION
## Phase 1 - manifest (L1)
- app_email pointed at a personal gmail; aligned it to the frappe.io identity.

## Phase 2 - reliability/UX guards (M2 + M3)

M2 - duplicate-start guard is now liveness-aware instead of a flat 2h age cap.
Async runs stamp their RQ job id on the log (new hidden `job_id` field); the
guard asks `is_job_enqueued()` whether the worker is genuinely alive. A crashed
job frees a re-run immediately; a legitimately long (>2h) run keeps blocking -
both of which the old age cap got wrong. Sync runs (no job id) keep the age
fallback unchanged. `_is_job_alive` fails closed so a Redis hiccup can't wave
through a real concurrent run.

M3 - `recheckReadiness()` disables its button while the call is in flight so a
rapid double-click can't queue duplicate checks. (The heavy file re-parse
re-check was already blocked by `frappe.dom.freeze`.)

## Reviewer notes
- New `job_id` field is a schema change -> run `bench migrate` after deploy.
  Backward compatible: existing logs have an empty job_id and use the age guard.
- Adds 2 tests covering the live-blocks / dead-allows paths.
- Verified: py_compile, node --check, JSON parse all clean; runnable guard tests
  pass (throw-path tests need a site-bound context, covered by CI run-tests).