### PR TITLE
CI: bump Node to 24 to match Frappe version-16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,10 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          # Frappe v16 requires Node 20+.
-          node-version: "20"
+          # Frappe version-16 declares engines.node ">=24" in package.json, so
+          # `yarn install` aborts on anything older ("engine node incompatible").
+          # Keep this in step with the FRAPPE_BRANCH above.
+          node-version: "24"
 
       - name: System dependencies
         run: |


### PR DESCRIPTION
bench init failed at the yarn install step: Frappe version-16 declares
engines.node ">=24" in package.json, so yarn aborts under the previous Node 20
pin ("The engine node is incompatible ... Expected >=24, Got 20.20.2"). The Node
counterpart to the earlier Python 3.14 floor bump - a Frappe v16 toolchain-floor
change, not app code. Bumps actions/setup-node to Node 24.