### PR TITLE
Map Tally GST UQC into India Compliance GST Settings

### DIFF
--- a/tally_migrator/erpnext/importers/units.py
+++ b/tally_migrator/erpnext/importers/units.py
@@ -55,7 +55,87 @@ class UnitImporter:
         for u in units:
             if not self._is_simple(u):
                 self._ensure_conversion(result, u)
+        # Third pass: map each UOM's GST Unit Quantity Code into India Compliance's
+        # GST Settings (must run after the UOMs themselves exist).
+        self._map_uqcs(units, result)
         return result
+
+    # ── GST UQC mapping (India Compliance) ─────────────────────────────────────
+    @staticmethod
+    def _gst_uom_code_map() -> "dict | None":
+        """``{UQC code: official option string}`` derived live from the GST UOM Map
+        field's option list (e.g. ``{"NOS": "NOS (Numbers)"}``).
+
+        Derived from IC's field metadata rather than a hardcoded list so it tracks
+        whatever UQC values the installed India Compliance version supports
+        (derive-don't-enumerate). Returns ``None`` when India Compliance is absent,
+        which makes the whole UQC pass a clean no-op."""
+        if not frappe.db.exists("DocType", "GST UOM Map"):
+            return None
+        try:
+            options = frappe.get_meta("GST UOM Map").get_field("gst_uom").options or ""
+        except Exception:
+            return None
+        out = {}
+        for opt in options.splitlines():
+            opt = opt.strip()
+            if opt:
+                out[opt.split("(")[0].strip().upper()] = opt
+        return out
+
+    @staticmethod
+    def _uqc_to_gst_uom(tally_uqc: str, code_map: dict) -> "str | None":
+        """Map a Tally REPORTINGUQCNAME ('NOS-NUMBERS') to the official GST UOM
+        option ('NOS (Numbers)'), or ``None`` when blank/'Not Applicable'/no match.
+
+        Tally encodes ``CODE-DESCRIPTION``; we match on the CODE prefix against the
+        official option set. A code with no official equivalent (e.g. Tally's
+        'REM-REAMS') returns ``None`` so the caller can warn rather than write an
+        invalid value into GST returns."""
+        raw = (tally_uqc or "").replace("\x04", " ").strip()  # Tally pads with &#4;
+        if not raw or "not applicable" in raw.lower():
+            return None
+        code = raw.split("-", 1)[0].strip().upper()
+        return code_map.get(code)
+
+    def _map_uqcs(self, units: list[dict], result: ImportResult) -> None:
+        """Append missing ``GST Settings.gst_uom_map`` rows for the imported UOMs.
+
+        India Compliance stores UQC globally in GST Settings (a Single doctype),
+        not per-UOM, so this writes shared config: append-only, idempotent (skips
+        UOMs already mapped by IC's defaults or a prior run), one save. No-op when
+        India Compliance is absent. Tally codes with no official GST equivalent are
+        left unmapped with a warning rather than guessed."""
+        code_map = self._gst_uom_code_map()
+        if not code_map:
+            return
+        settings = frappe.get_doc("GST Settings")
+        already = {(m.uom or "").strip().lower() for m in settings.gst_uom_map}
+        changed = False
+        seen = set()
+        for u in units:
+            uom = (u.get("_name") or "").strip()
+            if not uom or uom.lower() in seen:
+                continue
+            seen.add(uom.lower())
+            raw_uqc = (u.get("ReportingUQC") or "").replace("\x04", " ").strip()
+            gst_uom = self._uqc_to_gst_uom(raw_uqc, code_map)
+            if not gst_uom:
+                # Only warn when Tally actually carried a UQC we couldn't place;
+                # a blank/'Not Applicable' unit is simply skipped silently.
+                if raw_uqc and "not applicable" not in raw_uqc.lower():
+                    result.add_warning(
+                        uom, f"GST UQC '{raw_uqc}' has no standard GST code; left "
+                        "unmapped - set it manually in GST Settings if needed for filing.")
+                continue
+            if uom.lower() in already or not frappe.db.exists("UOM", uom):
+                continue
+            settings.append("gst_uom_map", {"uom": uom, "gst_uom": gst_uom})
+            already.add(uom.lower())
+            changed = True
+        if changed:
+            settings.save(ignore_permissions=True)
+            frappe.db.commit()
 
     @staticmethod
     def _is_simple(u: dict) -> bool:

--- a/tally_migrator/tally/extractors.py
+++ b/tally_migrator/tally/extractors.py
@@ -37,8 +37,14 @@ COSTCENTRE_FIELDS = ["Name", "Parent"]
 STOCKGROUP_FIELDS = ["Name", "Parent"]
 UNIT_FIELDS       = [
     "Name", "IsSimpleUnit", "OriginalName", "DecimalPlaces",
-    "BaseUnits", "AdditionalUnits", "Conversion",
+    "BaseUnits", "AdditionalUnits", "Conversion", "ReportingUQC",
 ]
+# The GST Unit Quantity Code lives in a dated revision list
+# (REPORTINGUQCDETAILS.LIST/REPORTINGUQCNAME, e.g. "NOS-NUMBERS"); _resolve_field
+# returns the last/most-recent entry. "Not Applicable" rows are filtered downstream.
+UNIT_TAGS = {
+    "ReportingUQC": ["REPORTINGUQCDETAILS.LIST/REPORTINGUQCNAME"],
+}
 
 
 # ── Tag overrides for fields whose real Tally tag ≠ FIELD.upper() ─────────────
@@ -236,7 +242,7 @@ class TallyExtractor:
             stock_groups = self._dedup_by_name(
                 self.client.get_collection("Stock Group", STOCKGROUP_FIELDS)),
             units        = self._dedup_by_name(
-                self.client.get_collection("Unit", UNIT_FIELDS)),
+                self.client.get_collection("Unit", UNIT_FIELDS, UNIT_TAGS)),
         )
 
     @staticmethod

--- a/tally_migrator/tests/test_uqc.py
+++ b/tally_migrator/tests/test_uqc.py
@@ -1,0 +1,105 @@
+"""
+Phase 1 (UQC) tests.
+
+India Compliance stores the GST Unit Quantity Code globally in
+GST Settings.gst_uom_map (uom -> gst_uom), not per-UOM. UnitImporter maps each
+imported Tally UOM's REPORTINGUQCNAME ("NOS-NUMBERS") to the official GST option
+("NOS (Numbers)"), appending only missing rows. Codes with no official match
+(e.g. Tally's "REM-REAMS") are left unmapped with a warning, never guessed.
+"""
+import types
+import unittest
+from unittest import mock
+
+from tally_migrator.erpnext.importers.units import UnitImporter
+from tally_migrator.erpnext.importers import ImportResult
+
+OPTIONS = "NOS (Numbers)\nKGS (Kilograms)\nBOX (Box)\nDOZ (Dozens)\nPCS (Pieces)\nOTH (Others)"
+
+
+def _code_map():
+    return {o.split("(")[0].strip().upper(): o for o in OPTIONS.splitlines()}
+
+
+class TestUqcMapping(unittest.TestCase):
+    def test_matches_by_code_case_insensitive(self):
+        cm = _code_map()
+        self.assertEqual(UnitImporter._uqc_to_gst_uom("NOS-NUMBERS", cm), "NOS (Numbers)")
+        self.assertEqual(UnitImporter._uqc_to_gst_uom("KGS-KILOGRAMS", cm), "KGS (Kilograms)")
+        self.assertEqual(UnitImporter._uqc_to_gst_uom("box-boxes", cm), "BOX (Box)")
+
+    def test_blank_not_applicable_and_unmatched_return_none(self):
+        cm = _code_map()
+        self.assertIsNone(UnitImporter._uqc_to_gst_uom("REM-REAMS", cm))      # no official code
+        self.assertIsNone(UnitImporter._uqc_to_gst_uom("", cm))
+        self.assertIsNone(UnitImporter._uqc_to_gst_uom("\x04 Not Applicable", cm))
+        self.assertIsNone(UnitImporter._uqc_to_gst_uom("Not Applicable", cm))
+
+    def _fake_settings(self, existing=()):
+        s = types.SimpleNamespace(
+            gst_uom_map=[types.SimpleNamespace(uom=u, gst_uom=g) for u, g in existing],
+            saved=False)
+        s.append = lambda table, row: s.gst_uom_map.append(
+            types.SimpleNamespace(uom=row["uom"], gst_uom=row["gst_uom"]))
+
+        def _save(**kw):
+            s.saved = True
+        s.save = _save
+        return s
+
+    def test_map_uqcs_appends_missing_skips_existing_warns_unmatched(self):
+        imp = UnitImporter("_T Co", "TC")
+        res = ImportResult("UOM")
+        units = [
+            {"_name": "Nos",  "ReportingUQC": "NOS-NUMBERS"},
+            {"_name": "Kg",   "ReportingUQC": "KGS-KILOGRAMS"},
+            {"_name": "Ream", "ReportingUQC": "REM-REAMS"},          # no match -> warn
+            {"_name": "Box",  "ReportingUQC": "\x04 Not Applicable"},  # skipped silently
+            {"_name": "Pcs",  "ReportingUQC": "PCS-PIECES"},          # already mapped -> skip
+        ]
+        settings = self._fake_settings(existing=[("Pcs", "PCS (Pieces)")])
+        meta = types.SimpleNamespace(
+            get_field=lambda f: types.SimpleNamespace(options=OPTIONS))
+        with mock.patch("frappe.db.exists", return_value=True), \
+                mock.patch("frappe.get_meta", return_value=meta), \
+                mock.patch("frappe.get_doc", return_value=settings), \
+                mock.patch("frappe.db.commit"):
+            imp._map_uqcs(units, res)
+
+        mapped = {(r.uom, r.gst_uom) for r in settings.gst_uom_map}
+        self.assertIn(("Nos", "NOS (Numbers)"), mapped)
+        self.assertIn(("Kg", "KGS (Kilograms)"), mapped)
+        self.assertFalse(any(r.uom == "Box" for r in settings.gst_uom_map))      # skipped
+        self.assertEqual(sum(1 for r in settings.gst_uom_map if r.uom == "Pcs"), 1)  # not duped
+        self.assertTrue(any(w["name"] == "Ream" for w in res.warnings))          # warned
+        self.assertTrue(settings.saved)
+
+    def test_no_india_compliance_is_noop(self):
+        imp = UnitImporter("_T Co", "TC")
+        res = ImportResult("UOM")
+        with mock.patch("frappe.db.exists", return_value=False):
+            imp._map_uqcs([{"_name": "Nos", "ReportingUQC": "NOS-NUMBERS"}], res)
+        self.assertEqual(res.warnings, [])
+
+
+class TestUqcExtraction(unittest.TestCase):
+    def test_extraction_reads_latest_reporting_uqc(self):
+        from tally_migrator.tally.file_source import FileTallySource
+        from tally_migrator.tally.extractors import UNIT_FIELDS, UNIT_TAGS
+        # Dated list with two entries; the most recent (last) wins.
+        xml = (
+            '<ENVELOPE><BODY><IMPORTDATA><REQUESTDATA>'
+            '<TALLYMESSAGE><UNIT NAME="Nos"><NAME>Nos</NAME>'
+            '<REPORTINGUQCDETAILS.LIST><APPLICABLEFROM>20200401</APPLICABLEFROM>'
+            '<REPORTINGUQCNAME>OTH-OTHERS</REPORTINGUQCNAME></REPORTINGUQCDETAILS.LIST>'
+            '<REPORTINGUQCDETAILS.LIST><APPLICABLEFROM>20260401</APPLICABLEFROM>'
+            '<REPORTINGUQCNAME>NOS-NUMBERS</REPORTINGUQCNAME></REPORTINGUQCDETAILS.LIST>'
+            '</UNIT></TALLYMESSAGE>'
+            '</REQUESTDATA></IMPORTDATA></BODY></ENVELOPE>'
+        )
+        rows = FileTallySource(xml).get_collection("Unit", UNIT_FIELDS, UNIT_TAGS)
+        self.assertEqual(rows[0]["ReportingUQC"], "NOS-NUMBERS")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Maps each Tally GST Unit Quantity Code (UQC) onto the matching India Compliance GST Settings entry so reported quantities use the correct statutory UQC.

Part of the masters-completeness coverage work. First in a stack of 6; merge bottom-up.