### PR TITLE
Link items to GST Item Tax Templates from Tally GST rate

### DIFF
--- a/tally_migrator/erpnext/importers/items.py
+++ b/tally_migrator/erpnext/importers/items.py
@@ -65,6 +65,11 @@ class ItemImporter(BaseImporter):
         # app is installed. Without it ERPNext core silently drops those keys, so we
         # say so once instead of pretending the GST data landed.
         self._india_compliance = "india_compliance" in frappe.get_installed_apps()
+        # Resolve each item's GST Item Tax Template once (links the rate to the
+        # India-Compliance-seeded "GST 18%" / "Nil-Rated" templates for this
+        # company). Done here, with access to ``result``, so a missing template
+        # warns exactly once; build_doc just reads the resolved map.
+        self._resolve_tax_templates(records, result)
         if not self._india_compliance and any(
             (r.get("GSTTaxability") or r.get("HSNCode")
              or r.get("GstApplicable") or r.get("TypeOfSupply"))
@@ -112,7 +117,62 @@ class ItemImporter(BaseImporter):
         if vm:
             doc["valuation_method"] = vm
         doc.update(self._gst_fields(record))
+        tpl = getattr(self, "_tax_templates", {}).get(record["_name"])
+        if tpl:
+            doc["taxes"] = [{"item_tax_template": tpl}]
         return doc
+
+    # ── GST rate -> Item Tax Template linking (India Compliance) ───────────────
+    @staticmethod
+    def _gst_treatment_label(record: dict) -> "str | None":
+        """ERPNext/India-Compliance gst_treatment string for an item, or None when
+        the Tally GST type is unrecognised (already warned elsewhere)."""
+        if (record.get("GstApplicable") or "").strip().lower() in ("not applicable", "no"):
+            return "Non-GST"
+        key = (record.get("GSTTaxability") or "").strip().lower().replace("-", " ").replace("_", " ")
+        key = " ".join(key.split())
+        return {
+            "": "Taxable", "taxable": "Taxable", "applicable": "Taxable",
+            "nil rated": "Nil-Rated", "nil": "Nil-Rated",
+            "exempt": "Exempted", "exempted": "Exempted",
+            "non gst": "Non-GST", "not applicable": "Non-GST",
+        }.get(key)
+
+    def _resolve_tax_template(self, treatment: str, rate: float) -> "str | None":
+        """The company's GST Item Tax Template for this treatment/rate, matched by
+        the India-Compliance gst_treatment + gst_rate fields (never by the
+        company-suffixed name), or None when none is seeded."""
+        filters = {"company": self.company, "gst_treatment": treatment}
+        if treatment == "Taxable":
+            if not rate:
+                return None
+            filters["gst_rate"] = rate
+        rows = frappe.get_all(
+            "Item Tax Template", filters=filters, pluck="name", limit=1,
+            ignore_permissions=True)
+        return rows[0] if rows else None
+
+    def _resolve_tax_templates(self, records: list[dict], result: ImportResult) -> None:
+        """Build ``{item name: template}`` for build_doc, warning once per item when
+        a taxable rate has no matching template. No-op without India Compliance
+        (its gst_rate/gst_treatment fields, and the seeded templates, don't exist)."""
+        self._tax_templates: dict = {}
+        if not getattr(self, "_india_compliance", False):
+            return
+        for r in records:
+            treatment = self._gst_treatment_label(r)
+            if not treatment:
+                continue
+            rate = self._to_float(r.get("GstRate"))
+            tpl = self._resolve_tax_template(treatment, rate)
+            if tpl:
+                self._tax_templates[r["_name"]] = tpl
+            elif treatment == "Taxable" and rate:
+                result.add_warning(
+                    r["_name"],
+                    f"no GST Item Tax Template for {rate:g}% on company "
+                    f"'{self.company}' - item imported without a tax rate; create a "
+                    f"'GST {rate:g}%' template or set it on the item manually.")
 
     def recover_insert(self, data: dict, exc: Exception):
         """India Compliance makes ``gst_hsn_code`` a Link to "GST HSN Code" and

--- a/tally_migrator/erpnext/importers/units.py
+++ b/tally_migrator/erpnext/importers/units.py
@@ -55,7 +55,87 @@ class UnitImporter:
         for u in units:
             if not self._is_simple(u):
                 self._ensure_conversion(result, u)
+        # Third pass: map each UOM's GST Unit Quantity Code into India Compliance's
+        # GST Settings (must run after the UOMs themselves exist).
+        self._map_uqcs(units, result)
         return result
+
+    # ── GST UQC mapping (India Compliance) ─────────────────────────────────────
+    @staticmethod
+    def _gst_uom_code_map() -> "dict | None":
+        """``{UQC code: official option string}`` derived live from the GST UOM Map
+        field's option list (e.g. ``{"NOS": "NOS (Numbers)"}``).
+
+        Derived from IC's field metadata rather than a hardcoded list so it tracks
+        whatever UQC values the installed India Compliance version supports
+        (derive-don't-enumerate). Returns ``None`` when India Compliance is absent,
+        which makes the whole UQC pass a clean no-op."""
+        if not frappe.db.exists("DocType", "GST UOM Map"):
+            return None
+        try:
+            options = frappe.get_meta("GST UOM Map").get_field("gst_uom").options or ""
+        except Exception:
+            return None
+        out = {}
+        for opt in options.splitlines():
+            opt = opt.strip()
+            if opt:
+                out[opt.split("(")[0].strip().upper()] = opt
+        return out
+
+    @staticmethod
+    def _uqc_to_gst_uom(tally_uqc: str, code_map: dict) -> "str | None":
+        """Map a Tally REPORTINGUQCNAME ('NOS-NUMBERS') to the official GST UOM
+        option ('NOS (Numbers)'), or ``None`` when blank/'Not Applicable'/no match.
+
+        Tally encodes ``CODE-DESCRIPTION``; we match on the CODE prefix against the
+        official option set. A code with no official equivalent (e.g. Tally's
+        'REM-REAMS') returns ``None`` so the caller can warn rather than write an
+        invalid value into GST returns."""
+        raw = (tally_uqc or "").replace("\x04", " ").strip()  # Tally pads with &#4;
+        if not raw or "not applicable" in raw.lower():
+            return None
+        code = raw.split("-", 1)[0].strip().upper()
+        return code_map.get(code)
+
+    def _map_uqcs(self, units: list[dict], result: ImportResult) -> None:
+        """Append missing ``GST Settings.gst_uom_map`` rows for the imported UOMs.
+
+        India Compliance stores UQC globally in GST Settings (a Single doctype),
+        not per-UOM, so this writes shared config: append-only, idempotent (skips
+        UOMs already mapped by IC's defaults or a prior run), one save. No-op when
+        India Compliance is absent. Tally codes with no official GST equivalent are
+        left unmapped with a warning rather than guessed."""
+        code_map = self._gst_uom_code_map()
+        if not code_map:
+            return
+        settings = frappe.get_doc("GST Settings")
+        already = {(m.uom or "").strip().lower() for m in settings.gst_uom_map}
+        changed = False
+        seen = set()
+        for u in units:
+            uom = (u.get("_name") or "").strip()
+            if not uom or uom.lower() in seen:
+                continue
+            seen.add(uom.lower())
+            raw_uqc = (u.get("ReportingUQC") or "").replace("\x04", " ").strip()
+            gst_uom = self._uqc_to_gst_uom(raw_uqc, code_map)
+            if not gst_uom:
+                # Only warn when Tally actually carried a UQC we couldn't place;
+                # a blank/'Not Applicable' unit is simply skipped silently.
+                if raw_uqc and "not applicable" not in raw_uqc.lower():
+                    result.add_warning(
+                        uom, f"GST UQC '{raw_uqc}' has no standard GST code; left "
+                        "unmapped - set it manually in GST Settings if needed for filing.")
+                continue
+            if uom.lower() in already or not frappe.db.exists("UOM", uom):
+                continue
+            settings.append("gst_uom_map", {"uom": uom, "gst_uom": gst_uom})
+            already.add(uom.lower())
+            changed = True
+        if changed:
+            settings.save(ignore_permissions=True)
+            frappe.db.commit()
 
     @staticmethod
     def _is_simple(u: dict) -> bool:

--- a/tally_migrator/tally/extractors.py
+++ b/tally_migrator/tally/extractors.py
@@ -37,8 +37,14 @@ COSTCENTRE_FIELDS = ["Name", "Parent"]
 STOCKGROUP_FIELDS = ["Name", "Parent"]
 UNIT_FIELDS       = [
     "Name", "IsSimpleUnit", "OriginalName", "DecimalPlaces",
-    "BaseUnits", "AdditionalUnits", "Conversion",
+    "BaseUnits", "AdditionalUnits", "Conversion", "ReportingUQC",
 ]
+# The GST Unit Quantity Code lives in a dated revision list
+# (REPORTINGUQCDETAILS.LIST/REPORTINGUQCNAME, e.g. "NOS-NUMBERS"); _resolve_field
+# returns the last/most-recent entry. "Not Applicable" rows are filtered downstream.
+UNIT_TAGS = {
+    "ReportingUQC": ["REPORTINGUQCDETAILS.LIST/REPORTINGUQCNAME"],
+}
 
 
 # ── Tag overrides for fields whose real Tally tag ≠ FIELD.upper() ─────────────
@@ -236,7 +242,7 @@ class TallyExtractor:
             stock_groups = self._dedup_by_name(
                 self.client.get_collection("Stock Group", STOCKGROUP_FIELDS)),
             units        = self._dedup_by_name(
-                self.client.get_collection("Unit", UNIT_FIELDS)),
+                self.client.get_collection("Unit", UNIT_FIELDS, UNIT_TAGS)),
         )
 
     @staticmethod

--- a/tally_migrator/tally/extractors.py
+++ b/tally_migrator/tally/extractors.py
@@ -232,7 +232,7 @@ class TallyExtractor:
         # (repeating child lists a real export carries beyond the single primary
         # mailing address / mobile). No-op for a live client without child lists.
         self._attach_party_subrecords(ledgers)
-        return ExtractedMasters(
+        masters = ExtractedMasters(
             customers    = [l for l in ledgers if resolver.kind_of(l["_name"]) == CUSTOMER],
             suppliers    = [l for l in ledgers if resolver.kind_of(l["_name"]) == SUPPLIER],
             items        = self._dedup_by_name(
@@ -244,6 +244,19 @@ class TallyExtractor:
             units        = self._dedup_by_name(
                 self.client.get_collection("Unit", UNIT_FIELDS, UNIT_TAGS)),
         )
+        # Attach each item's combined GST rate (IGST), read per duty head from the
+        # nested rate list. No-op for a live client that can't supply it.
+        self._attach_item_gst_rates(masters.items)
+        return masters
+
+    def _attach_item_gst_rates(self, items: list[dict]) -> None:
+        """Set ``GstRate`` on each item dict from the source's per-duty-head rate
+        read. Degrades to a no-op when the source can't supply it (live client)."""
+        if not hasattr(self.client, "item_gst_rates"):
+            return
+        rates = self.client.item_gst_rates()
+        for it in items:
+            it.setdefault("GstRate", rates.get(it.get("_name", ""), ""))
 
     @staticmethod
     def _dedup_by_name(records: list[dict]) -> list[dict]:

--- a/tally_migrator/tally/file_source.py
+++ b/tally_migrator/tally/file_source.py
@@ -255,6 +255,44 @@ class FileTallySource:
         self._collection_cache[cache_key] = rows
         return [dict(r) for r in rows]
 
+    def item_gst_rates(self) -> dict:
+        """``{stock item name: combined GST rate string}`` read per duty head.
+
+        The rate lives nested under GSTDETAILS.LIST/STATEWISEDETAILS.LIST/
+        RATEDETAILS.LIST, one entry per duty head (CGST/SGST-UTGST/IGST/Cess). The
+        combined GST rate is IGST (== CGST + SGST); we read by duty head rather than
+        relying on tag order, so a Cess rate can never be mistaken for the GST rate.
+        Empty string when the item carries no rate (nil/exempt/non-GST)."""
+        out: dict = {}
+        for elem in self._by_tag.get("STOCKITEM", ()):
+            name = (elem.get("NAME") or elem.findtext("NAME") or "").strip()
+            if not name:
+                continue
+            heads: dict = {}
+            for node in elem.iter():
+                if node.tag.split("}")[-1].upper() != "RATEDETAILS.LIST":
+                    continue
+                duty = rate = ""
+                for ch in node:
+                    local = ch.tag.split("}")[-1].upper()
+                    if local == "GSTRATEDUTYHEAD":
+                        duty = (ch.text or "").strip().upper()
+                    elif local == "GSTRATE":
+                        rate = (ch.text or "").strip()
+                if duty and rate:
+                    heads[duty] = rate
+            igst = heads.get("IGST")
+            if not igst:
+                cgst = heads.get("CGST")
+                sgst = heads.get("SGST/UTGST") or heads.get("SGST")
+                if cgst or sgst:
+                    try:
+                        igst = f"{float(cgst or 0) + float(sgst or 0):g}"
+                    except ValueError:
+                        igst = ""
+            out[name] = igst or ""
+        return out
+
     # ── Field resolution (tag overrides + nested .LIST descent) ────────────────
     @classmethod
     def _resolve_field(cls, elem, candidates: list) -> str:

--- a/tally_migrator/tests/test_item_tax_template.py
+++ b/tally_migrator/tests/test_item_tax_template.py
@@ -1,0 +1,113 @@
+"""
+Phase 3 tests: item GST rate -> India Compliance GST Item Tax Template.
+
+The combined GST rate is read per duty head (IGST == CGST + SGST), so a Cess
+rate can never be mistaken for the GST rate. Each item is then linked to the
+company's seeded template (matched by gst_treatment + gst_rate, not by name);
+a taxable rate with no template warns rather than guessing.
+"""
+import unittest
+from unittest import mock
+
+from tally_migrator.tally.file_source import FileTallySource
+from tally_migrator.erpnext.importers.items import ItemImporter
+from tally_migrator.erpnext.importers import ImportResult
+
+
+def _item_xml(name, rate_rows):
+    rd = "".join(
+        f"<RATEDETAILS.LIST><GSTRATEDUTYHEAD>{h}</GSTRATEDUTYHEAD>"
+        + (f"<GSTRATE>{r}</GSTRATE>" if r is not None else "")
+        + "</RATEDETAILS.LIST>"
+        for h, r in rate_rows)
+    return (f'<TALLYMESSAGE><STOCKITEM NAME="{name}"><NAME>{name}</NAME>'
+            f'<GSTDETAILS.LIST><STATEWISEDETAILS.LIST><STATENAME>Any</STATENAME>'
+            f'{rd}</STATEWISEDETAILS.LIST></GSTDETAILS.LIST></STOCKITEM></TALLYMESSAGE>')
+
+
+class TestGstRateExtraction(unittest.TestCase):
+    def _rates(self, *items):
+        xml = "<ENVELOPE><BODY><IMPORTDATA><REQUESTDATA>" + "".join(items) + \
+              "</REQUESTDATA></IMPORTDATA></BODY></ENVELOPE>"
+        return FileTallySource(xml).item_gst_rates()
+
+    def test_picks_igst_not_cess(self):
+        rates = self._rates(_item_xml("Widget", [
+            ("CGST", " 9"), ("SGST/UTGST", " 9"), ("IGST", " 18"),
+            ("Cess", " 1"),            # must NOT be mistaken for the GST rate
+        ]))
+        self.assertEqual(rates["Widget"], "18")
+
+    def test_falls_back_to_cgst_plus_sgst_when_no_igst(self):
+        rates = self._rates(_item_xml("Gadget", [("CGST", "6"), ("SGST/UTGST", "6")]))
+        self.assertEqual(rates["Gadget"], "12")
+
+    def test_no_rate_for_exempt_item(self):
+        rates = self._rates(_item_xml("Rice", [("IGST", None)]))   # head present, no rate
+        self.assertEqual(rates["Rice"], "")
+
+
+class TestTreatmentLabel(unittest.TestCase):
+    def test_labels(self):
+        L = ItemImporter._gst_treatment_label
+        self.assertEqual(L({"GSTTaxability": "Taxable"}), "Taxable")
+        self.assertEqual(L({"GSTTaxability": "Nil Rated"}), "Nil-Rated")
+        self.assertEqual(L({"GSTTaxability": "Exempt"}), "Exempted")
+        self.assertEqual(L({"GSTTaxability": "Non-GST"}), "Non-GST")
+        self.assertEqual(L({"GstApplicable": "Not Applicable"}), "Non-GST")
+        self.assertEqual(L({"GSTTaxability": ""}), "Taxable")
+        self.assertIsNone(L({"GSTTaxability": "Weird Value"}))
+
+
+class TestTaxTemplateResolution(unittest.TestCase):
+    def _imp(self):
+        imp = ItemImporter(company="Frappe Tech", abbr="FT")
+        imp._india_compliance = True
+        return imp
+
+    def test_resolves_links_and_warns_on_missing(self):
+        imp = self._imp()
+        res = ImportResult("Item")
+        records = [
+            {"_name": "A", "GSTTaxability": "Taxable", "GstRate": "18"},   # -> template
+            {"_name": "B", "GSTTaxability": "Taxable", "GstRate": "3"},    # -> no template, warn
+            {"_name": "C", "GSTTaxability": "Exempt",  "GstRate": ""},     # -> Exempted template
+        ]
+
+        def fake_get_all(doctype, filters=None, **kw):
+            if filters.get("gst_treatment") == "Taxable" and filters.get("gst_rate") == 18:
+                return ["GST 18% - FT"]
+            if filters.get("gst_treatment") == "Exempted":
+                return ["Exempted - FT"]
+            return []
+        with mock.patch("frappe.get_all", side_effect=fake_get_all):
+            imp._resolve_tax_templates(records, res)
+
+        self.assertEqual(imp._tax_templates.get("A"), "GST 18% - FT")
+        self.assertEqual(imp._tax_templates.get("C"), "Exempted - FT")
+        self.assertNotIn("B", imp._tax_templates)
+        self.assertTrue(any(w["name"] == "B" and "3%" in w["reason"] for w in res.warnings))
+
+    def test_no_india_compliance_is_noop(self):
+        imp = ItemImporter(company="Frappe Tech", abbr="FT")
+        imp._india_compliance = False
+        res = ImportResult("Item")
+        imp._resolve_tax_templates([{"_name": "A", "GSTTaxability": "Taxable", "GstRate": "18"}], res)
+        self.assertEqual(imp._tax_templates, {})
+        self.assertEqual(res.warnings, [])
+
+    def test_build_doc_adds_resolved_template(self):
+        imp = self._imp()
+        imp._tax_templates = {"Pen": "GST 18% - FT"}
+        doc = imp.build_doc({"_name": "Pen", "BaseUnits": "Nos", "GSTTaxability": "Taxable"})
+        self.assertEqual(doc["taxes"], [{"item_tax_template": "GST 18% - FT"}])
+
+    def test_build_doc_no_template_no_taxes_key(self):
+        imp = self._imp()
+        imp._tax_templates = {}
+        doc = imp.build_doc({"_name": "Pen", "BaseUnits": "Nos", "GSTTaxability": "Taxable"})
+        self.assertNotIn("taxes", doc)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tally_migrator/tests/test_uqc.py
+++ b/tally_migrator/tests/test_uqc.py
@@ -1,0 +1,105 @@
+"""
+Phase 1 (UQC) tests.
+
+India Compliance stores the GST Unit Quantity Code globally in
+GST Settings.gst_uom_map (uom -> gst_uom), not per-UOM. UnitImporter maps each
+imported Tally UOM's REPORTINGUQCNAME ("NOS-NUMBERS") to the official GST option
+("NOS (Numbers)"), appending only missing rows. Codes with no official match
+(e.g. Tally's "REM-REAMS") are left unmapped with a warning, never guessed.
+"""
+import types
+import unittest
+from unittest import mock
+
+from tally_migrator.erpnext.importers.units import UnitImporter
+from tally_migrator.erpnext.importers import ImportResult
+
+OPTIONS = "NOS (Numbers)\nKGS (Kilograms)\nBOX (Box)\nDOZ (Dozens)\nPCS (Pieces)\nOTH (Others)"
+
+
+def _code_map():
+    return {o.split("(")[0].strip().upper(): o for o in OPTIONS.splitlines()}
+
+
+class TestUqcMapping(unittest.TestCase):
+    def test_matches_by_code_case_insensitive(self):
+        cm = _code_map()
+        self.assertEqual(UnitImporter._uqc_to_gst_uom("NOS-NUMBERS", cm), "NOS (Numbers)")
+        self.assertEqual(UnitImporter._uqc_to_gst_uom("KGS-KILOGRAMS", cm), "KGS (Kilograms)")
+        self.assertEqual(UnitImporter._uqc_to_gst_uom("box-boxes", cm), "BOX (Box)")
+
+    def test_blank_not_applicable_and_unmatched_return_none(self):
+        cm = _code_map()
+        self.assertIsNone(UnitImporter._uqc_to_gst_uom("REM-REAMS", cm))      # no official code
+        self.assertIsNone(UnitImporter._uqc_to_gst_uom("", cm))
+        self.assertIsNone(UnitImporter._uqc_to_gst_uom("\x04 Not Applicable", cm))
+        self.assertIsNone(UnitImporter._uqc_to_gst_uom("Not Applicable", cm))
+
+    def _fake_settings(self, existing=()):
+        s = types.SimpleNamespace(
+            gst_uom_map=[types.SimpleNamespace(uom=u, gst_uom=g) for u, g in existing],
+            saved=False)
+        s.append = lambda table, row: s.gst_uom_map.append(
+            types.SimpleNamespace(uom=row["uom"], gst_uom=row["gst_uom"]))
+
+        def _save(**kw):
+            s.saved = True
+        s.save = _save
+        return s
+
+    def test_map_uqcs_appends_missing_skips_existing_warns_unmatched(self):
+        imp = UnitImporter("_T Co", "TC")
+        res = ImportResult("UOM")
+        units = [
+            {"_name": "Nos",  "ReportingUQC": "NOS-NUMBERS"},
+            {"_name": "Kg",   "ReportingUQC": "KGS-KILOGRAMS"},
+            {"_name": "Ream", "ReportingUQC": "REM-REAMS"},          # no match -> warn
+            {"_name": "Box",  "ReportingUQC": "\x04 Not Applicable"},  # skipped silently
+            {"_name": "Pcs",  "ReportingUQC": "PCS-PIECES"},          # already mapped -> skip
+        ]
+        settings = self._fake_settings(existing=[("Pcs", "PCS (Pieces)")])
+        meta = types.SimpleNamespace(
+            get_field=lambda f: types.SimpleNamespace(options=OPTIONS))
+        with mock.patch("frappe.db.exists", return_value=True), \
+                mock.patch("frappe.get_meta", return_value=meta), \
+                mock.patch("frappe.get_doc", return_value=settings), \
+                mock.patch("frappe.db.commit"):
+            imp._map_uqcs(units, res)
+
+        mapped = {(r.uom, r.gst_uom) for r in settings.gst_uom_map}
+        self.assertIn(("Nos", "NOS (Numbers)"), mapped)
+        self.assertIn(("Kg", "KGS (Kilograms)"), mapped)
+        self.assertFalse(any(r.uom == "Box" for r in settings.gst_uom_map))      # skipped
+        self.assertEqual(sum(1 for r in settings.gst_uom_map if r.uom == "Pcs"), 1)  # not duped
+        self.assertTrue(any(w["name"] == "Ream" for w in res.warnings))          # warned
+        self.assertTrue(settings.saved)
+
+    def test_no_india_compliance_is_noop(self):
+        imp = UnitImporter("_T Co", "TC")
+        res = ImportResult("UOM")
+        with mock.patch("frappe.db.exists", return_value=False):
+            imp._map_uqcs([{"_name": "Nos", "ReportingUQC": "NOS-NUMBERS"}], res)
+        self.assertEqual(res.warnings, [])
+
+
+class TestUqcExtraction(unittest.TestCase):
+    def test_extraction_reads_latest_reporting_uqc(self):
+        from tally_migrator.tally.file_source import FileTallySource
+        from tally_migrator.tally.extractors import UNIT_FIELDS, UNIT_TAGS
+        # Dated list with two entries; the most recent (last) wins.
+        xml = (
+            '<ENVELOPE><BODY><IMPORTDATA><REQUESTDATA>'
+            '<TALLYMESSAGE><UNIT NAME="Nos"><NAME>Nos</NAME>'
+            '<REPORTINGUQCDETAILS.LIST><APPLICABLEFROM>20200401</APPLICABLEFROM>'
+            '<REPORTINGUQCNAME>OTH-OTHERS</REPORTINGUQCNAME></REPORTINGUQCDETAILS.LIST>'
+            '<REPORTINGUQCDETAILS.LIST><APPLICABLEFROM>20260401</APPLICABLEFROM>'
+            '<REPORTINGUQCNAME>NOS-NUMBERS</REPORTINGUQCNAME></REPORTINGUQCDETAILS.LIST>'
+            '</UNIT></TALLYMESSAGE>'
+            '</REQUESTDATA></IMPORTDATA></BODY></ENVELOPE>'
+        )
+        rows = FileTallySource(xml).get_collection("Unit", UNIT_FIELDS, UNIT_TAGS)
+        self.assertEqual(rows[0]["ReportingUQC"], "NOS-NUMBERS")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reads each item's Tally GST rate and links it to the corresponding ERPNext GST Item Tax Template, so item tax is driven by the source rate rather than a manual mapping.

Stacked on feat/uqc-mapping.