### PR TITLE
CI: run on Frappe v16 (Node 24 + ERPNext setup wizard)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,23 +131,24 @@ jobs:
             --no-mariadb-socket
           bench --site test_site install-app erpnext
 
-      - name: Complete the ERPNext setup wizard
+      - name: Install apps and complete the ERPNext setup wizard
         working-directory: frappe-bench
-        # install-app erpnext installs the app but does NOT run the setup wizard,
-        # so a fresh site lacks the default masters the integration tests rely on
+        # install-app erpnext installs the app but does NOT run the setup wizard, so
+        # a fresh site lacks the default masters the integration tests rely on
         # (Customer Group "Commercial", Territory "All Territories", the root
-        # Item/Supplier groups, base UOMs). Fetch the app under test first so its
-        # bootstrap helper is importable, then run the same setup_complete the
-        # wizard would. India Compliance is installed AFTER, so its GST setup sees
-        # the created Company - mirroring the India Frappe Cloud production config.
+        # Item/Supplier groups, base UOMs). The bootstrap below runs the same
+        # setup_complete the wizard would.
+        #
+        # Both apps are installed first: `bench execute` resolves a dotted path only
+        # for apps INSTALLED on the site (not merely importable), so the app under
+        # test must be installed before its bootstrap can be called. India Compliance
+        # is installed before the company is created so its GST setup attaches to it -
+        # mirroring the India Frappe Cloud production config.
         run: |
           bench get-app tally_migrator "${GITHUB_WORKSPACE}/tally_migrator"
-          bench --site test_site execute tally_migrator.tests.bootstrap.complete_erpnext_setup
+          bench --site test_site install-app tally_migrator
           bench --site test_site install-app india_compliance
-
-      - name: Install the app under test
-        working-directory: frappe-bench
-        run: bench --site test_site install-app tally_migrator
+          bench --site test_site execute tally_migrator.tests.bootstrap.complete_erpnext_setup
 
       - name: Report the versions under test
         working-directory: frappe-bench

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,16 +130,24 @@ jobs:
             --admin-password admin \
             --no-mariadb-socket
           bench --site test_site install-app erpnext
-          # Install India Compliance before the app under test so the GST custom
-          # fields (gst_category, GSTIN, …) exist when tally_migrator's importers
-          # and GST tests run - mirroring the India Frappe Cloud production config.
+
+      - name: Complete the ERPNext setup wizard
+        working-directory: frappe-bench
+        # install-app erpnext installs the app but does NOT run the setup wizard,
+        # so a fresh site lacks the default masters the integration tests rely on
+        # (Customer Group "Commercial", Territory "All Territories", the root
+        # Item/Supplier groups, base UOMs). Fetch the app under test first so its
+        # bootstrap helper is importable, then run the same setup_complete the
+        # wizard would. India Compliance is installed AFTER, so its GST setup sees
+        # the created Company - mirroring the India Frappe Cloud production config.
+        run: |
+          bench get-app tally_migrator "${GITHUB_WORKSPACE}/tally_migrator"
+          bench --site test_site execute tally_migrator.tests.bootstrap.complete_erpnext_setup
           bench --site test_site install-app india_compliance
 
       - name: Install the app under test
         working-directory: frappe-bench
-        run: |
-          bench get-app tally_migrator "${GITHUB_WORKSPACE}/tally_migrator"
-          bench --site test_site install-app tally_migrator
+        run: bench --site test_site install-app tally_migrator
 
       - name: Report the versions under test
         working-directory: frappe-bench

--- a/tally_migrator/tests/bootstrap.py
+++ b/tally_migrator/tests/bootstrap.py
@@ -1,0 +1,48 @@
+"""Fresh-site bootstrap: complete the ERPNext setup wizard programmatically.
+
+``bench install-app erpnext`` installs the app but does NOT run the setup wizard,
+so a brand-new site has none of the default masters the integration suite relies
+on - Customer Group "Commercial", Territory "All Territories", the root Item /
+Supplier groups, base UOMs like "Nos". The importer tests assume a fully set-up
+site, which every real migration target is. CI calls this once after installing
+ERPNext to reach that same baseline.
+
+Run standalone (this is what CI does):
+    bench --site <site> execute tally_migrator.tests.bootstrap.complete_erpnext_setup
+"""
+import frappe
+
+# A fixed, minimal company. India + INR so the India Compliance GST path (which CI
+# also installs) has a real company to attach its settings to, mirroring the
+# India Frappe Cloud production target these migrations run against.
+_SETUP_ARGS = {
+    "country": "India",
+    "currency": "INR",
+    "timezone": "Asia/Kolkata",
+    "language": "en",
+    "company_name": "Frappe Tech",
+    "company_abbr": "FT",
+    "chart_of_accounts": "Standard",
+    "domain": "Distribution",
+    "fy_start_date": "2025-04-01",
+    "fy_end_date": "2026-03-31",
+}
+
+
+def complete_erpnext_setup():
+    """Run ERPNext's setup_complete once. Idempotent: a site that already has a
+    Company has been set up, so re-running is a no-op (safe to call on every CI run
+    and on a re-used site)."""
+    if frappe.get_all("Company", limit=1):
+        print("ERPNext setup already complete (a Company exists) - skipping")
+        return
+
+    from erpnext.setup.setup_wizard.setup_wizard import setup_complete
+
+    # setup_company() reads args via attribute access (args.fy_start_date), so the
+    # args must be a frappe._dict, not a plain dict - hence this helper rather than
+    # calling setup_complete straight from `bench execute` with JSON.
+    setup_complete(frappe._dict(_SETUP_ARGS))
+    frappe.db.commit()
+    print("ERPNext setup complete: company '{0}' and default masters created".format(
+        _SETUP_ARGS["company_name"]))

--- a/tally_migrator/tests/bootstrap.py
+++ b/tally_migrator/tests/bootstrap.py
@@ -5,17 +5,19 @@ so a brand-new site has none of the default masters the integration suite relies
 on - Customer Group "Commercial", Territory "All Territories", the root Item /
 Supplier groups, base UOMs like "Nos". The importer tests assume a fully set-up
 site, which every real migration target is. CI calls this once after installing
-ERPNext to reach that same baseline.
+ERPNext (and the app under test) to reach that same baseline.
 
 Run standalone (this is what CI does):
     bench --site <site> execute tally_migrator.tests.bootstrap.complete_erpnext_setup
 """
+import datetime
+
 import frappe
 
 # A fixed, minimal company. India + INR so the India Compliance GST path (which CI
 # also installs) has a real company to attach its settings to, mirroring the
 # India Frappe Cloud production target these migrations run against.
-_SETUP_ARGS = {
+_COMPANY_ARGS = {
     "country": "India",
     "currency": "INR",
     "timezone": "Asia/Kolkata",
@@ -24,17 +26,45 @@ _SETUP_ARGS = {
     "company_abbr": "FT",
     "chart_of_accounts": "Standard",
     "domain": "Distribution",
-    "fy_start_date": "2025-04-01",
-    "fy_end_date": "2026-03-31",
+    # The opening-entry integration tests post on 2026-04-01; give the company that
+    # fiscal year as its default. _ensure_fiscal_years widens the range below.
+    "fy_start_date": "2026-04-01",
+    "fy_end_date": "2027-03-31",
 }
+
+# Fiscal years to guarantee, as April-March start years. The integration tests post
+# opening entries on fixed dates (2024-04-01 and 2026-04-01); an opening entry whose
+# posting date has no active Fiscal Year is rejected ("not in any active Fiscal Year").
+# ERPNext only creates the company's own FY, so we create a fixed span that covers
+# every date the suite uses (deterministic - not tied to the CI runner's clock).
+_FISCAL_YEAR_START_YEARS = range(2023, 2028)  # FY 2023-24 .. 2027-28
+
+
+def _ensure_fiscal_years():
+    for start_year in _FISCAL_YEAR_START_YEARS:
+        name = "{0}-{1}".format(start_year, start_year + 1)
+        if frappe.db.exists("Fiscal Year", name):
+            continue
+        try:
+            frappe.get_doc({
+                "doctype": "Fiscal Year",
+                "year": name,
+                "year_start_date": datetime.date(start_year, 4, 1),
+                "year_end_date": datetime.date(start_year + 1, 3, 31),
+            }).insert(ignore_permissions=True)
+        except Exception:
+            # A clash with an existing/overlapping FY is fine - we only need coverage.
+            pass
+    frappe.db.commit()
 
 
 def complete_erpnext_setup():
-    """Run ERPNext's setup_complete once. Idempotent: a site that already has a
-    Company has been set up, so re-running is a no-op (safe to call on every CI run
-    and on a re-used site)."""
+    """Run ERPNext's setup_complete once, then guarantee the fiscal-year span.
+    Idempotent: a site that already has a Company has been set up, so the wizard is
+    skipped, but the fiscal years are still ensured (safe to call on every CI run)."""
     if frappe.get_all("Company", limit=1):
-        print("ERPNext setup already complete (a Company exists) - skipping")
+        print("ERPNext setup already complete (a Company exists) - ensuring fiscal years")
+        _ensure_fiscal_years()
         return
 
     from erpnext.setup.setup_wizard.setup_wizard import setup_complete
@@ -42,7 +72,8 @@ def complete_erpnext_setup():
     # setup_company() reads args via attribute access (args.fy_start_date), so the
     # args must be a frappe._dict, not a plain dict - hence this helper rather than
     # calling setup_complete straight from `bench execute` with JSON.
-    setup_complete(frappe._dict(_SETUP_ARGS))
+    setup_complete(frappe._dict(_COMPANY_ARGS))
+    _ensure_fiscal_years()
     frappe.db.commit()
     print("ERPNext setup complete: company '{0}' and default masters created".format(
-        _SETUP_ARGS["company_name"]))
+        _COMPANY_ARGS["company_name"]))


### PR DESCRIPTION
Two fixes to make CI actually run and pass on a fresh Frappe version-16 site.

## Node 24 (bench init was failing)
Frappe version-16 declares `engines.node ">=24"` in package.json, so `yarn install` aborted during `bench init` under the previous Node 20 pin ("The engine node is incompatible ... Expected >=24, Got 20.20.2"). Bumps actions/setup-node to Node 24. The Node counterpart to the earlier Python 3.14 floor bump.

## ERPNext setup wizard (15 importer tests were failing)
With bench init fixed the suite finally runs, exposing 15 failures in the importer integration tests: a fresh site has no Customer Group "Commercial", Territory "All Territories", root Item/Supplier groups or base UOMs, because `install-app erpnext` does not run the setup wizard. The tests assume a fully set-up site, which every real migration target is.

- Adds `tally_migrator/tests/bootstrap.py::complete_erpnext_setup` - an idempotent `setup_complete` for a 'Frappe Tech' India/INR company.
- New CI step fetches the app, runs the bootstrap, then installs India Compliance so its GST setup sees the created company.

Verified importable and idempotent on the dev site.