### PR TITLE
Migrate Tally bills of materials to ERPNext BOM

### DIFF
--- a/tally_migrator/erpnext/importers/__init__.py
+++ b/tally_migrator/erpnext/importers/__init__.py
@@ -31,6 +31,7 @@ from .items import ItemImporter
 from .warehouses import WarehouseImporter, StockGroupImporter
 from .units import UnitImporter
 from .prices import PriceImporter
+from .bom import BomImporter
 from .accounts import AccountImporter, CostCentreImporter
 from .hsn import (
     _HSN_GUARD_KEY,

--- a/tally_migrator/erpnext/importers/__init__.py
+++ b/tally_migrator/erpnext/importers/__init__.py
@@ -30,6 +30,7 @@ from .party import PartyImporter, CustomerImporter, SupplierImporter
 from .items import ItemImporter
 from .warehouses import WarehouseImporter, StockGroupImporter
 from .units import UnitImporter
+from .prices import PriceImporter
 from .accounts import AccountImporter, CostCentreImporter
 from .hsn import (
     _HSN_GUARD_KEY,

--- a/tally_migrator/erpnext/importers/bom.py
+++ b/tally_migrator/erpnext/importers/bom.py
@@ -1,0 +1,113 @@
+"""BOM importer: Tally multi-component lists -> ERPNext BOM (submitted, active)."""
+
+import frappe
+
+from tally_migrator.naming import safe_item_code
+from .base import BaseImporter, ImportResult
+
+
+class BomImporter:
+    """Create ERPNext BOMs from Tally bills of materials.
+
+    Each Tally BOM becomes a submitted, active BOM; the first BOM per item is the
+    default. Runs after Items so the finished item and components exist. Only
+    NATUREOFITEM=Component rows are migrated; by-products/co-products/scrap are
+    skipped with a warning (no fixture coverage to build secondary_items against).
+
+    Idempotent by skip-if-exists: BOM names auto-increment, so a re-run would
+    create duplicates; if any BOM already exists for an item we skip it entirely.
+    """
+
+    doctype = "BOM"
+
+    def __init__(self, company: str, abbr: str):
+        self.company = company
+        self.abbr = abbr
+        self.currency = frappe.get_cached_value(
+            "Company", company, "default_currency") or "INR"
+
+    def run(self, items: list[dict]) -> ImportResult:
+        result = ImportResult(self.doctype)
+        for it in items:
+            boms = it.get("Boms") or []
+            if not boms:
+                continue
+            code = safe_item_code(it.get("_name", ""))
+            if not frappe.db.exists("Item", code):
+                continue                         # finished item didn't import
+            if frappe.db.exists("BOM", {"item": code}):
+                result.skipped += 1              # idempotent: never duplicate
+                continue
+            for i, bom in enumerate(boms):
+                self._import_bom(result, code, it.get("_name", ""), bom, is_default=(i == 0))
+        return result
+
+    def _import_bom(self, result, code, item_name, bom, is_default):
+        rows, warns = self._component_rows(code, bom.get("components") or [])
+        for w in warns:
+            result.add_warning(item_name, w)
+        if not rows:
+            result.add_warning(item_name, "BOM skipped - no usable Component rows.")
+            return
+        qty, uom = self._parse_qty_uom(bom.get("basic_qty"))
+        doc = {
+            "doctype": "BOM", "item": code, "company": self.company,
+            "quantity": qty or 1, "currency": self.currency, "conversion_rate": 1,
+            "is_active": 1, "is_default": 1 if is_default else 0, "items": rows,
+        }
+        if uom and frappe.db.exists("UOM", uom):
+            doc["uom"] = uom
+        try:
+            d = frappe.get_doc(doc)
+            d.insert(ignore_permissions=True)
+            d.submit()
+            frappe.db.commit()
+            result.add_created(d.name, "BOM")
+        except Exception as exc:
+            frappe.db.rollback()
+            result.add_error(f"{item_name} (BOM {bom.get('name')})", exc)
+
+    def _component_rows(self, finished_code, components):
+        rows, warns = [], []
+        for c in components:
+            nature = (c.get("natureofitem") or "Component").strip()
+            cname = (c.get("stockitemname") or "").strip()
+            if nature.lower() != "component":
+                warns.append(f"component '{cname}' is a {nature}, not migrated "
+                             "(only Components are imported into the BOM).")
+                continue
+            ccode = safe_item_code(cname)
+            if not frappe.db.exists("Item", ccode):
+                warns.append(f"BOM component '{cname}' not found as an item - skipped.")
+                continue
+            if ccode == finished_code:
+                warns.append(f"BOM component '{cname}' is the finished item itself "
+                             "(self-reference) - skipped.")
+                continue
+            qty, uom = self._parse_qty_uom(c.get("actualqty"))
+            if not qty:
+                warns.append(f"BOM component '{cname}' has no quantity - skipped.")
+                continue
+            stock_uom = frappe.db.get_value("Item", ccode, "stock_uom")
+            if uom and frappe.db.exists("UOM", uom):
+                if uom != stock_uom:
+                    warns.append(
+                        f"component '{cname}' quantity is in '{uom}' but its stock "
+                        f"unit is '{stock_uom}'; ERPNext assumes 1:1 unless the item "
+                        "defines that conversion - verify the BOM quantity.")
+            else:
+                uom = stock_uom
+            rows.append({"item_code": ccode, "qty": qty, "uom": uom})
+        return rows, warns
+
+    @staticmethod
+    def _parse_qty_uom(raw):
+        """' 1 Ream' -> (1.0, 'Ream'); '2 Box' -> (2.0, 'Box'); '' -> (0.0, '')."""
+        raw = (raw or "").strip()
+        if not raw:
+            return 0.0, ""
+        parts = raw.split(None, 1)
+        try:
+            return float(parts[0].replace(",", "")), (parts[1].strip() if len(parts) > 1 else "")
+        except ValueError:
+            return 0.0, ""

--- a/tally_migrator/erpnext/importers/items.py
+++ b/tally_migrator/erpnext/importers/items.py
@@ -65,6 +65,11 @@ class ItemImporter(BaseImporter):
         # app is installed. Without it ERPNext core silently drops those keys, so we
         # say so once instead of pretending the GST data landed.
         self._india_compliance = "india_compliance" in frappe.get_installed_apps()
+        # Resolve each item's GST Item Tax Template once (links the rate to the
+        # India-Compliance-seeded "GST 18%" / "Nil-Rated" templates for this
+        # company). Done here, with access to ``result``, so a missing template
+        # warns exactly once; build_doc just reads the resolved map.
+        self._resolve_tax_templates(records, result)
         if not self._india_compliance and any(
             (r.get("GSTTaxability") or r.get("HSNCode")
              or r.get("GstApplicable") or r.get("TypeOfSupply"))
@@ -112,7 +117,62 @@ class ItemImporter(BaseImporter):
         if vm:
             doc["valuation_method"] = vm
         doc.update(self._gst_fields(record))
+        tpl = getattr(self, "_tax_templates", {}).get(record["_name"])
+        if tpl:
+            doc["taxes"] = [{"item_tax_template": tpl}]
         return doc
+
+    # ── GST rate -> Item Tax Template linking (India Compliance) ───────────────
+    @staticmethod
+    def _gst_treatment_label(record: dict) -> "str | None":
+        """ERPNext/India-Compliance gst_treatment string for an item, or None when
+        the Tally GST type is unrecognised (already warned elsewhere)."""
+        if (record.get("GstApplicable") or "").strip().lower() in ("not applicable", "no"):
+            return "Non-GST"
+        key = (record.get("GSTTaxability") or "").strip().lower().replace("-", " ").replace("_", " ")
+        key = " ".join(key.split())
+        return {
+            "": "Taxable", "taxable": "Taxable", "applicable": "Taxable",
+            "nil rated": "Nil-Rated", "nil": "Nil-Rated",
+            "exempt": "Exempted", "exempted": "Exempted",
+            "non gst": "Non-GST", "not applicable": "Non-GST",
+        }.get(key)
+
+    def _resolve_tax_template(self, treatment: str, rate: float) -> "str | None":
+        """The company's GST Item Tax Template for this treatment/rate, matched by
+        the India-Compliance gst_treatment + gst_rate fields (never by the
+        company-suffixed name), or None when none is seeded."""
+        filters = {"company": self.company, "gst_treatment": treatment}
+        if treatment == "Taxable":
+            if not rate:
+                return None
+            filters["gst_rate"] = rate
+        rows = frappe.get_all(
+            "Item Tax Template", filters=filters, pluck="name", limit=1,
+            ignore_permissions=True)
+        return rows[0] if rows else None
+
+    def _resolve_tax_templates(self, records: list[dict], result: ImportResult) -> None:
+        """Build ``{item name: template}`` for build_doc, warning once per item when
+        a taxable rate has no matching template. No-op without India Compliance
+        (its gst_rate/gst_treatment fields, and the seeded templates, don't exist)."""
+        self._tax_templates: dict = {}
+        if not getattr(self, "_india_compliance", False):
+            return
+        for r in records:
+            treatment = self._gst_treatment_label(r)
+            if not treatment:
+                continue
+            rate = self._to_float(r.get("GstRate"))
+            tpl = self._resolve_tax_template(treatment, rate)
+            if tpl:
+                self._tax_templates[r["_name"]] = tpl
+            elif treatment == "Taxable" and rate:
+                result.add_warning(
+                    r["_name"],
+                    f"no GST Item Tax Template for {rate:g}% on company "
+                    f"'{self.company}' - item imported without a tax rate; create a "
+                    f"'GST {rate:g}%' template or set it on the item manually.")
 
     def recover_insert(self, data: dict, exc: Exception):
         """India Compliance makes ``gst_hsn_code`` a Link to "GST HSN Code" and

--- a/tally_migrator/erpnext/importers/orchestrator.py
+++ b/tally_migrator/erpnext/importers/orchestrator.py
@@ -29,6 +29,7 @@ from .party import PartyImporter, CustomerImporter, SupplierImporter
 from .items import ItemImporter
 from .warehouses import WarehouseImporter, StockGroupImporter
 from .units import UnitImporter
+from .prices import PriceImporter
 from .accounts import AccountImporter, CostCentreImporter
 from .hsn import _restore_hsn_validation, _hsn_validation_suspended
 from .openings import (
@@ -115,6 +116,9 @@ class ERPNextImporter:
 
     def import_units(self, units: list[dict]) -> ImportResult:
         return UnitImporter(self.company, self.abbr).run(units)
+
+    def import_prices(self, items: list[dict]) -> ImportResult:
+        return PriceImporter(self.company, self.abbr).run(items)
 
     def import_warehouses(self, warehouses: list[dict]) -> ImportResult:
         return WarehouseImporter(self.company, self.abbr).run(warehouses)

--- a/tally_migrator/erpnext/importers/orchestrator.py
+++ b/tally_migrator/erpnext/importers/orchestrator.py
@@ -30,6 +30,7 @@ from .items import ItemImporter
 from .warehouses import WarehouseImporter, StockGroupImporter
 from .units import UnitImporter
 from .prices import PriceImporter
+from .bom import BomImporter
 from .accounts import AccountImporter, CostCentreImporter
 from .hsn import _restore_hsn_validation, _hsn_validation_suspended
 from .openings import (
@@ -119,6 +120,9 @@ class ERPNextImporter:
 
     def import_prices(self, items: list[dict]) -> ImportResult:
         return PriceImporter(self.company, self.abbr).run(items)
+
+    def import_boms(self, items: list[dict]) -> ImportResult:
+        return BomImporter(self.company, self.abbr).run(items)
 
     def import_warehouses(self, warehouses: list[dict]) -> ImportResult:
         return WarehouseImporter(self.company, self.abbr).run(warehouses)

--- a/tally_migrator/erpnext/importers/prices.py
+++ b/tally_migrator/erpnext/importers/prices.py
@@ -1,0 +1,140 @@
+"""Price importer: Tally price levels -> ERPNext Price List + Item Price (+ a
+price-list-scoped Pricing Rule for any per-level discount)."""
+
+import frappe
+
+from tally_migrator.naming import safe_item_code
+from .base import BaseImporter, ImportResult
+
+
+class PriceImporter:
+    """Create selling Price Lists and Item Prices from Tally price levels.
+
+    Each Tally price level (Retail / Wholesale) becomes a selling Price List; the
+    level's rate becomes an Item Price on that list. A per-level discount becomes a
+    Pricing Rule scoped to that price list (for_price_list), so it applies only when
+    that list is used - mirroring Tally's "rate then discount" billing. Runs after
+    Items so the item_code/UOM links resolve. All upserts are idempotent.
+    """
+
+    doctype = "Item Price"
+
+    def __init__(self, company: str, abbr: str):
+        self.company = company
+        self.abbr = abbr
+        self.currency = frappe.get_cached_value(
+            "Company", company, "default_currency") or "INR"
+
+    def run(self, items: list[dict]) -> ImportResult:
+        result = ImportResult(self.doctype)
+        for it in items:
+            for lv in (it.get("PriceLevels") or []):
+                self._import_level(result, it.get("_name", ""), lv)
+        return result
+
+    def _import_level(self, result: ImportResult, item_name: str, lv: dict) -> None:
+        rate, uom = self._parse_rate(lv.get("rate", ""))
+        if rate is None:
+            return                              # a level with no rate carries nothing
+        item_code = safe_item_code(item_name)
+        if not frappe.db.exists("Item", item_code):
+            return                              # item didn't import (warned by ItemImporter)
+        if not (uom and frappe.db.exists("UOM", uom)):
+            uom = frappe.db.get_value("Item", item_code, "stock_uom")
+        level = (lv.get("level") or "").strip()
+        if not level:
+            return
+        try:
+            price_list = self._ensure_price_list(level)
+            valid_from = self._parse_date(lv.get("date"))
+            self._ensure_item_price(result, item_code, price_list, uom, rate, valid_from)
+            disc = BaseImporter._to_float(lv.get("discount"))
+            if disc:
+                self._ensure_pricing_rule(
+                    result, item_code, price_list, disc, valid_from, lv.get("ending"))
+        except Exception as exc:
+            result.add_error(f"{item_name} ({level})", exc)
+            frappe.db.rollback()
+
+    # ── upserts ────────────────────────────────────────────────────────────────
+    def _ensure_price_list(self, level: str) -> str:
+        if not frappe.db.exists("Price List", level):
+            frappe.get_doc({
+                "doctype": "Price List", "price_list_name": level,
+                "selling": 1, "enabled": 1, "currency": self.currency,
+            }).insert(ignore_permissions=True)
+            frappe.db.commit()
+        return level
+
+    def _ensure_item_price(self, result, item_code, price_list, uom, rate, valid_from):
+        if frappe.db.exists("Item Price", {
+                "item_code": item_code, "price_list": price_list, "uom": uom}):
+            result.skipped += 1
+            return
+        doc = frappe.get_doc({
+            "doctype": "Item Price", "item_code": item_code, "uom": uom,
+            "price_list": price_list, "price_list_rate": rate, "selling": 1,
+            "currency": self.currency, "valid_from": valid_from or None,
+        })
+        doc.insert(ignore_permissions=True)
+        frappe.db.commit()
+        result.add_created(doc.name, "Item Price")
+
+    def _ensure_pricing_rule(self, result, item_code, price_list, discount,
+                             valid_from, ending):
+        # Deterministic title is the idempotency key (Pricing Rule has no natural
+        # one), so a re-run finds and skips the rule rather than duplicating it.
+        title = f"Tally {price_list} discount - {item_code}"[:140]
+        if frappe.db.exists("Pricing Rule", title):
+            return
+        # for_price_list scopes the rule to this price list, so the discount applies
+        # only when selling at that level, on its Item Price rate (Retail 398 - 10%
+        # = 358.20) - mirroring Tally. NB: do NOT set apply_discount_on_rate: that is
+        # the "stack on an already-discounted rate" flag and would force a Priority.
+        rule = {
+            "doctype": "Pricing Rule", "title": title,
+            "apply_on": "Item Code", "items": [{"item_code": item_code}],
+            "price_or_product_discount": "Price",
+            "rate_or_discount": "Discount Percentage",
+            "discount_percentage": discount,
+            "for_price_list": price_list, "selling": 1, "company": self.company,
+            "valid_from": valid_from or None,
+        }
+        # The slab's qty ceiling (ENDINGAT "100 Ream") bounds the discount, when present.
+        max_qty = self._parse_qty(ending)
+        if max_qty:
+            rule["max_qty"] = max_qty
+        frappe.get_doc(rule).insert(ignore_permissions=True)
+        frappe.db.commit()
+        result.add_created(title, "Pricing Rule")
+
+    # ── parsing ─────────────────────────────────────────────────────────────────
+    @staticmethod
+    def _parse_rate(raw: str):
+        """'398.00/Ream' -> (398.0, 'Ream'); '360.00' -> (360.0, ''); '' -> (None, '')."""
+        raw = (raw or "").strip()
+        if not raw:
+            return None, ""
+        rate_part, _, uom = raw.partition("/")
+        try:
+            return float(rate_part.replace(",", "").strip()), uom.strip()
+        except ValueError:
+            return None, ""
+
+    @staticmethod
+    def _parse_qty(raw: str) -> float:
+        """' 100 Ream' -> 100.0; '' -> 0.0."""
+        raw = (raw or "").strip()
+        num = raw.split()[0] if raw else ""
+        try:
+            return float(num.replace(",", ""))
+        except ValueError:
+            return 0.0
+
+    @staticmethod
+    def _parse_date(raw: str):
+        """Tally 'YYYYMMDD' -> 'YYYY-MM-DD'; anything else -> ''."""
+        raw = (raw or "").strip()
+        if len(raw) == 8 and raw.isdigit():
+            return f"{raw[0:4]}-{raw[4:6]}-{raw[6:8]}"
+        return ""

--- a/tally_migrator/erpnext/importers/units.py
+++ b/tally_migrator/erpnext/importers/units.py
@@ -55,7 +55,87 @@ class UnitImporter:
         for u in units:
             if not self._is_simple(u):
                 self._ensure_conversion(result, u)
+        # Third pass: map each UOM's GST Unit Quantity Code into India Compliance's
+        # GST Settings (must run after the UOMs themselves exist).
+        self._map_uqcs(units, result)
         return result
+
+    # ── GST UQC mapping (India Compliance) ─────────────────────────────────────
+    @staticmethod
+    def _gst_uom_code_map() -> "dict | None":
+        """``{UQC code: official option string}`` derived live from the GST UOM Map
+        field's option list (e.g. ``{"NOS": "NOS (Numbers)"}``).
+
+        Derived from IC's field metadata rather than a hardcoded list so it tracks
+        whatever UQC values the installed India Compliance version supports
+        (derive-don't-enumerate). Returns ``None`` when India Compliance is absent,
+        which makes the whole UQC pass a clean no-op."""
+        if not frappe.db.exists("DocType", "GST UOM Map"):
+            return None
+        try:
+            options = frappe.get_meta("GST UOM Map").get_field("gst_uom").options or ""
+        except Exception:
+            return None
+        out = {}
+        for opt in options.splitlines():
+            opt = opt.strip()
+            if opt:
+                out[opt.split("(")[0].strip().upper()] = opt
+        return out
+
+    @staticmethod
+    def _uqc_to_gst_uom(tally_uqc: str, code_map: dict) -> "str | None":
+        """Map a Tally REPORTINGUQCNAME ('NOS-NUMBERS') to the official GST UOM
+        option ('NOS (Numbers)'), or ``None`` when blank/'Not Applicable'/no match.
+
+        Tally encodes ``CODE-DESCRIPTION``; we match on the CODE prefix against the
+        official option set. A code with no official equivalent (e.g. Tally's
+        'REM-REAMS') returns ``None`` so the caller can warn rather than write an
+        invalid value into GST returns."""
+        raw = (tally_uqc or "").replace("\x04", " ").strip()  # Tally pads with &#4;
+        if not raw or "not applicable" in raw.lower():
+            return None
+        code = raw.split("-", 1)[0].strip().upper()
+        return code_map.get(code)
+
+    def _map_uqcs(self, units: list[dict], result: ImportResult) -> None:
+        """Append missing ``GST Settings.gst_uom_map`` rows for the imported UOMs.
+
+        India Compliance stores UQC globally in GST Settings (a Single doctype),
+        not per-UOM, so this writes shared config: append-only, idempotent (skips
+        UOMs already mapped by IC's defaults or a prior run), one save. No-op when
+        India Compliance is absent. Tally codes with no official GST equivalent are
+        left unmapped with a warning rather than guessed."""
+        code_map = self._gst_uom_code_map()
+        if not code_map:
+            return
+        settings = frappe.get_doc("GST Settings")
+        already = {(m.uom or "").strip().lower() for m in settings.gst_uom_map}
+        changed = False
+        seen = set()
+        for u in units:
+            uom = (u.get("_name") or "").strip()
+            if not uom or uom.lower() in seen:
+                continue
+            seen.add(uom.lower())
+            raw_uqc = (u.get("ReportingUQC") or "").replace("\x04", " ").strip()
+            gst_uom = self._uqc_to_gst_uom(raw_uqc, code_map)
+            if not gst_uom:
+                # Only warn when Tally actually carried a UQC we couldn't place;
+                # a blank/'Not Applicable' unit is simply skipped silently.
+                if raw_uqc and "not applicable" not in raw_uqc.lower():
+                    result.add_warning(
+                        uom, f"GST UQC '{raw_uqc}' has no standard GST code; left "
+                        "unmapped - set it manually in GST Settings if needed for filing.")
+                continue
+            if uom.lower() in already or not frappe.db.exists("UOM", uom):
+                continue
+            settings.append("gst_uom_map", {"uom": uom, "gst_uom": gst_uom})
+            already.add(uom.lower())
+            changed = True
+        if changed:
+            settings.save(ignore_permissions=True)
+            frappe.db.commit()
 
     @staticmethod
     def _is_simple(u: dict) -> bool:

--- a/tally_migrator/migration/master_migrator.py
+++ b/tally_migrator/migration/master_migrator.py
@@ -281,6 +281,10 @@ class MasterMigrator:
             PipelineStep("Suppliers", 65, self.importer.import_suppliers, masters.suppliers),
             PipelineStep("Items", 80, self.importer.import_items, masters.items),
         ]
+        # Price levels (Retail/Wholesale) -> Price List + Item Price (+ discount
+        # Pricing Rule). After Items so item_code/UOM links resolve.
+        if any(i.get("PriceLevels") for i in masters.items):
+            steps.append(PipelineStep("Prices", 82, self.importer.import_prices, masters.items))
         # Ledger account opening balances (cash, assets, P&L) - one balanced,
         # submitted Opening Entry (JE) once every account exists. Party balances
         # NO LONGER go through this path: they post invoice-wise below, so the JE

--- a/tally_migrator/migration/master_migrator.py
+++ b/tally_migrator/migration/master_migrator.py
@@ -285,6 +285,10 @@ class MasterMigrator:
         # Pricing Rule). After Items so item_code/UOM links resolve.
         if any(i.get("PriceLevels") for i in masters.items):
             steps.append(PipelineStep("Prices", 82, self.importer.import_prices, masters.items))
+        # Bills of materials -> ERPNext BOM (submitted). After Items so the finished
+        # item and every component exist.
+        if any(i.get("Boms") for i in masters.items):
+            steps.append(PipelineStep("BOMs", 84, self.importer.import_boms, masters.items))
         # Ledger account opening balances (cash, assets, P&L) - one balanced,
         # submitted Opening Entry (JE) once every account exists. Party balances
         # NO LONGER go through this path: they post invoice-wise below, so the JE

--- a/tally_migrator/tally/extractors.py
+++ b/tally_migrator/tally/extractors.py
@@ -37,8 +37,14 @@ COSTCENTRE_FIELDS = ["Name", "Parent"]
 STOCKGROUP_FIELDS = ["Name", "Parent"]
 UNIT_FIELDS       = [
     "Name", "IsSimpleUnit", "OriginalName", "DecimalPlaces",
-    "BaseUnits", "AdditionalUnits", "Conversion",
+    "BaseUnits", "AdditionalUnits", "Conversion", "ReportingUQC",
 ]
+# The GST Unit Quantity Code lives in a dated revision list
+# (REPORTINGUQCDETAILS.LIST/REPORTINGUQCNAME, e.g. "NOS-NUMBERS"); _resolve_field
+# returns the last/most-recent entry. "Not Applicable" rows are filtered downstream.
+UNIT_TAGS = {
+    "ReportingUQC": ["REPORTINGUQCDETAILS.LIST/REPORTINGUQCNAME"],
+}
 
 
 # ── Tag overrides for fields whose real Tally tag ≠ FIELD.upper() ─────────────
@@ -236,7 +242,7 @@ class TallyExtractor:
             stock_groups = self._dedup_by_name(
                 self.client.get_collection("Stock Group", STOCKGROUP_FIELDS)),
             units        = self._dedup_by_name(
-                self.client.get_collection("Unit", UNIT_FIELDS)),
+                self.client.get_collection("Unit", UNIT_FIELDS, UNIT_TAGS)),
         )
 
     @staticmethod

--- a/tally_migrator/tally/extractors.py
+++ b/tally_migrator/tally/extractors.py
@@ -249,6 +249,8 @@ class TallyExtractor:
         self._attach_item_gst_rates(masters.items)
         # Attach each item's price levels (Retail/Wholesale rates + discounts).
         self._attach_item_price_levels(masters.items)
+        # Attach each item's bills of materials (component lists).
+        self._attach_item_boms(masters.items)
         return masters
 
     def _attach_item_gst_rates(self, items: list[dict]) -> None:
@@ -268,6 +270,15 @@ class TallyExtractor:
         levels = self.client.item_price_levels()
         for it in items:
             it.setdefault("PriceLevels", levels.get(it.get("_name", ""), []))
+
+    def _attach_item_boms(self, items: list[dict]) -> None:
+        """Set ``Boms`` (list of {name, basic_qty, components}) on each item dict.
+        No-op when the source can't supply it (live client)."""
+        if not hasattr(self.client, "item_boms"):
+            return
+        boms = self.client.item_boms()
+        for it in items:
+            it.setdefault("Boms", boms.get(it.get("_name", ""), []))
 
     @staticmethod
     def _dedup_by_name(records: list[dict]) -> list[dict]:

--- a/tally_migrator/tally/extractors.py
+++ b/tally_migrator/tally/extractors.py
@@ -232,7 +232,7 @@ class TallyExtractor:
         # (repeating child lists a real export carries beyond the single primary
         # mailing address / mobile). No-op for a live client without child lists.
         self._attach_party_subrecords(ledgers)
-        return ExtractedMasters(
+        masters = ExtractedMasters(
             customers    = [l for l in ledgers if resolver.kind_of(l["_name"]) == CUSTOMER],
             suppliers    = [l for l in ledgers if resolver.kind_of(l["_name"]) == SUPPLIER],
             items        = self._dedup_by_name(
@@ -244,6 +244,19 @@ class TallyExtractor:
             units        = self._dedup_by_name(
                 self.client.get_collection("Unit", UNIT_FIELDS, UNIT_TAGS)),
         )
+        # Attach each item's combined GST rate (IGST), read per duty head from the
+        # nested rate list. No-op for a live client that can't supply it.
+        self._attach_item_gst_rates(masters.items)
+        return masters
+
+    def _attach_item_gst_rates(self, items: list[dict]) -> None:
+        """Set ``GstRate`` on each item dict from the source's per-duty-head rate
+        read. Degrades to a no-op when the source can't supply it (live client)."""
+        if not hasattr(self.client, "item_gst_rates"):
+            return
+        rates = self.client.item_gst_rates()
+        for it in items:
+            it.setdefault("GstRate", rates.get(it.get("_name", ""), ""))
 
     @staticmethod
     def _dedup_by_name(records: list[dict]) -> list[dict]:

--- a/tally_migrator/tally/extractors.py
+++ b/tally_migrator/tally/extractors.py
@@ -247,6 +247,8 @@ class TallyExtractor:
         # Attach each item's combined GST rate (IGST), read per duty head from the
         # nested rate list. No-op for a live client that can't supply it.
         self._attach_item_gst_rates(masters.items)
+        # Attach each item's price levels (Retail/Wholesale rates + discounts).
+        self._attach_item_price_levels(masters.items)
         return masters
 
     def _attach_item_gst_rates(self, items: list[dict]) -> None:
@@ -257,6 +259,15 @@ class TallyExtractor:
         rates = self.client.item_gst_rates()
         for it in items:
             it.setdefault("GstRate", rates.get(it.get("_name", ""), ""))
+
+    def _attach_item_price_levels(self, items: list[dict]) -> None:
+        """Set ``PriceLevels`` (list of {level, date, rate, discount, ending}) on
+        each item dict. No-op when the source can't supply it (live client)."""
+        if not hasattr(self.client, "item_price_levels"):
+            return
+        levels = self.client.item_price_levels()
+        for it in items:
+            it.setdefault("PriceLevels", levels.get(it.get("_name", ""), []))
 
     @staticmethod
     def _dedup_by_name(records: list[dict]) -> list[dict]:

--- a/tally_migrator/tally/file_source.py
+++ b/tally_migrator/tally/file_source.py
@@ -293,6 +293,53 @@ class FileTallySource:
             out[name] = igst or ""
         return out
 
+    def item_price_levels(self) -> dict:
+        """``{stock item name: [{level, date, rate, discount, ending}, ...]}``.
+
+        Reads Tally price levels from FULLPRICELIST.LIST (one per price level +
+        effective DATE), each carrying PRICELEVELLIST.LIST slabs (ENDINGAT / RATE /
+        DISCOUNT). Per price level we keep the latest DATE only (price revisions
+        collapse to the current price) and the first slab (single-slab is the norm).
+        Raw strings are returned; the importer parses rate/uom/qty."""
+        out: dict = {}
+        for elem in self._by_tag.get("STOCKITEM", ()):
+            name = (elem.get("NAME") or elem.findtext("NAME") or "").strip()
+            if not name:
+                continue
+            by_level: dict = {}     # level -> (date, slab dict)
+            for fp in elem.iter():
+                if fp.tag.split("}")[-1].upper() != "FULLPRICELIST.LIST":
+                    continue
+                date = level = ""
+                slabs = []
+                for ch in fp:
+                    t = ch.tag.split("}")[-1].upper()
+                    if t == "DATE":
+                        date = (ch.text or "").strip()
+                    elif t == "PRICELEVEL":
+                        level = (ch.text or "").strip()
+                    elif t == "PRICELEVELLIST.LIST":
+                        row = {}
+                        for c in ch:
+                            ct = c.tag.split("}")[-1].upper()
+                            if ct in ("ENDINGAT", "RATE", "DISCOUNT"):
+                                row[ct.lower()] = (c.text or "").strip()
+                        if row:
+                            slabs.append(row)
+                if not level or not slabs:
+                    continue
+                prev = by_level.get(level)
+                # YYYYMMDD strings sort chronologically; keep the latest revision.
+                if prev is None or date > prev[0]:
+                    by_level[level] = (date, slabs[0])
+            if by_level:
+                out[name] = [
+                    {"level": lvl, "date": d, "rate": s.get("rate", ""),
+                     "discount": s.get("discount", ""), "ending": s.get("endingat", "")}
+                    for lvl, (d, s) in by_level.items()
+                ]
+        return out
+
     # ── Field resolution (tag overrides + nested .LIST descent) ────────────────
     @classmethod
     def _resolve_field(cls, elem, candidates: list) -> str:

--- a/tally_migrator/tally/file_source.py
+++ b/tally_migrator/tally/file_source.py
@@ -255,6 +255,44 @@ class FileTallySource:
         self._collection_cache[cache_key] = rows
         return [dict(r) for r in rows]
 
+    def item_gst_rates(self) -> dict:
+        """``{stock item name: combined GST rate string}`` read per duty head.
+
+        The rate lives nested under GSTDETAILS.LIST/STATEWISEDETAILS.LIST/
+        RATEDETAILS.LIST, one entry per duty head (CGST/SGST-UTGST/IGST/Cess). The
+        combined GST rate is IGST (== CGST + SGST); we read by duty head rather than
+        relying on tag order, so a Cess rate can never be mistaken for the GST rate.
+        Empty string when the item carries no rate (nil/exempt/non-GST)."""
+        out: dict = {}
+        for elem in self._by_tag.get("STOCKITEM", ()):
+            name = (elem.get("NAME") or elem.findtext("NAME") or "").strip()
+            if not name:
+                continue
+            heads: dict = {}
+            for node in elem.iter():
+                if node.tag.split("}")[-1].upper() != "RATEDETAILS.LIST":
+                    continue
+                duty = rate = ""
+                for ch in node:
+                    local = ch.tag.split("}")[-1].upper()
+                    if local == "GSTRATEDUTYHEAD":
+                        duty = (ch.text or "").strip().upper()
+                    elif local == "GSTRATE":
+                        rate = (ch.text or "").strip()
+                if duty and rate:
+                    heads[duty] = rate
+            igst = heads.get("IGST")
+            if not igst:
+                cgst = heads.get("CGST")
+                sgst = heads.get("SGST/UTGST") or heads.get("SGST")
+                if cgst or sgst:
+                    try:
+                        igst = f"{float(cgst or 0) + float(sgst or 0):g}"
+                    except ValueError:
+                        igst = ""
+            out[name] = igst or ""
+        return out
+
     # ── Field resolution (tag overrides + nested .LIST descent) ────────────────
     @classmethod
     def _resolve_field(cls, elem, candidates: list) -> str:

--- a/tally_migrator/tally/file_source.py
+++ b/tally_migrator/tally/file_source.py
@@ -340,6 +340,46 @@ class FileTallySource:
                 ]
         return out
 
+    def item_boms(self) -> dict:
+        """``{stock item name: [{name, basic_qty, components:[...]}]}``.
+
+        Reads Tally bills of materials from MULTICOMPONENTLIST.LIST (Tally supports
+        multiple BOMs per item), each carrying COMPONENTLISTNAME, COMPONENTBASICQTY
+        ("1 Nos" = qty the BOM makes) and MULTICOMPONENTITEMLIST.LIST components
+        (NATUREOFITEM / STOCKITEMNAME / GODOWNNAME / ACTUALQTY "1 Ream"). The legacy
+        empty COMPONENTLIST.LIST is ignored. Raw strings; the importer parses qty/uom."""
+        out: dict = {}
+        for elem in self._by_tag.get("STOCKITEM", ()):
+            name = (elem.get("NAME") or elem.findtext("NAME") or "").strip()
+            if not name:
+                continue
+            boms = []
+            for mc in elem.iter():
+                if mc.tag.split("}")[-1].upper() != "MULTICOMPONENTLIST.LIST":
+                    continue
+                bom_name = basic_qty = ""
+                comps = []
+                for ch in mc:
+                    t = ch.tag.split("}")[-1].upper()
+                    if t == "COMPONENTLISTNAME":
+                        bom_name = (ch.text or "").strip()
+                    elif t == "COMPONENTBASICQTY":
+                        basic_qty = (ch.text or "").strip()
+                    elif t == "MULTICOMPONENTITEMLIST.LIST":
+                        row = {}
+                        for c in ch:
+                            ct = c.tag.split("}")[-1].upper()
+                            if ct in ("NATUREOFITEM", "STOCKITEMNAME", "GODOWNNAME", "ACTUALQTY"):
+                                row[ct.lower()] = (c.text or "").strip()
+                        if row.get("stockitemname"):
+                            comps.append(row)
+                if comps:
+                    boms.append({"name": bom_name or name, "basic_qty": basic_qty,
+                                 "components": comps})
+            if boms:
+                out[name] = boms
+        return out
+
     # ── Field resolution (tag overrides + nested .LIST descent) ────────────────
     @classmethod
     def _resolve_field(cls, elem, candidates: list) -> str:

--- a/tally_migrator/tests/test_bom.py
+++ b/tally_migrator/tests/test_bom.py
@@ -1,0 +1,141 @@
+"""
+Phase 5 tests: Tally multi-component lists -> ERPNext BOM.
+
+Covers the two guards live re-validation proved necessary: a component UOM that
+differs from the item's stock UOM is kept but WARNED (ERPNext silently assumes
+1:1, so it needs review), and a self-referential component is explicitly skipped
+(ERPNext does not reject it). Plus skip-if-exists idempotency and skip+warn for
+non-Component natures.
+"""
+import types
+import unittest
+from unittest import mock
+
+from tally_migrator.tally.file_source import FileTallySource
+from tally_migrator.erpnext.importers.bom import BomImporter
+from tally_migrator.erpnext.importers import ImportResult
+
+
+class TestBomExtraction(unittest.TestCase):
+    def test_reads_multicomponent_ignores_empty_legacy_list(self):
+        xml = (
+            '<ENVELOPE><BODY><IMPORTDATA><REQUESTDATA><TALLYMESSAGE>'
+            '<STOCKITEM NAME="Kit"><NAME>Kit</NAME>'
+            '<COMPONENTLIST.LIST>      </COMPONENTLIST.LIST>'        # legacy empty - ignored
+            '<MULTICOMPONENTLIST.LIST><COMPONENTLISTNAME>Kit</COMPONENTLISTNAME>'
+            '<COMPONENTBASICQTY> 1 Nos</COMPONENTBASICQTY>'
+            '<MULTICOMPONENTITEMLIST.LIST><NATUREOFITEM>Component</NATUREOFITEM>'
+            '<STOCKITEMNAME>A4 Paper Ream</STOCKITEMNAME><GODOWNNAME>Main</GODOWNNAME>'
+            '<ACTUALQTY> 1 Ream</ACTUALQTY></MULTICOMPONENTITEMLIST.LIST>'
+            '</MULTICOMPONENTLIST.LIST></STOCKITEM>'
+            '</TALLYMESSAGE></REQUESTDATA></IMPORTDATA></BODY></ENVELOPE>'
+        )
+        boms = FileTallySource(xml).item_boms()["Kit"]
+        self.assertEqual(len(boms), 1)
+        self.assertEqual(boms[0]["basic_qty"], "1 Nos")
+        self.assertEqual(boms[0]["components"][0]["stockitemname"], "A4 Paper Ream")
+        self.assertEqual(boms[0]["components"][0]["actualqty"], "1 Ream")
+
+
+class TestParseQtyUom(unittest.TestCase):
+    def test_parse(self):
+        self.assertEqual(BomImporter._parse_qty_uom(" 1 Ream"), (1.0, "Ream"))
+        self.assertEqual(BomImporter._parse_qty_uom("2 Box"), (2.0, "Box"))
+        self.assertEqual(BomImporter._parse_qty_uom("5"), (5.0, ""))
+        self.assertEqual(BomImporter._parse_qty_uom(""), (0.0, ""))
+
+
+class TestComponentRows(unittest.TestCase):
+    def _imp(self):
+        with mock.patch("frappe.get_cached_value", return_value="INR"):
+            return BomImporter("Frappe Tech", "FT")
+
+    def test_guards(self):
+        imp = self._imp()
+        comps = [
+            {"natureofitem": "Component",  "stockitemname": "A", "actualqty": "2 Box"},
+            {"natureofitem": "By-Product", "stockitemname": "BP", "actualqty": "1 Nos"},
+            {"natureofitem": "Component",  "stockitemname": "Missing", "actualqty": "1 Nos"},
+            {"natureofitem": "Component",  "stockitemname": "Kit", "actualqty": "1 Nos"},   # self
+            {"natureofitem": "Component",  "stockitemname": "C", "actualqty": "1 Nos"},     # uom mismatch
+            {"natureofitem": "Component",  "stockitemname": "D", "actualqty": ""},          # no qty
+        ]
+        existing = {"A", "C", "Kit", "D"}
+        stock = {"A": "Box", "C": "Box", "Kit": "Nos", "D": "Nos"}
+
+        def fake_exists(dt, name=None):
+            if dt == "Item":
+                return name in existing
+            if dt == "UOM":
+                return True
+            return False
+        with mock.patch("frappe.db.exists", side_effect=fake_exists), \
+                mock.patch("frappe.db.get_value", side_effect=lambda d, n, f: stock.get(n)):
+            rows, warns = imp._component_rows("Kit", comps)
+
+        self.assertEqual(rows, [
+            {"item_code": "A", "qty": 2.0, "uom": "Box"},
+            {"item_code": "C", "qty": 1.0, "uom": "Nos"},     # kept, but warned
+        ])
+        joined = " ".join(warns)
+        self.assertIn("By-Product", joined)          # non-Component skipped
+        self.assertIn("Missing", joined)             # missing item skipped
+        self.assertIn("self-reference", joined)      # self skipped
+        self.assertIn("stock unit is 'Box'", joined)  # C uom mismatch warned
+        self.assertIn("no quantity", joined)         # D skipped
+
+
+class TestBomImporterRun(unittest.TestCase):
+    def _imp(self):
+        with mock.patch("frappe.get_cached_value", return_value="INR"):
+            return BomImporter("Frappe Tech", "FT")
+
+    def _items(self):
+        return [{"_name": "Kit", "Boms": [{"name": "Kit BOM", "basic_qty": "1 Nos",
+                 "components": [{"natureofitem": "Component", "stockitemname": "A",
+                                 "actualqty": "2 Nos"}]}]}]
+
+    def test_creates_submitted_default_bom(self):
+        imp = self._imp()
+        captured = {}
+
+        def fake_get_doc(d):
+            captured["doc"] = d
+            return types.SimpleNamespace(name="BOM-Kit-001",
+                                         insert=lambda **k: None, submit=lambda: None)
+
+        def fake_exists(dt, filt=None):
+            if dt == "Item":
+                return True
+            if dt == "BOM":
+                return False         # none yet -> create
+            if dt == "UOM":
+                return True
+            return False
+        with mock.patch("frappe.db.exists", side_effect=fake_exists), \
+                mock.patch("frappe.db.get_value", return_value="Nos"), \
+                mock.patch("frappe.get_doc", side_effect=fake_get_doc), \
+                mock.patch("frappe.db.commit"):
+            res = imp.run(self._items())
+
+        self.assertEqual(res.created, 1)
+        d = captured["doc"]
+        self.assertEqual((d["item"], d["is_active"], d["is_default"], d["quantity"]),
+                         ("Kit", 1, 1, 1.0))
+        self.assertEqual(d["items"], [{"item_code": "A", "qty": 2.0, "uom": "Nos"}])
+
+    def test_idempotent_skip_when_bom_exists(self):
+        imp = self._imp()
+
+        def fake_exists(dt, filt=None):
+            return True              # Item + BOM both exist
+        with mock.patch("frappe.db.exists", side_effect=fake_exists), \
+                mock.patch("frappe.get_doc") as gd, \
+                mock.patch("frappe.db.commit"):
+            res = imp.run(self._items())
+        gd.assert_not_called()
+        self.assertEqual(res.skipped, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tally_migrator/tests/test_item_tax_template.py
+++ b/tally_migrator/tests/test_item_tax_template.py
@@ -1,0 +1,113 @@
+"""
+Phase 3 tests: item GST rate -> India Compliance GST Item Tax Template.
+
+The combined GST rate is read per duty head (IGST == CGST + SGST), so a Cess
+rate can never be mistaken for the GST rate. Each item is then linked to the
+company's seeded template (matched by gst_treatment + gst_rate, not by name);
+a taxable rate with no template warns rather than guessing.
+"""
+import unittest
+from unittest import mock
+
+from tally_migrator.tally.file_source import FileTallySource
+from tally_migrator.erpnext.importers.items import ItemImporter
+from tally_migrator.erpnext.importers import ImportResult
+
+
+def _item_xml(name, rate_rows):
+    rd = "".join(
+        f"<RATEDETAILS.LIST><GSTRATEDUTYHEAD>{h}</GSTRATEDUTYHEAD>"
+        + (f"<GSTRATE>{r}</GSTRATE>" if r is not None else "")
+        + "</RATEDETAILS.LIST>"
+        for h, r in rate_rows)
+    return (f'<TALLYMESSAGE><STOCKITEM NAME="{name}"><NAME>{name}</NAME>'
+            f'<GSTDETAILS.LIST><STATEWISEDETAILS.LIST><STATENAME>Any</STATENAME>'
+            f'{rd}</STATEWISEDETAILS.LIST></GSTDETAILS.LIST></STOCKITEM></TALLYMESSAGE>')
+
+
+class TestGstRateExtraction(unittest.TestCase):
+    def _rates(self, *items):
+        xml = "<ENVELOPE><BODY><IMPORTDATA><REQUESTDATA>" + "".join(items) + \
+              "</REQUESTDATA></IMPORTDATA></BODY></ENVELOPE>"
+        return FileTallySource(xml).item_gst_rates()
+
+    def test_picks_igst_not_cess(self):
+        rates = self._rates(_item_xml("Widget", [
+            ("CGST", " 9"), ("SGST/UTGST", " 9"), ("IGST", " 18"),
+            ("Cess", " 1"),            # must NOT be mistaken for the GST rate
+        ]))
+        self.assertEqual(rates["Widget"], "18")
+
+    def test_falls_back_to_cgst_plus_sgst_when_no_igst(self):
+        rates = self._rates(_item_xml("Gadget", [("CGST", "6"), ("SGST/UTGST", "6")]))
+        self.assertEqual(rates["Gadget"], "12")
+
+    def test_no_rate_for_exempt_item(self):
+        rates = self._rates(_item_xml("Rice", [("IGST", None)]))   # head present, no rate
+        self.assertEqual(rates["Rice"], "")
+
+
+class TestTreatmentLabel(unittest.TestCase):
+    def test_labels(self):
+        L = ItemImporter._gst_treatment_label
+        self.assertEqual(L({"GSTTaxability": "Taxable"}), "Taxable")
+        self.assertEqual(L({"GSTTaxability": "Nil Rated"}), "Nil-Rated")
+        self.assertEqual(L({"GSTTaxability": "Exempt"}), "Exempted")
+        self.assertEqual(L({"GSTTaxability": "Non-GST"}), "Non-GST")
+        self.assertEqual(L({"GstApplicable": "Not Applicable"}), "Non-GST")
+        self.assertEqual(L({"GSTTaxability": ""}), "Taxable")
+        self.assertIsNone(L({"GSTTaxability": "Weird Value"}))
+
+
+class TestTaxTemplateResolution(unittest.TestCase):
+    def _imp(self):
+        imp = ItemImporter(company="Frappe Tech", abbr="FT")
+        imp._india_compliance = True
+        return imp
+
+    def test_resolves_links_and_warns_on_missing(self):
+        imp = self._imp()
+        res = ImportResult("Item")
+        records = [
+            {"_name": "A", "GSTTaxability": "Taxable", "GstRate": "18"},   # -> template
+            {"_name": "B", "GSTTaxability": "Taxable", "GstRate": "3"},    # -> no template, warn
+            {"_name": "C", "GSTTaxability": "Exempt",  "GstRate": ""},     # -> Exempted template
+        ]
+
+        def fake_get_all(doctype, filters=None, **kw):
+            if filters.get("gst_treatment") == "Taxable" and filters.get("gst_rate") == 18:
+                return ["GST 18% - FT"]
+            if filters.get("gst_treatment") == "Exempted":
+                return ["Exempted - FT"]
+            return []
+        with mock.patch("frappe.get_all", side_effect=fake_get_all):
+            imp._resolve_tax_templates(records, res)
+
+        self.assertEqual(imp._tax_templates.get("A"), "GST 18% - FT")
+        self.assertEqual(imp._tax_templates.get("C"), "Exempted - FT")
+        self.assertNotIn("B", imp._tax_templates)
+        self.assertTrue(any(w["name"] == "B" and "3%" in w["reason"] for w in res.warnings))
+
+    def test_no_india_compliance_is_noop(self):
+        imp = ItemImporter(company="Frappe Tech", abbr="FT")
+        imp._india_compliance = False
+        res = ImportResult("Item")
+        imp._resolve_tax_templates([{"_name": "A", "GSTTaxability": "Taxable", "GstRate": "18"}], res)
+        self.assertEqual(imp._tax_templates, {})
+        self.assertEqual(res.warnings, [])
+
+    def test_build_doc_adds_resolved_template(self):
+        imp = self._imp()
+        imp._tax_templates = {"Pen": "GST 18% - FT"}
+        doc = imp.build_doc({"_name": "Pen", "BaseUnits": "Nos", "GSTTaxability": "Taxable"})
+        self.assertEqual(doc["taxes"], [{"item_tax_template": "GST 18% - FT"}])
+
+    def test_build_doc_no_template_no_taxes_key(self):
+        imp = self._imp()
+        imp._tax_templates = {}
+        doc = imp.build_doc({"_name": "Pen", "BaseUnits": "Nos", "GSTTaxability": "Taxable"})
+        self.assertNotIn("taxes", doc)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tally_migrator/tests/test_prices.py
+++ b/tally_migrator/tests/test_prices.py
@@ -1,0 +1,126 @@
+"""
+Phase 4 tests: Tally price levels -> Price List + Item Price + (discount) Pricing Rule.
+
+Per price level the latest dated revision wins; the rate becomes an Item Price on
+a selling Price List named after the level, and any per-level discount becomes a
+Pricing Rule scoped to that price list (for_price_list) so it mirrors Tally's
+"rate then discount" billing.
+"""
+import types
+import unittest
+from unittest import mock
+
+from tally_migrator.tally.file_source import FileTallySource
+from tally_migrator.erpnext.importers.prices import PriceImporter
+from tally_migrator.erpnext.importers import ImportResult
+
+
+class TestPriceLevelExtraction(unittest.TestCase):
+    def test_latest_date_wins_and_slabs_parsed(self):
+        xml = (
+            '<ENVELOPE><BODY><IMPORTDATA><REQUESTDATA><TALLYMESSAGE>'
+            '<STOCKITEM NAME="A4"><NAME>A4</NAME>'
+            '<FULLPRICELIST.LIST><DATE>20250401</DATE><PRICELEVEL>Retail</PRICELEVEL>'
+            '<PRICELEVELLIST.LIST><ENDINGAT> 100 Ream</ENDINGAT><RATE>398.00/Ream</RATE>'
+            '<DISCOUNT> 10</DISCOUNT></PRICELEVELLIST.LIST></FULLPRICELIST.LIST>'
+            '<FULLPRICELIST.LIST><DATE>20260401</DATE><PRICELEVEL>Retail</PRICELEVEL>'
+            '<PRICELEVELLIST.LIST><RATE>420.00/Ream</RATE><DISCOUNT> 12</DISCOUNT>'
+            '</PRICELEVELLIST.LIST></FULLPRICELIST.LIST>'
+            '<FULLPRICELIST.LIST><DATE>20260401</DATE><PRICELEVEL>Wholesale</PRICELEVEL>'
+            '<PRICELEVELLIST.LIST><RATE>360.00/Ream</RATE><DISCOUNT> 15</DISCOUNT>'
+            '</PRICELEVELLIST.LIST></FULLPRICELIST.LIST>'
+            '</STOCKITEM></TALLYMESSAGE></REQUESTDATA></IMPORTDATA></BODY></ENVELOPE>'
+        )
+        levels = {l["level"]: l for l in FileTallySource(xml).item_price_levels()["A4"]}
+        self.assertEqual(set(levels), {"Retail", "Wholesale"})
+        self.assertEqual(levels["Retail"]["rate"], "420.00/Ream")     # latest date, not 398
+        self.assertEqual(levels["Retail"]["discount"], "12")
+        self.assertEqual(levels["Wholesale"]["rate"], "360.00/Ream")
+
+
+class TestParsers(unittest.TestCase):
+    def test_parse_rate(self):
+        self.assertEqual(PriceImporter._parse_rate("398.00/Ream"), (398.0, "Ream"))
+        self.assertEqual(PriceImporter._parse_rate("360.00"), (360.0, ""))
+        self.assertEqual(PriceImporter._parse_rate(""), (None, ""))
+        self.assertEqual(PriceImporter._parse_rate("x/Ream"), (None, ""))
+
+    def test_parse_qty_and_date(self):
+        self.assertEqual(PriceImporter._parse_qty(" 100 Ream"), 100.0)
+        self.assertEqual(PriceImporter._parse_qty(""), 0.0)
+        self.assertEqual(PriceImporter._parse_date("20260401"), "2026-04-01")
+        self.assertEqual(PriceImporter._parse_date("bad"), "")
+
+
+class TestPriceImporter(unittest.TestCase):
+    def _imp(self):
+        with mock.patch("frappe.get_cached_value", return_value="INR"):
+            return PriceImporter("Frappe Tech", "FT")
+
+    def test_creates_price_list_item_price_and_discount_rule(self):
+        imp = self._imp()
+        res = ImportResult("Item Price")
+        created = []
+
+        def fake_get_doc(d):
+            created.append(d)
+            return types.SimpleNamespace(
+                name=d.get("title") or d.get("price_list_name") or "IP-1",
+                insert=lambda **k: None)
+
+        exists_state = {"Price List": False, "Item Price": False, "Pricing Rule": False}
+
+        def fake_exists(dt, filt=None):
+            if dt == "Item":
+                return True
+            if dt == "UOM":
+                return True
+            return exists_state.get(dt, False)
+
+        with mock.patch("frappe.db.exists", side_effect=fake_exists), \
+                mock.patch("frappe.get_doc", side_effect=fake_get_doc), \
+                mock.patch("frappe.db.commit"), \
+                mock.patch("frappe.db.get_value", return_value="Ream"):
+            imp._import_level(res, "A4 Paper Ream", {
+                "level": "Retail", "date": "20260401",
+                "rate": "398.00/Ream", "discount": "10", "ending": " 100 Ream"})
+
+        kinds = [d["doctype"] for d in created]
+        self.assertEqual(kinds, ["Price List", "Item Price", "Pricing Rule"])
+        ip = next(d for d in created if d["doctype"] == "Item Price")
+        self.assertEqual((ip["price_list"], ip["price_list_rate"], ip["uom"], ip["selling"]),
+                         ("Retail", 398.0, "Ream", 1))
+        self.assertEqual(ip["valid_from"], "2026-04-01")
+        pr = next(d for d in created if d["doctype"] == "Pricing Rule")
+        self.assertEqual(pr["for_price_list"], "Retail")
+        self.assertEqual(pr["rate_or_discount"], "Discount Percentage")
+        self.assertEqual(pr["discount_percentage"], 10.0)
+        self.assertNotIn("apply_discount_on_rate", pr)       # would force a Priority
+        self.assertEqual(pr["max_qty"], 100.0)               # ENDINGAT bound carried
+        self.assertEqual(pr["items"], [{"item_code": "A4 Paper Ream"}])
+
+    def test_idempotent_skips_existing(self):
+        imp = self._imp()
+        res = ImportResult("Item Price")
+        created = []
+        with mock.patch("frappe.db.exists", return_value=True), \
+                mock.patch("frappe.get_doc", side_effect=lambda d: created.append(d)), \
+                mock.patch("frappe.db.commit"), \
+                mock.patch("frappe.db.get_value", return_value="Ream"):
+            imp._import_level(res, "A4 Paper Ream", {
+                "level": "Retail", "date": "20260401",
+                "rate": "398.00/Ream", "discount": "10", "ending": ""})
+        # Price List exists (reused), Item Price exists (skipped), Pricing Rule exists (skipped)
+        self.assertEqual(created, [])
+        self.assertEqual(res.skipped, 1)
+
+    def test_no_rate_creates_nothing(self):
+        imp = self._imp()
+        res = ImportResult("Item Price")
+        with mock.patch("frappe.get_doc") as gd:
+            imp._import_level(res, "X", {"level": "Retail", "rate": "", "discount": "5"})
+        gd.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tally_migrator/tests/test_uqc.py
+++ b/tally_migrator/tests/test_uqc.py
@@ -1,0 +1,105 @@
+"""
+Phase 1 (UQC) tests.
+
+India Compliance stores the GST Unit Quantity Code globally in
+GST Settings.gst_uom_map (uom -> gst_uom), not per-UOM. UnitImporter maps each
+imported Tally UOM's REPORTINGUQCNAME ("NOS-NUMBERS") to the official GST option
+("NOS (Numbers)"), appending only missing rows. Codes with no official match
+(e.g. Tally's "REM-REAMS") are left unmapped with a warning, never guessed.
+"""
+import types
+import unittest
+from unittest import mock
+
+from tally_migrator.erpnext.importers.units import UnitImporter
+from tally_migrator.erpnext.importers import ImportResult
+
+OPTIONS = "NOS (Numbers)\nKGS (Kilograms)\nBOX (Box)\nDOZ (Dozens)\nPCS (Pieces)\nOTH (Others)"
+
+
+def _code_map():
+    return {o.split("(")[0].strip().upper(): o for o in OPTIONS.splitlines()}
+
+
+class TestUqcMapping(unittest.TestCase):
+    def test_matches_by_code_case_insensitive(self):
+        cm = _code_map()
+        self.assertEqual(UnitImporter._uqc_to_gst_uom("NOS-NUMBERS", cm), "NOS (Numbers)")
+        self.assertEqual(UnitImporter._uqc_to_gst_uom("KGS-KILOGRAMS", cm), "KGS (Kilograms)")
+        self.assertEqual(UnitImporter._uqc_to_gst_uom("box-boxes", cm), "BOX (Box)")
+
+    def test_blank_not_applicable_and_unmatched_return_none(self):
+        cm = _code_map()
+        self.assertIsNone(UnitImporter._uqc_to_gst_uom("REM-REAMS", cm))      # no official code
+        self.assertIsNone(UnitImporter._uqc_to_gst_uom("", cm))
+        self.assertIsNone(UnitImporter._uqc_to_gst_uom("\x04 Not Applicable", cm))
+        self.assertIsNone(UnitImporter._uqc_to_gst_uom("Not Applicable", cm))
+
+    def _fake_settings(self, existing=()):
+        s = types.SimpleNamespace(
+            gst_uom_map=[types.SimpleNamespace(uom=u, gst_uom=g) for u, g in existing],
+            saved=False)
+        s.append = lambda table, row: s.gst_uom_map.append(
+            types.SimpleNamespace(uom=row["uom"], gst_uom=row["gst_uom"]))
+
+        def _save(**kw):
+            s.saved = True
+        s.save = _save
+        return s
+
+    def test_map_uqcs_appends_missing_skips_existing_warns_unmatched(self):
+        imp = UnitImporter("_T Co", "TC")
+        res = ImportResult("UOM")
+        units = [
+            {"_name": "Nos",  "ReportingUQC": "NOS-NUMBERS"},
+            {"_name": "Kg",   "ReportingUQC": "KGS-KILOGRAMS"},
+            {"_name": "Ream", "ReportingUQC": "REM-REAMS"},          # no match -> warn
+            {"_name": "Box",  "ReportingUQC": "\x04 Not Applicable"},  # skipped silently
+            {"_name": "Pcs",  "ReportingUQC": "PCS-PIECES"},          # already mapped -> skip
+        ]
+        settings = self._fake_settings(existing=[("Pcs", "PCS (Pieces)")])
+        meta = types.SimpleNamespace(
+            get_field=lambda f: types.SimpleNamespace(options=OPTIONS))
+        with mock.patch("frappe.db.exists", return_value=True), \
+                mock.patch("frappe.get_meta", return_value=meta), \
+                mock.patch("frappe.get_doc", return_value=settings), \
+                mock.patch("frappe.db.commit"):
+            imp._map_uqcs(units, res)
+
+        mapped = {(r.uom, r.gst_uom) for r in settings.gst_uom_map}
+        self.assertIn(("Nos", "NOS (Numbers)"), mapped)
+        self.assertIn(("Kg", "KGS (Kilograms)"), mapped)
+        self.assertFalse(any(r.uom == "Box" for r in settings.gst_uom_map))      # skipped
+        self.assertEqual(sum(1 for r in settings.gst_uom_map if r.uom == "Pcs"), 1)  # not duped
+        self.assertTrue(any(w["name"] == "Ream" for w in res.warnings))          # warned
+        self.assertTrue(settings.saved)
+
+    def test_no_india_compliance_is_noop(self):
+        imp = UnitImporter("_T Co", "TC")
+        res = ImportResult("UOM")
+        with mock.patch("frappe.db.exists", return_value=False):
+            imp._map_uqcs([{"_name": "Nos", "ReportingUQC": "NOS-NUMBERS"}], res)
+        self.assertEqual(res.warnings, [])
+
+
+class TestUqcExtraction(unittest.TestCase):
+    def test_extraction_reads_latest_reporting_uqc(self):
+        from tally_migrator.tally.file_source import FileTallySource
+        from tally_migrator.tally.extractors import UNIT_FIELDS, UNIT_TAGS
+        # Dated list with two entries; the most recent (last) wins.
+        xml = (
+            '<ENVELOPE><BODY><IMPORTDATA><REQUESTDATA>'
+            '<TALLYMESSAGE><UNIT NAME="Nos"><NAME>Nos</NAME>'
+            '<REPORTINGUQCDETAILS.LIST><APPLICABLEFROM>20200401</APPLICABLEFROM>'
+            '<REPORTINGUQCNAME>OTH-OTHERS</REPORTINGUQCNAME></REPORTINGUQCDETAILS.LIST>'
+            '<REPORTINGUQCDETAILS.LIST><APPLICABLEFROM>20260401</APPLICABLEFROM>'
+            '<REPORTINGUQCNAME>NOS-NUMBERS</REPORTINGUQCNAME></REPORTINGUQCDETAILS.LIST>'
+            '</UNIT></TALLYMESSAGE>'
+            '</REQUESTDATA></IMPORTDATA></BODY></ENVELOPE>'
+        )
+        rows = FileTallySource(xml).get_collection("Unit", UNIT_FIELDS, UNIT_TAGS)
+        self.assertEqual(rows[0]["ReportingUQC"], "NOS-NUMBERS")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Imports Tally multi-component bills of materials as ERPNext BOMs (components only), with item UOM resolution so components match their stock units.

Stacked on feat/price-levels.