### PR TITLE
Drop misleading example causes from results warning headline

### DIFF
--- a/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
+++ b/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
@@ -2022,7 +2022,7 @@ class TallyMigratorPage {
 				totalCreated === 1 ? "" : "s"
 			} imported, but <strong>${totalWarnings}</strong> warning${
 				totalWarnings === 1 ? "" : "s"
-			} need a look - some dependent data (e.g. an address, contact, or opening balance) was dropped. See Warnings below and the migration log.`;
+			} need a look. See Warnings below and the migration log.`;
 		}
 		let html = TallyMigratorPage.callout(headlineKind, TallyMigratorPage.iconRow(headlineKind, `${headlineMsg}`));
 


### PR DESCRIPTION
Display-only copy fix.

## Problem
The post-migration warning headline guessed at specific causes:
> N records imported, but M warnings need a look - some dependent data (e.g. an address, contact, or opening balance) was dropped. See Warnings below and the migration log.

When the warnings were on Accounts or Opening Balances (nothing to do with addresses/contacts), this gave a wrong impression that address/contact data had been lost.

## Change
Drop the guessed phrase; keep the rest:
> N records imported, but M warnings need a look. See Warnings below and the migration log.

The user opens the migration log to see each warning's actual reason.

## Scope
One line in the wizard JS. No backend/schema change. Progress bar intentionally left untouched. `node --check` passes.

## Rollback
`git revert` + `bench clear-cache`.