### PR TITLE
Fix file access denial when an export was already uploaded by another user

### DIFF
--- a/tally_migrator/api.py
+++ b/tally_migrator/api.py
@@ -398,9 +398,15 @@ def _source_from_file(file_url):
     migration run also reads ``file_doc.file_name`` for the log label. Access is
     checked (see ``_assert_file_access``) and the parse is cached per file version.
     """
+    # Frappe stores byte-identical uploads at one path, so a single file_url can map
+    # to several File rows owned by different users (e.g. the same export uploaded by
+    # two people). Prefer the row owned by the current user; otherwise fall back to any
+    # match (access is still enforced by _assert_file_access below).
+    name = frappe.db.exists(
+        "File", {"file_url": file_url, "owner": frappe.session.user}
+    ) or frappe.db.exists("File", {"file_url": file_url})
     # A stale draft (or a re-run from a log) can point at a File that has since been
     # deleted; surface that as a clear, actionable message instead of a raw 500.
-    name = frappe.db.exists("File", {"file_url": file_url})
     if not name:
         frappe.throw(
             frappe._(

--- a/tally_migrator/tests/test_file_lookup.py
+++ b/tally_migrator/tests/test_file_lookup.py
@@ -1,0 +1,79 @@
+"""
+Regression test for shared-file_url resolution in ``api._source_from_file``.
+
+Byte-identical uploads are stored at one path in Frappe, so a single ``file_url``
+can map to several File rows owned by different users. The resolver must pick the
+row owned by the current user; otherwise a manager re-uploading an export someone
+else already uploaded resolves to the other user's File and is wrongly refused
+access ("You are not permitted to access this file").
+"""
+import types
+import unittest
+from unittest import mock
+
+from tally_migrator import api
+
+
+class TestSharedFileUrlResolution(unittest.TestCase):
+    def _run(self, exists_rows, session_user="manager@example.com"):
+        """Drive _source_from_file with a fake File table and capture the row picked."""
+        # exists_rows: dict keyed by frozenset(filter items) -> File name (or None)
+        calls = []
+
+        def fake_exists(doctype, filters):
+            calls.append(filters)
+            return exists_rows.get(frozenset(filters.items()))
+
+        picked = {}
+
+        def fake_get_doc(doctype, name):
+            picked["name"] = name
+            return types.SimpleNamespace(
+                name=name, owner="ignored", modified="t", file_name="x.xml"
+            )
+
+        prev_user = api.frappe.session.user
+        api.frappe.session.user = session_user
+        try:
+            with mock.patch.object(api.frappe.db, "exists", side_effect=fake_exists), \
+                 mock.patch.object(api.frappe, "get_doc", side_effect=fake_get_doc), \
+                 mock.patch.object(api, "_assert_file_access"), \
+                 mock.patch.object(api, "_raw_file_bytes", return_value=b"<x/>"), \
+                 mock.patch.object(api, "_decode", return_value="<x/>"), \
+                 mock.patch.object(api, "FileTallySource", side_effect=lambda s: ("src", s)), \
+                 mock.patch.dict(api._SOURCE_CACHE, clear=True):
+                file_doc, _ = api._source_from_file("/private/files/shared.xml")
+        finally:
+            api.frappe.session.user = prev_user
+        return picked["name"], calls
+
+    def test_prefers_row_owned_by_current_user(self):
+        url = "/private/files/shared.xml"
+        rows = {
+            frozenset({"file_url": url, "owner": "manager@example.com"}.items()): "MINE",
+            frozenset({"file_url": url}.items()): "OTHERS",  # the bare fallback
+        }
+        name, calls = self._run(rows)
+        self.assertEqual(name, "MINE")
+        # owner-scoped lookup must be the first query
+        self.assertEqual(calls[0].get("owner"), "manager@example.com")
+
+    def test_falls_back_to_any_row_when_user_owns_none(self):
+        url = "/private/files/shared.xml"
+        rows = {
+            frozenset({"file_url": url, "owner": "manager@example.com"}.items()): None,
+            frozenset({"file_url": url}.items()): "OTHERS",
+        }
+        name, _ = self._run(rows)
+        # access is still enforced by _assert_file_access; resolution just falls back
+        self.assertEqual(name, "OTHERS")
+
+    def test_missing_file_raises(self):
+        url = "/private/files/shared.xml"
+        rows = {}  # nothing matches either query
+        with self.assertRaises(api.frappe.DoesNotExistError):
+            self._run(rows)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
Byte-identical uploads share one path in Frappe, so a single `file_url` can map to several File rows owned by different users. `_source_from_file` resolved the URL with a bare `frappe.db.exists`, which returns the oldest row - often owned by someone else - and `_assert_file_access` then correctly refused it, surfacing 'You are not permitted to access this file' to a legitimate user re-uploading the same export.

## Fix
Resolve the File owned by the current user first, falling back to any match (access is still enforced by `_assert_file_access`).

## Tests
Adds `test_file_lookup.py`: owner-first selection, fallback, and the missing-file path. All pass.