### PR TITLE
Fix silent failures in wizard calls and file decode fallback

### DIFF
--- a/tally_migrator/api.py
+++ b/tally_migrator/api.py
@@ -470,8 +470,23 @@ def _raw_file_bytes(file_doc) -> bytes:
     except frappe.ValidationError:
         raise                       # the size-limit rejection must propagate
     except Exception:
-        # Last resort: re-encode the str we were given. Lossless only if it was a
-        # latin-1 round-trip, but better than failing outright.
+        frappe.log_error(
+            title="tally_migrator: could not read original file bytes",
+            message=frappe.get_traceback(),
+        )
+        # The disk re-read failed, so all we have is the already-decoded str. Re-encoding
+        # it as latin-1 is lossless only if the original was a latin-1 round-trip; for a
+        # genuine UTF-16 Tally export it silently corrupts the data and the migration
+        # then imports wrong masters with no error. Fail loud by default so the user
+        # never gets silently-wrong books. Operators who knowingly handle latin-1 exports
+        # can opt back into the legacy best-effort path via site config.
+        if frappe.conf.get("tally_migrator_strict_decode", True):
+            frappe.throw(
+                frappe._(
+                    "Could not read the original bytes of this file, so it can't be "
+                    "imported safely. Please upload your Tally Masters XML again."
+                )
+            )
         encoded = content.encode("latin-1", errors="ignore")
         _assert_within_size_limit(len(encoded))
         return encoded

--- a/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
+++ b/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
@@ -496,7 +496,26 @@ class TallyMigratorPage {
 			frappe.call({
 				method: "tally_migrator.api.save_draft",
 				args: { payload: JSON.stringify(payload) },
-				callback: () => {},
+				callback: () => {
+					this._draftSaveFailed = false;
+				},
+				error: () => {
+					// Autosave failed (e.g. network drop). Re-queue this payload so the
+					// next change - or the unload beacon - retries it, and warn the user
+					// once so they know their progress is not being saved. Without this
+					// the wizard would silently stop persisting and an accidental reload
+					// would lose every fix.
+					if (!this._draftPending) this._draftPending = payload;
+					if (!this._draftSaveFailed) {
+						this._draftSaveFailed = true;
+						frappe.show_alert({
+							message: __(
+								"Couldn't save your progress just now. Your work is still on screen; we'll keep retrying."
+							),
+							indicator: "orange",
+						}, 7);
+					}
+				},
 			});
 		}, 600);
 	}
@@ -539,6 +558,11 @@ class TallyMigratorPage {
 				$("#btn-resume").on("click", () => this.resumeDraft(d));
 				$("#btn-discard").on("click", () => this.confirmStartOver());
 			},
+			// Intentionally silent on error: a failed draft lookup is non-destructive
+			// (the draft, if any, is safe server-side). We simply don't offer a resume
+			// banner this load rather than alarming the user on page open; the next load
+			// retries. The wizard is fully usable without it.
+			error: () => {},
 		});
 	}
 
@@ -585,7 +609,21 @@ class TallyMigratorPage {
 		clearTimeout(this._draftTimer);
 		this._draftPending = null;   // don't let the unload beacon re-save a cleared draft
 		$("#resume-banner").hide().empty();
-		frappe.call({ method: "tally_migrator.api.clear_draft", callback: () => {} });
+		frappe.call({
+			method: "tally_migrator.api.clear_draft",
+			callback: () => {},
+			error: () => {
+				// The draft was not deleted server-side, so it would be offered again on
+				// the next load. Warn the user rather than letting a stale resume banner
+				// reappear unexplained.
+				frappe.show_alert({
+					message: __(
+						"Couldn't discard the saved draft. It may reappear next time; reload and choose Start over again if so."
+					),
+					indicator: "orange",
+				}, 7);
+			},
+		});
 	}
 
 	loadERPNextCompanies() {
@@ -624,6 +662,26 @@ class TallyMigratorPage {
 				} else if (companies.length === 1) {
 					$select.val(companies[0].name);
 				}
+			},
+			error: () => {
+				// A failed load leaves the picker empty, which looks identical to "no
+				// companies exist" and silently strands the user on this step. Tell them
+				// what actually happened and offer a retry instead.
+				$("#erpnext-company").empty();
+				$("#btn-next-2").prop("disabled", true);
+				$("#company-empty")
+					.html(
+						__("Couldn't load the company list.") +
+							' <a href="#" id="btn-retry-companies">' +
+							__("Try again") +
+							"</a>"
+					)
+					.show();
+				$("#btn-retry-companies").on("click", (e) => {
+					e.preventDefault();
+					$("#company-empty").text("").hide();
+					this.loadERPNextCompanies();
+				});
 			},
 		});
 	}

--- a/tally_migrator/tests/test_raw_file_bytes.py
+++ b/tally_migrator/tests/test_raw_file_bytes.py
@@ -1,0 +1,62 @@
+"""
+Regression test for ``api._raw_file_bytes`` strict-decode behaviour.
+
+When ``File.get_content()`` hands back an already-decoded ``str`` (recent Frappe
+decodes text uploads), the resolver re-reads the original bytes from disk so a
+UTF-16 Tally export survives. If that disk re-read also fails, the only remaining
+option is to re-encode the decoded str as latin-1 - which silently corrupts a
+genuine UTF-16 export and imports wrong masters with no error.
+
+By default we fail loud instead (``tally_migrator_strict_decode`` defaults to
+True). Operators who knowingly handle latin-1 exports can opt back into the legacy
+best-effort path. These tests pin both branches.
+"""
+import types
+import unittest
+from unittest import mock
+
+from tally_migrator import api
+
+
+def _str_content_doc():
+    """A File doc whose get_content() returns a str and whose disk read fails."""
+    return types.SimpleNamespace(
+        get_content=lambda: "already-decoded text",
+        get_full_path=lambda: "/nonexistent/path/does-not-exist.xml",
+    )
+
+
+class TestRawFileBytesStrictDecode(unittest.TestCase):
+    def test_strict_default_throws_instead_of_corrupting(self):
+        doc = _str_content_doc()
+        # no flag set -> strict default (True)
+        with mock.patch.object(api.frappe, "conf", {}), \
+             mock.patch.object(api.frappe, "log_error"), \
+             mock.patch.object(api.frappe, "get_traceback", return_value=""):
+            with self.assertRaises(api.frappe.ValidationError):
+                api._raw_file_bytes(doc)
+
+    def test_opt_out_falls_back_to_latin1(self):
+        doc = _str_content_doc()
+        # strict disabled -> legacy best-effort re-encode path
+        with mock.patch.object(
+            api.frappe, "conf", {"tally_migrator_strict_decode": False}
+        ), \
+             mock.patch.object(api.frappe, "log_error"), \
+             mock.patch.object(api.frappe, "get_traceback", return_value=""), \
+             mock.patch.object(api, "_assert_within_size_limit"):
+            out = api._raw_file_bytes(doc)
+        self.assertEqual(out, b"already-decoded text")
+
+    def test_failure_is_logged(self):
+        doc = _str_content_doc()
+        with mock.patch.object(api.frappe, "conf", {}), \
+             mock.patch.object(api.frappe, "log_error") as log_error, \
+             mock.patch.object(api.frappe, "get_traceback", return_value=""):
+            with self.assertRaises(api.frappe.ValidationError):
+                api._raw_file_bytes(doc)
+        log_error.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Phase 0 of the excellence-review remediation: closes the two findings that touch the hard rules (no silent failures, no silent data loss). Code-only, no schema changes.

## H3 - unguarded wizard `frappe.call` sites no longer fail silently
- **save_draft (autosave):** on failure, re-queues the payload so the next change or the unload beacon retries it, and warns the user once that progress is not being saved. Removes the silent loss of resume safety.
- **get_companies:** a failed load now shows "Couldn't load the company list / Try again" with a working retry, instead of an empty picker indistinguishable from "no companies exist" that silently strands the user on the Configure step.
- **clear_draft:** warns if the draft was not deleted server-side, so a stale resume banner does not reappear unexplained.
- **get_draft:** documented-silent (a failed lookup is non-destructive; the draft stays safe server-side and the next load retries).

## M2 - no silent UTF-16 corruption, behind a kill-switch
`_raw_file_bytes` last-resort `latin-1 errors="ignore"` re-encode silently corrupted genuine UTF-16 exports. It now logs the failure and throws an actionable "upload again" message **by default** (`tally_migrator_strict_decode`, defaults to True). Operators who knowingly handle latin-1 exports can opt back into the legacy path:
`bench set-config tally_migrator_strict_decode 0 && bench restart`

## Tests
- New `test_raw_file_bytes`: strict-default throw, opt-out fallback, failure-is-logged.
- Pure suite 152 pass; `test_raw_file_bytes`, `test_file_lookup`, `test_get_companies`, `test_critical_fixes` pass under bench.
- `py_compile` + `node --check` clean.

## Rollback
Code-only. Revert with `git revert` + `bench clear-cache` (JS) / `bench restart` (Python). Baseline tagged `pre-audit-baseline`.

## Not covered by automation
The JS error paths have no automated coverage; a live click-through of the autosave-failure alert and the company-list retry is recommended before merge.