### PR TITLE
Perf: bound the source-parse cache as an LRU (H2)

### DIFF
--- a/tally_migrator/api.py
+++ b/tally_migrator/api.py
@@ -1,5 +1,6 @@
 import json
 import threading
+from collections import OrderedDict
 
 import frappe
 
@@ -282,19 +283,26 @@ def rerun_from_log(log_name: str):
 
 # ── Internal helpers ──────────────────────────────────────────────────────────
 
-# Most-recently-parsed source, keyed by (user, File name, modified timestamp). The
+# LRU of recently-parsed sources, keyed by (user, File name, modified timestamp). The
 # wizard re-calls validate/preview on every inline fix ("Re-check"), each of which
 # would otherwise re-read, re-decode, re-sanitize and re-parse the whole file. The
 # File's bytes are immutable for a given (name, modified), so a cached parse is
 # always valid; a new upload (new name) or an edit (new modified) misses and
-# re-parses. Bounded to one entry so a large file can't pin memory across uploads.
+# re-parses. The key includes the user so one person's upload can never hand another
+# person's request a different file's parse.
+#
+# Bounded to ``_SOURCE_CACHE_MAX`` entries (least-recently-used evicted): a single
+# slot meant two managers migrating at once - or one user re-checking two files -
+# kept evicting each other and re-parsing a large file on every call. A handful of
+# entries removes that thrash; the cap still limits how much parsed data can pin
+# memory (worst case ~_SOURCE_CACHE_MAX large files), so it stays a small number.
 #
 # The cache is a process global shared by every worker thread, so all access goes
-# through ``_SOURCE_CACHE_LOCK``: without it two concurrent requests could clear /
-# repopulate it mid-read, and the key includes the user so one person's upload can
-# never hand another person's request a different file's parse.
-_SOURCE_CACHE: dict = {}
+# through ``_SOURCE_CACHE_LOCK``: without it two concurrent requests could mutate the
+# ordering / evict mid-read.
+_SOURCE_CACHE: "OrderedDict" = OrderedDict()
 _SOURCE_CACHE_LOCK = threading.Lock()
+_SOURCE_CACHE_MAX = 4
 
 # Reject uploads above this size before parsing, with an actionable message,
 # rather than letting a multi-gigabyte file exhaust the worker. UTF-16 exports
@@ -383,10 +391,13 @@ def _source_from_file(file_url):
     cache_key = (frappe.session.user, file_doc.name, str(file_doc.modified))
     with _SOURCE_CACHE_LOCK:
         source = _SOURCE_CACHE.get(cache_key)
-        if source is None:
-            source = FileTallySource(_decode(_raw_file_bytes(file_doc)))
-            _SOURCE_CACHE.clear()        # keep only the most-recent file's parse
-            _SOURCE_CACHE[cache_key] = source
+        if source is not None:
+            _SOURCE_CACHE.move_to_end(cache_key)     # mark most-recently used
+            return file_doc, source
+        source = FileTallySource(_decode(_raw_file_bytes(file_doc)))
+        _SOURCE_CACHE[cache_key] = source            # inserts as most-recently used
+        while len(_SOURCE_CACHE) > _SOURCE_CACHE_MAX:
+            _SOURCE_CACHE.popitem(last=False)        # evict least-recently used
     return file_doc, source
 
 

--- a/tally_migrator/tests/test_file_source.py
+++ b/tally_migrator/tests/test_file_source.py
@@ -3,7 +3,9 @@
 No Tally connection and no Frappe site required - exercises the parser and its
 interop with TallyExtractor directly.
 """
+import types
 import unittest
+from unittest import mock
 
 from tally_migrator.tally.file_source import (
     FileTallySource, decode_tally_bytes, sanitize_tally_xml,
@@ -278,6 +280,70 @@ class TestCacheIsolation(unittest.TestCase):
         self.assertEqual(len(log2), 1, "cached parse was poisoned - second apply lost the edit")
         self.assertEqual(log2[0]["old"], "Maharashtra")
         self.assertEqual(log2[0]["new"], "Gujarat")
+
+
+class TestSourceCacheLRU(unittest.TestCase):
+    """api._SOURCE_CACHE is a bounded LRU. A single slot used to make two managers
+    migrating at once (or one user re-checking two files) evict each other and
+    re-parse a large file on every call; the LRU keeps a handful of parses alive and
+    only drops the least-recently-used past the cap."""
+
+    def setUp(self):
+        from tally_migrator import api
+        self.api = api
+        api._SOURCE_CACHE.clear()
+        self.addCleanup(api._SOURCE_CACHE.clear)
+
+    def _fetch(self, fname, parses):
+        """Drive api._source_from_file for a file, recording each real (cache-miss)
+        parse in ``parses``. Returns the source so identity (cache hit) can be checked."""
+        api = self.api
+        file_doc = types.SimpleNamespace(name=fname, modified="m", file_name=fname)
+
+        def make(_decoded):
+            parses.append(fname)
+            return object()                      # a unique sentinel per parse
+
+        with mock.patch.object(api.frappe.db, "exists", return_value=fname), \
+                mock.patch.object(api.frappe, "get_doc", return_value=file_doc), \
+                mock.patch.object(api, "_assert_file_access"), \
+                mock.patch.object(api, "_raw_file_bytes", return_value=b""), \
+                mock.patch.object(api, "_decode", return_value=""), \
+                mock.patch.object(api, "FileTallySource", side_effect=make), \
+                mock.patch.object(api.frappe, "session",
+                                  types.SimpleNamespace(user="u@example.com")):
+            _, source = api._source_from_file("/files/" + fname)
+        return source
+
+    def test_two_files_coexist_and_hit_skips_reparse(self):
+        parses = []
+        s_a = self._fetch("A", parses)
+        self._fetch("B", parses)
+        s_a_again = self._fetch("A", parses)
+        self.assertIs(s_a, s_a_again)            # cache hit returns the same parse
+        self.assertEqual(parses, ["A", "B"])     # A was NOT re-parsed (no thrash)
+
+    def test_evicts_least_recently_used(self):
+        parses = []
+        with mock.patch.object(self.api, "_SOURCE_CACHE_MAX", 2):
+            self._fetch("A", parses)
+            self._fetch("B", parses)
+            self._fetch("C", parses)             # over cap -> evicts A (LRU)
+            self.assertEqual(len(self.api._SOURCE_CACHE), 2)
+            self._fetch("A", parses)             # A was evicted, so re-parsed
+        self.assertEqual(parses, ["A", "B", "C", "A"])
+
+    def test_hit_refreshes_recency(self):
+        parses = []
+        with mock.patch.object(self.api, "_SOURCE_CACHE_MAX", 2):
+            a = self._fetch("A", parses)
+            self._fetch("B", parses)
+            a2 = self._fetch("A", parses)        # hit -> A becomes most-recent
+            self.assertIs(a, a2)
+            self._fetch("C", parses)             # evicts B (now LRU), keeps A
+            a3 = self._fetch("A", parses)        # A still cached
+            self.assertIs(a, a3)
+        self.assertEqual(parses, ["A", "B", "C"])  # A parsed once despite 4 fetches
 
 
 class TestDecode(unittest.TestCase):


### PR DESCRIPTION
## What
Replace the single-slot `_SOURCE_CACHE` with an OrderedDict LRU capped at 4.

## Why
The parse cache held exactly one entry and clear()'d on every miss, so two
managers migrating at once - or one user re-checking two files - kept evicting
each other and re-parsing the whole (up to 150MB) export on every call. The
cache meant to make "Re-check" cheap was instead guaranteeing a re-parse under
any concurrency.

## How
`_SOURCE_CACHE` is now an OrderedDict LRU (`_SOURCE_CACHE_MAX = 4`): evicts
least-recently-used past the cap, refreshes recency on a hit. The cap still
bounds worst-case memory (~4 parsed files). Locking and the per-user cache key
are unchanged.

## Tests
Adds `TestSourceCacheLRU`: files coexist without thrash, a hit skips re-parse,
LRU eviction, and recency-refresh on hit. No schema change, so no `bench migrate`.