### PR TITLE
Load wizard company list via a role-gated API

### DIFF
--- a/tally_migrator/api.py
+++ b/tally_migrator/api.py
@@ -55,6 +55,22 @@ def validate_masters_file(file_url: str):
 
 
 @frappe.whitelist(methods=["GET", "POST"])
+def get_companies():
+    """List ERPNext companies for the wizard's target-company picker.
+
+    The wizard runs under the Tally Migration Manager role, which deliberately
+    holds no Company read permission (it only needs to migrate, not browse the
+    Company master). A plain ``frappe.client.get_list`` would therefore return
+    nothing. This gated endpoint returns the names with ``ignore_permissions`` so
+    the picker works without widening the role.
+    """
+    frappe.only_for(ALLOWED_ROLES)
+    return frappe.get_all(
+        "Company", fields=["name"], order_by="name", ignore_permissions=True
+    )
+
+
+@frappe.whitelist(methods=["GET", "POST"])
 def company_readiness(erpnext_company: str = "", posting_date: str = ""):
     """Pre-flight: is the target ERPNext company set up to receive masters?
 

--- a/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
+++ b/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
@@ -590,8 +590,7 @@ class TallyMigratorPage {
 
 	loadERPNextCompanies() {
 		frappe.call({
-			method: "frappe.client.get_list",
-			args: { doctype: "Company", fields: ["name"], limit_page_length: 0 },
+			method: "tally_migrator.api.get_companies",
 			callback: (r) => {
 				const companies = r.message || [];
 				const $select = $("#erpnext-company").empty();

--- a/tally_migrator/tests/test_get_companies.py
+++ b/tally_migrator/tests/test_get_companies.py
@@ -1,0 +1,33 @@
+"""
+Regression test for api.get_companies.
+
+The wizard's target-company picker must work for the Tally Migration Manager
+role, which deliberately holds no Company read permission. get_companies is a
+role-gated endpoint that reads with ignore_permissions so the picker is not
+empty without widening the role.
+"""
+import unittest
+from unittest import mock
+
+from tally_migrator import api
+
+
+class TestGetCompanies(unittest.TestCase):
+    def test_gated_and_ignores_permissions(self):
+        with mock.patch.object(api.frappe, "only_for") as only_for, \
+             mock.patch.object(
+                 api.frappe, "get_all", return_value=[{"name": "Acme"}]
+             ) as get_all:
+            result = api.get_companies()
+
+        # access is gated to the migrator roles
+        only_for.assert_called_once_with(api.ALLOWED_ROLES)
+        # the read bypasses the (absent) Company read permission
+        _, kwargs = get_all.call_args
+        self.assertEqual(get_all.call_args.args[0], "Company")
+        self.assertTrue(kwargs.get("ignore_permissions"))
+        self.assertEqual(result, [{"name": "Acme"}])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
The wizard's step-2 company picker called `frappe.client.get_list` for Company, which enforces read permission. The Tally Migration Manager role holds no Company read perm (by design - it migrates, it doesn't browse the Company master), so the list came back empty and the user was stuck at step 2 with 'No company found'.

## Fix
Add a whitelisted `get_companies()` gated to `ALLOWED_ROLES` that reads with `ignore_permissions`, and point the wizard at it. Keeps the role minimal and matches how the rest of the migrator's data access is gated.

## Audit
Verified all 5 wizard steps for a pure Tally Migration Manager: company list was the only client-side perm gap. All document creation in importers uses `ignore_permissions` (inserts + the three submits inherit the flag), and the Log is created with `ignore_permissions` despite the role's `create:0`.

## Tests
Adds `test_get_companies.py` asserting the role gate and `ignore_permissions`.