### PR TITLE
Surface new masters in the coverage report + UOM/idempotency fixes

### DIFF
--- a/tally_migrator/erpnext/importers/__init__.py
+++ b/tally_migrator/erpnext/importers/__init__.py
@@ -31,6 +31,7 @@ from .items import ItemImporter
 from .warehouses import WarehouseImporter, StockGroupImporter
 from .units import UnitImporter
 from .prices import PriceImporter
+from .bom import BomImporter
 from .accounts import AccountImporter, CostCentreImporter
 from .hsn import (
     _HSN_GUARD_KEY,

--- a/tally_migrator/erpnext/importers/__init__.py
+++ b/tally_migrator/erpnext/importers/__init__.py
@@ -30,6 +30,7 @@ from .party import PartyImporter, CustomerImporter, SupplierImporter
 from .items import ItemImporter
 from .warehouses import WarehouseImporter, StockGroupImporter
 from .units import UnitImporter
+from .prices import PriceImporter
 from .accounts import AccountImporter, CostCentreImporter
 from .hsn import (
     _HSN_GUARD_KEY,

--- a/tally_migrator/erpnext/importers/bom.py
+++ b/tally_migrator/erpnext/importers/bom.py
@@ -1,0 +1,113 @@
+"""BOM importer: Tally multi-component lists -> ERPNext BOM (submitted, active)."""
+
+import frappe
+
+from tally_migrator.naming import safe_item_code
+from .base import BaseImporter, ImportResult
+
+
+class BomImporter:
+    """Create ERPNext BOMs from Tally bills of materials.
+
+    Each Tally BOM becomes a submitted, active BOM; the first BOM per item is the
+    default. Runs after Items so the finished item and components exist. Only
+    NATUREOFITEM=Component rows are migrated; by-products/co-products/scrap are
+    skipped with a warning (no fixture coverage to build secondary_items against).
+
+    Idempotent by skip-if-exists: BOM names auto-increment, so a re-run would
+    create duplicates; if any BOM already exists for an item we skip it entirely.
+    """
+
+    doctype = "BOM"
+
+    def __init__(self, company: str, abbr: str):
+        self.company = company
+        self.abbr = abbr
+        self.currency = frappe.get_cached_value(
+            "Company", company, "default_currency") or "INR"
+
+    def run(self, items: list[dict]) -> ImportResult:
+        result = ImportResult(self.doctype)
+        for it in items:
+            boms = it.get("Boms") or []
+            if not boms:
+                continue
+            code = safe_item_code(it.get("_name", ""))
+            if not frappe.db.exists("Item", code):
+                continue                         # finished item didn't import
+            if frappe.db.exists("BOM", {"item": code}):
+                result.skipped += 1              # idempotent: never duplicate
+                continue
+            for i, bom in enumerate(boms):
+                self._import_bom(result, code, it.get("_name", ""), bom, is_default=(i == 0))
+        return result
+
+    def _import_bom(self, result, code, item_name, bom, is_default):
+        rows, warns = self._component_rows(code, bom.get("components") or [])
+        for w in warns:
+            result.add_warning(item_name, w)
+        if not rows:
+            result.add_warning(item_name, "BOM skipped - no usable Component rows.")
+            return
+        qty, uom = self._parse_qty_uom(bom.get("basic_qty"))
+        doc = {
+            "doctype": "BOM", "item": code, "company": self.company,
+            "quantity": qty or 1, "currency": self.currency, "conversion_rate": 1,
+            "is_active": 1, "is_default": 1 if is_default else 0, "items": rows,
+        }
+        if uom and frappe.db.exists("UOM", uom):
+            doc["uom"] = uom
+        try:
+            d = frappe.get_doc(doc)
+            d.insert(ignore_permissions=True)
+            d.submit()
+            frappe.db.commit()
+            result.add_created(d.name, "BOM")
+        except Exception as exc:
+            frappe.db.rollback()
+            result.add_error(f"{item_name} (BOM {bom.get('name')})", exc)
+
+    def _component_rows(self, finished_code, components):
+        rows, warns = [], []
+        for c in components:
+            nature = (c.get("natureofitem") or "Component").strip()
+            cname = (c.get("stockitemname") or "").strip()
+            if nature.lower() != "component":
+                warns.append(f"component '{cname}' is a {nature}, not migrated "
+                             "(only Components are imported into the BOM).")
+                continue
+            ccode = safe_item_code(cname)
+            if not frappe.db.exists("Item", ccode):
+                warns.append(f"BOM component '{cname}' not found as an item - skipped.")
+                continue
+            if ccode == finished_code:
+                warns.append(f"BOM component '{cname}' is the finished item itself "
+                             "(self-reference) - skipped.")
+                continue
+            qty, uom = self._parse_qty_uom(c.get("actualqty"))
+            if not qty:
+                warns.append(f"BOM component '{cname}' has no quantity - skipped.")
+                continue
+            stock_uom = frappe.db.get_value("Item", ccode, "stock_uom")
+            if uom and frappe.db.exists("UOM", uom):
+                if uom != stock_uom:
+                    warns.append(
+                        f"component '{cname}' quantity is in '{uom}' but its stock "
+                        f"unit is '{stock_uom}'; ERPNext assumes 1:1 unless the item "
+                        "defines that conversion - verify the BOM quantity.")
+            else:
+                uom = stock_uom
+            rows.append({"item_code": ccode, "qty": qty, "uom": uom})
+        return rows, warns
+
+    @staticmethod
+    def _parse_qty_uom(raw):
+        """' 1 Ream' -> (1.0, 'Ream'); '2 Box' -> (2.0, 'Box'); '' -> (0.0, '')."""
+        raw = (raw or "").strip()
+        if not raw:
+            return 0.0, ""
+        parts = raw.split(None, 1)
+        try:
+            return float(parts[0].replace(",", "")), (parts[1].strip() if len(parts) > 1 else "")
+        except ValueError:
+            return 0.0, ""

--- a/tally_migrator/erpnext/importers/items.py
+++ b/tally_migrator/erpnext/importers/items.py
@@ -65,6 +65,11 @@ class ItemImporter(BaseImporter):
         # app is installed. Without it ERPNext core silently drops those keys, so we
         # say so once instead of pretending the GST data landed.
         self._india_compliance = "india_compliance" in frappe.get_installed_apps()
+        # Resolve each item's GST Item Tax Template once (links the rate to the
+        # India-Compliance-seeded "GST 18%" / "Nil-Rated" templates for this
+        # company). Done here, with access to ``result``, so a missing template
+        # warns exactly once; build_doc just reads the resolved map.
+        self._resolve_tax_templates(records, result)
         if not self._india_compliance and any(
             (r.get("GSTTaxability") or r.get("HSNCode")
              or r.get("GstApplicable") or r.get("TypeOfSupply"))
@@ -112,7 +117,62 @@ class ItemImporter(BaseImporter):
         if vm:
             doc["valuation_method"] = vm
         doc.update(self._gst_fields(record))
+        tpl = getattr(self, "_tax_templates", {}).get(record["_name"])
+        if tpl:
+            doc["taxes"] = [{"item_tax_template": tpl}]
         return doc
+
+    # ── GST rate -> Item Tax Template linking (India Compliance) ───────────────
+    @staticmethod
+    def _gst_treatment_label(record: dict) -> "str | None":
+        """ERPNext/India-Compliance gst_treatment string for an item, or None when
+        the Tally GST type is unrecognised (already warned elsewhere)."""
+        if (record.get("GstApplicable") or "").strip().lower() in ("not applicable", "no"):
+            return "Non-GST"
+        key = (record.get("GSTTaxability") or "").strip().lower().replace("-", " ").replace("_", " ")
+        key = " ".join(key.split())
+        return {
+            "": "Taxable", "taxable": "Taxable", "applicable": "Taxable",
+            "nil rated": "Nil-Rated", "nil": "Nil-Rated",
+            "exempt": "Exempted", "exempted": "Exempted",
+            "non gst": "Non-GST", "not applicable": "Non-GST",
+        }.get(key)
+
+    def _resolve_tax_template(self, treatment: str, rate: float) -> "str | None":
+        """The company's GST Item Tax Template for this treatment/rate, matched by
+        the India-Compliance gst_treatment + gst_rate fields (never by the
+        company-suffixed name), or None when none is seeded."""
+        filters = {"company": self.company, "gst_treatment": treatment}
+        if treatment == "Taxable":
+            if not rate:
+                return None
+            filters["gst_rate"] = rate
+        rows = frappe.get_all(
+            "Item Tax Template", filters=filters, pluck="name", limit=1,
+            ignore_permissions=True)
+        return rows[0] if rows else None
+
+    def _resolve_tax_templates(self, records: list[dict], result: ImportResult) -> None:
+        """Build ``{item name: template}`` for build_doc, warning once per item when
+        a taxable rate has no matching template. No-op without India Compliance
+        (its gst_rate/gst_treatment fields, and the seeded templates, don't exist)."""
+        self._tax_templates: dict = {}
+        if not getattr(self, "_india_compliance", False):
+            return
+        for r in records:
+            treatment = self._gst_treatment_label(r)
+            if not treatment:
+                continue
+            rate = self._to_float(r.get("GstRate"))
+            tpl = self._resolve_tax_template(treatment, rate)
+            if tpl:
+                self._tax_templates[r["_name"]] = tpl
+            elif treatment == "Taxable" and rate:
+                result.add_warning(
+                    r["_name"],
+                    f"no GST Item Tax Template for {rate:g}% on company "
+                    f"'{self.company}' - item imported without a tax rate; create a "
+                    f"'GST {rate:g}%' template or set it on the item manually.")
 
     def recover_insert(self, data: dict, exc: Exception):
         """India Compliance makes ``gst_hsn_code`` a Link to "GST HSN Code" and

--- a/tally_migrator/erpnext/importers/items.py
+++ b/tally_migrator/erpnext/importers/items.py
@@ -97,10 +97,29 @@ class ItemImporter(BaseImporter):
                 by_code[safe_item_code(name)].append(name)
         return {code: names for code, names in by_code.items() if len(names) > 1}
 
+    def _resolve_uom(self, tally_uom: str) -> str:
+        """Resolve a Tally base unit to an ERPNext UOM, matching what the pre-flight
+        Check step tells the user: a user override, then the built-in UOM_MAP, then
+        the Tally unit's OWN name when a UOM by that name exists (the Unit importer
+        creates it earlier in the same run), and only DEFAULT_UOM as a last resort.
+
+        Previously this skipped straight to DEFAULT_UOM for any unit not in UOM_MAP,
+        which contradicted the resolver (uom_resolver: ``UOM_MAP.get(u, u)``) - so an
+        item whose unit (e.g. 'Ream') existed but wasn't in UOM_MAP silently became
+        'Nos', and its price levels / BOM components then mismatched the item."""
+        if not tally_uom:
+            return DEFAULT_UOM
+        override = self._uom_overrides.get(tally_uom)
+        if override:
+            return override
+        if tally_uom in UOM_MAP:
+            return UOM_MAP[tally_uom]
+        if frappe.db.exists("UOM", tally_uom):
+            return tally_uom
+        return DEFAULT_UOM
+
     def build_doc(self, record: dict) -> dict:
-        tally_uom = (record.get("BaseUnits") or "").strip()
-        # User-supplied overrides (from pre-flight check) take precedence
-        uom = self._uom_overrides.get(tally_uom) or UOM_MAP.get(tally_uom, DEFAULT_UOM)
+        uom = self._resolve_uom((record.get("BaseUnits") or "").strip())
         doc = {
             "doctype": "Item",
             "item_code": safe_item_code(record["_name"]),

--- a/tally_migrator/erpnext/importers/openings.py
+++ b/tally_migrator/erpnext/importers/openings.py
@@ -460,24 +460,19 @@ class PartyOpeningImporter:
                     "created (its import failed earlier). Fix it and re-run.")
                 continue
 
-            # Multi-currency guard (v1): an opening document posted in the company
-            # currency for a party that bills in another currency would silently
-            # misstate the balance (the exchange rate is unknown). Two independent
-            # signals, either of which marks a party foreign: the ledger's own
-            # CurrencyName differs from the Tally base currency (read from the file),
-            # or the already-created ERPNext party carries a non-company currency. The
-            # file signal is what actually fires here, since a freshly imported party
-            # has no currency set yet. Skip with a clear warning rather than post a
-            # wrong figure - the user enters that party's opening manually.
-            if (self._tally_currency_foreign(record)
+            # Forex party: post in its own currency (Option B - true multi-currency
+            # AR/AP). CurrencyISO is set in extraction only when the opening balance
+            # carried a foreign currency symbol that resolved to an ISO (Tally exports
+            # no CurrencyName tag on the party ledger), so its presence is the forex
+            # signal. We also honour an already-created party that carries a
+            # non-company default currency. Routed to a dedicated path that posts one
+            # opening invoice in the foreign currency against a currency-denominated
+            # receivable/payable account, so the outstanding tracks the foreign amount
+            # and the base reconciles.
+            if (record.get("CurrencyISO")
                     or self._is_foreign_currency_party(party_type, party)):
-                result.add_warning(
-                    tally_name,
-                    f"opening balance skipped - {party_type} '{tally_name}' uses a "
-                    "currency other than the company currency, and invoice-wise "
-                    "opening balances are single-currency in this version. Enter this "
-                    "party's opening invoices/payments manually so the exchange rate "
-                    "is correct.")
+                self._emit_forex(party_type, party, tally_name, record,
+                                 party_bills, seen, result)
                 continue
 
             ledger_signed = self._signed(ledger_amt, ledger_drcr)
@@ -542,6 +537,109 @@ class PartyOpeningImporter:
         except Exception as exc:
             frappe.db.rollback()
             result.add_error(f"{tally_name} | {bill_no}", exc)
+
+    # ── Foreign-currency openings (Option B: true multi-currency AR/AP) ────────
+    def _emit_forex(self, party_type: str, party: str, tally_name: str, record: dict,
+                    party_bills: list, seen: set, result: ImportResult) -> None:
+        """Post a forex party's opening as one foreign-currency opening invoice
+        against a currency-denominated receivable/payable account."""
+        iso = (record.get("CurrencyISO") or "").strip()
+        if not iso or iso == self._company_currency():
+            result.add_warning(
+                tally_name,
+                f"opening balance skipped - couldn't resolve the foreign currency for "
+                f"'{tally_name}'; enter its opening manually so the rate is correct.")
+            return
+        foreign, _sym, base, drcr = TallyExtractor._parse_forex_opening(
+            record.get("OpeningBalance", ""))
+        if not foreign or not base:
+            result.add_warning(
+                tally_name,
+                f"opening balance skipped - couldn't read the {iso} opening for "
+                f"'{tally_name}'.")
+            return
+        if party_bills:
+            result.add_warning(
+                tally_name,
+                f"'{tally_name}' carries bill-wise detail in {iso}; posted as a single "
+                "opening invoice (per-bill foreign-currency openings are not split in "
+                "this version).")
+        signed = self._signed(base, drcr)
+        if self._classify(party_type, signed, is_advance=False) != "invoice":
+            result.add_warning(
+                tally_name,
+                f"opening balance skipped - '{tally_name}' is a {iso} advance (credit "
+                "side); enter it manually (foreign-currency advances are not migrated "
+                "in this version).")
+            return
+        marker = f"{self._MARKER}: {tally_name} | Opening"
+        if marker in seen:
+            result.skipped += 1
+            return
+        try:
+            account = self._ensure_currency_account(party_type, iso)
+            frappe.db.set_value(party_type, party, "default_currency", iso,
+                                update_modified=False)
+            # Derive the rate from Tally's stated base, not the '@ rate' clause, so
+            # the ERPNext base equals Tally's base exactly (the books reconcile even
+            # when the stated base and foreign x clause-rate disagree by rounding).
+            rate = base / foreign
+            data = self._forex_invoice_dict(party_type, party, foreign, iso, rate,
+                                            account, marker)
+            doc = frappe.get_doc(data)
+            doc.insert(ignore_permissions=True)
+            doc.submit()
+            frappe.db.commit()
+            seen.add(marker)
+            result.add_created(doc.name, doc.doctype)
+        except Exception as exc:
+            frappe.db.rollback()
+            result.add_error(f"{tally_name} | Opening ({iso})", exc)
+
+    def _ensure_currency_account(self, party_type: str, iso: str) -> str:
+        """The company's receivable/payable account in ``iso`` (e.g. 'Debtors USD'),
+        created once under the default control account's parent. ERPNext requires the
+        party account currency to match a foreign invoice currency, so each foreign
+        currency gets its own leaf account."""
+        label = "Debtors" if party_type == "Customer" else "Creditors"
+        name = company_scoped(f"{label} {iso}", self.abbr)
+        if frappe.db.exists("Account", name):
+            return name
+        parent = frappe.db.get_value("Account", self._party_account(party_type),
+                                     "parent_account")
+        acc = frappe.get_doc({
+            "doctype": "Account", "account_name": f"{label} {iso}",
+            "parent_account": parent, "company": self.company,
+            "account_type": "Receivable" if party_type == "Customer" else "Payable",
+            "account_currency": iso, "is_group": 0,
+        })
+        acc.insert(ignore_permissions=True)
+        frappe.db.commit()
+        return acc.name
+
+    def _forex_invoice_dict(self, party_type: str, party: str, amount: float,
+                            iso: str, rate: float, account: str, marker: str) -> dict:
+        is_sales = party_type == "Customer"
+        item = {
+            "item_name": "Opening", "description": "Opening balance",
+            "uom": self._stock_uom(), "conversion_factor": 1.0, "qty": 1,
+            "rate": amount,
+            ("income_account" if is_sales else "expense_account"): self._temp_account(),
+            "cost_center": self._cost_center(),
+        }
+        data = {
+            "doctype": "Sales Invoice" if is_sales else "Purchase Invoice",
+            "company": self.company, "is_opening": "Yes", "set_posting_time": 1,
+            "posting_date": self.posting_date, "due_date": self.posting_date,
+            frappe.scrub(party_type): party, "items": [item],
+            "currency": iso, "conversion_rate": rate,
+            ("debit_to" if is_sales else "credit_to"): account,
+            "update_stock": 0, "disable_rounded_total": 1, "remarks": marker,
+        }
+        if not is_sales:
+            data["bill_no"] = "Opening"
+            data["bill_date"] = self.posting_date
+        return data
 
     def _insert_invoice(self, data: dict, set_name, tally_name: str, bill_no: str,
                         result: ImportResult):

--- a/tally_migrator/erpnext/importers/openings.py
+++ b/tally_migrator/erpnext/importers/openings.py
@@ -566,7 +566,7 @@ class PartyOpeningImporter:
             result.skipped += 1
             return
         try:
-            account = self._ensure_currency_account(party_type, iso)
+            account = self._ensure_currency_account(party_type, iso, result)
             frappe.db.set_value(party_type, party, "default_currency", iso,
                                 update_modified=False)
             # Derive the rate from Tally's stated base, not the '@ rate' clause, so
@@ -585,7 +585,8 @@ class PartyOpeningImporter:
             frappe.db.rollback()
             result.add_error(f"{tally_name} | Opening ({iso})", exc)
 
-    def _ensure_currency_account(self, party_type: str, iso: str) -> str:
+    def _ensure_currency_account(self, party_type: str, iso: str,
+                                 result: "ImportResult | None" = None) -> str:
         """The company's receivable/payable account in ``iso`` (e.g. 'Debtors USD'),
         created once under the default control account's parent. ERPNext requires the
         party account currency to match a foreign invoice currency, so each foreign
@@ -604,6 +605,11 @@ class PartyOpeningImporter:
         })
         acc.insert(ignore_permissions=True)
         frappe.db.commit()
+        # Record the account this run creates in the migration manifest, so an undo
+        # can remove it too. Created before the forex invoice that uses it, so within
+        # the Party Openings batch it is deleted after that invoice (reverse order).
+        if result is not None:
+            result.add_created(acc.name, "Account")
         return acc.name
 
     def _forex_invoice_dict(self, party_type: str, party: str, amount: float,

--- a/tally_migrator/erpnext/importers/openings.py
+++ b/tally_migrator/erpnext/importers/openings.py
@@ -530,8 +530,14 @@ class PartyOpeningImporter:
     # ── Foreign-currency openings (Option B: true multi-currency AR/AP) ────────
     def _emit_forex(self, party_type: str, party: str, tally_name: str, record: dict,
                     party_bills: list, seen: set, result: ImportResult) -> None:
-        """Post a forex party's opening as one foreign-currency opening invoice
-        against a currency-denominated receivable/payable account."""
+        """Post a forex party's opening as foreign-currency opening invoice(s) against
+        a currency-denominated receivable/payable account.
+
+        Bill-wise when the export carries per-bill foreign amounts: one named invoice
+        per Tally bill (mirroring the base-currency path, so the ERPNext invoice id IS
+        the Tally bill id and reconciles individually). Otherwise a single consolidated
+        invoice for the whole ledger opening. Foreign-currency advances/credits are not
+        migrated (flagged for manual entry)."""
         iso = (record.get("CurrencyISO") or "").strip()
         if not iso or iso == self._company_currency():
             result.add_warning(
@@ -547,43 +553,99 @@ class PartyOpeningImporter:
                 f"opening balance skipped - couldn't read the {iso} opening for "
                 f"'{tally_name}'.")
             return
-        if party_bills:
-            result.add_warning(
-                tally_name,
-                f"'{tally_name}' carries bill-wise detail in {iso}; posted as a single "
-                "opening invoice (per-bill foreign-currency openings are not split in "
-                "this version).")
-        signed = self._signed(base, drcr)
-        if self._classify(party_type, signed, is_advance=False) != "invoice":
+        ledger_signed = self._signed(base, drcr)
+        if self._classify(party_type, ledger_signed, is_advance=False) != "invoice":
             result.add_warning(
                 tally_name,
                 f"opening balance skipped - '{tally_name}' is a {iso} advance (credit "
                 "side); enter it manually (foreign-currency advances are not migrated "
                 "in this version).")
             return
-        marker = f"{self._MARKER}: {tally_name} | Opening"
+        account = self._ensure_currency_account(party_type, iso, result)
+        frappe.db.set_value(party_type, party, "default_currency", iso,
+                            update_modified=False)
+        # Ledger rate, derived from Tally's stated base (not the '@ rate' clause) so the
+        # ERPNext base equals Tally's base exactly even if they disagree by rounding.
+        rate = base / foreign
+
+        # Bills that carry a parseable foreign amount and sit on the party's natural
+        # side become per-bill invoices; a forex advance/credit bill is not migrated.
+        invoice_bills: list = []
+        for b in party_bills:
+            if not b.foreign_amount:
+                continue
+            if self._classify(party_type, self._signed(b.amount, b.dr_cr),
+                              b.is_advance) != "invoice":
+                result.add_warning(
+                    tally_name,
+                    f"{iso} advance/credit bill '{b.bill_no}' for '{tally_name}' not "
+                    "migrated (foreign-currency advances are not supported in this "
+                    "version); enter it manually.")
+                continue
+            invoice_bills.append(b)
+
+        if invoice_bills:
+            posted_base = 0.0
+            for b in invoice_bills:
+                # Per-bill rate from its own foreign/base, so each invoice's base ties
+                # to Tally's bill amount exactly; falls back to the ledger rate.
+                b_rate = (b.amount / b.foreign_amount) if b.foreign_amount else rate
+                self._post_forex_invoice(
+                    party_type, party, tally_name, b.foreign_amount, iso, b_rate,
+                    account, f"{self._MARKER}: {tally_name} | {b.bill_no}",
+                    b.bill_no, seen, result)
+                posted_base += self._signed(b.amount, b.dr_cr)
+            # A remainder on the natural side (bills short of the ledger opening) posts
+            # as one 'Opening' invoice, so the party still ties to its ledger figure.
+            residual = round(ledger_signed - posted_base, 2)
+            if (abs(residual) >= self._PLUG_THRESHOLD
+                    and self._classify(party_type, residual, False) == "invoice"):
+                self._post_forex_invoice(
+                    party_type, party, tally_name, round(abs(residual) / rate, 2), iso,
+                    rate, account, f"{self._MARKER}: {tally_name} | Opening", None,
+                    seen, result)
+                result.add_warning(
+                    tally_name,
+                    f"bill-wise {iso} openings for '{tally_name}' did not add up to its "
+                    f"ledger opening; the remainder was posted as one 'Opening' invoice.")
+            return
+
+        # No parseable per-bill foreign detail: one consolidated invoice for the whole
+        # opening (the only faithful option - bill references without amounts can't be
+        # split). Flag the collapse so the loss of bill-level detail is visible.
+        if party_bills:
+            result.add_warning(
+                tally_name,
+                f"'{tally_name}' carries bill references in {iso} without per-bill "
+                "amounts; posted as a single opening invoice.")
+        self._post_forex_invoice(
+            party_type, party, tally_name, foreign, iso, rate, account,
+            f"{self._MARKER}: {tally_name} | Opening", None, seen, result)
+
+    def _post_forex_invoice(self, party_type: str, party: str, tally_name: str,
+                            amount: float, iso: str, rate: float, account: str,
+                            marker: str, set_name, seen: set,
+                            result: ImportResult) -> None:
+        """Insert + submit one foreign-currency opening invoice (one bill, or the lump).
+
+        Routed through ``_insert_invoice`` so a per-bill invoice is named after the
+        Tally bill id (and falls back to auto-naming on an id clash), exactly like the
+        base-currency path. Idempotent on the remarks marker."""
         if marker in seen:
             result.skipped += 1
             return
         try:
-            account = self._ensure_currency_account(party_type, iso, result)
-            frappe.db.set_value(party_type, party, "default_currency", iso,
-                                update_modified=False)
-            # Derive the rate from Tally's stated base, not the '@ rate' clause, so
-            # the ERPNext base equals Tally's base exactly (the books reconcile even
-            # when the stated base and foreign x clause-rate disagree by rounding).
-            rate = base / foreign
-            data = self._forex_invoice_dict(party_type, party, foreign, iso, rate,
-                                            account, marker)
-            doc = frappe.get_doc(data)
-            doc.insert(ignore_permissions=True)
+            data = self._forex_invoice_dict(party_type, party, amount, iso, rate,
+                                            account, marker, bill_no=set_name or "Opening")
+            doc = self._insert_invoice(data, set_name, tally_name,
+                                       set_name or "Opening", result)
             doc.submit()
             frappe.db.commit()
             seen.add(marker)
             result.add_created(doc.name, doc.doctype)
         except Exception as exc:
             frappe.db.rollback()
-            result.add_error(f"{tally_name} | Opening ({iso})", exc)
+            result.add_error(f"{tally_name} | {set_name or 'Opening'} ({iso})", exc)
 
     def _ensure_currency_account(self, party_type: str, iso: str,
                                  result: "ImportResult | None" = None) -> str:
@@ -613,7 +675,8 @@ class PartyOpeningImporter:
         return acc.name
 
     def _forex_invoice_dict(self, party_type: str, party: str, amount: float,
-                            iso: str, rate: float, account: str, marker: str) -> dict:
+                            iso: str, rate: float, account: str, marker: str,
+                            bill_no: str = "Opening") -> dict:
         is_sales = party_type == "Customer"
         item = {
             "item_name": "Opening", "description": "Opening balance",
@@ -632,7 +695,7 @@ class PartyOpeningImporter:
             "update_stock": 0, "disable_rounded_total": 1, "remarks": marker,
         }
         if not is_sales:
-            data["bill_no"] = "Opening"
+            data["bill_no"] = bill_no
             data["bill_date"] = self.posting_date
         return data
 

--- a/tally_migrator/erpnext/importers/openings.py
+++ b/tally_migrator/erpnext/importers/openings.py
@@ -1,7 +1,6 @@
 """Opening balances: the per-company lock and the three opening importers."""
 
 import contextlib
-from collections import Counter
 from dataclasses import dataclass, field
 
 import frappe
@@ -417,21 +416,11 @@ class PartyOpeningImporter:
         self.company = company
         self.abbr = abbr
         self.posting_date = posting_date
-        # Set for real in run() from the parties' ledger currencies; default blank so
-        # _process()/_tally_currency_foreign() stay valid (and treat the book as
-        # single-currency) even if _process is exercised before run() populates it.
-        self._tally_base_ccy = ""
 
     # ── Orchestration ─────────────────────────────────────────────────────────
     def run(self, bills: list, customers: list[dict],
             suppliers: list[dict]) -> ImportResult:
         result = ImportResult("Opening Invoice")
-        # The Tally base currency, derived as the most common ledger CurrencyName
-        # across all parties (a forex party carries a different one). Used to skip a
-        # party whose ledger currency differs from the base - the in-file signal the
-        # ERPNext default_currency guard can't give us, since freshly imported parties
-        # carry no currency yet. Equality only, never an ISO-code mapping.
-        self._tally_base_ccy = self._base_currency(customers, suppliers)
         by_party: dict[str, list] = {}
         for b in bills or []:
             by_party.setdefault(b.party, []).append(b)
@@ -796,26 +785,6 @@ class PartyOpeningImporter:
                  else "default_payable_account")
         return frappe.get_cached_value("Company", self.company, field)
 
-    @staticmethod
-    def _base_currency(customers: list[dict], suppliers: list[dict]) -> str:
-        """The Tally base currency: the most common non-empty ledger CurrencyName
-        across every party. A book is overwhelmingly single-currency, so the modal
-        value is the base; a party whose CurrencyName differs is forex. Returns ""
-        when the file carries no currency name (older exports) - the ERPNext-side
-        guard then remains the only check."""
-        counts = Counter(
-            (r.get("CurrencyName") or "").strip()
-            for r in (*customers, *suppliers)
-            if (r.get("CurrencyName") or "").strip()
-        )
-        return counts.most_common(1)[0][0] if counts else ""
-
-    def _tally_currency_foreign(self, record: dict) -> bool:
-        """True when this party ledger's own CurrencyName differs from the Tally base
-        currency. Blank base or blank ledger currency means 'unknown' -> not foreign,
-        so a single-currency book (or an export without the field) is never skipped."""
-        ccy = (record.get("CurrencyName") or "").strip()
-        return bool(self._tally_base_ccy and ccy and ccy != self._tally_base_ccy)
 
     def _is_foreign_currency_party(self, party_type: str, party: str) -> bool:
         """True when the party's own default currency is set and differs from the

--- a/tally_migrator/erpnext/importers/orchestrator.py
+++ b/tally_migrator/erpnext/importers/orchestrator.py
@@ -29,6 +29,7 @@ from .party import PartyImporter, CustomerImporter, SupplierImporter
 from .items import ItemImporter
 from .warehouses import WarehouseImporter, StockGroupImporter
 from .units import UnitImporter
+from .prices import PriceImporter
 from .accounts import AccountImporter, CostCentreImporter
 from .hsn import _restore_hsn_validation, _hsn_validation_suspended
 from .openings import (
@@ -115,6 +116,9 @@ class ERPNextImporter:
 
     def import_units(self, units: list[dict]) -> ImportResult:
         return UnitImporter(self.company, self.abbr).run(units)
+
+    def import_prices(self, items: list[dict]) -> ImportResult:
+        return PriceImporter(self.company, self.abbr).run(items)
 
     def import_warehouses(self, warehouses: list[dict]) -> ImportResult:
         return WarehouseImporter(self.company, self.abbr).run(warehouses)

--- a/tally_migrator/erpnext/importers/orchestrator.py
+++ b/tally_migrator/erpnext/importers/orchestrator.py
@@ -30,6 +30,7 @@ from .items import ItemImporter
 from .warehouses import WarehouseImporter, StockGroupImporter
 from .units import UnitImporter
 from .prices import PriceImporter
+from .bom import BomImporter
 from .accounts import AccountImporter, CostCentreImporter
 from .hsn import _restore_hsn_validation, _hsn_validation_suspended
 from .openings import (
@@ -119,6 +120,9 @@ class ERPNextImporter:
 
     def import_prices(self, items: list[dict]) -> ImportResult:
         return PriceImporter(self.company, self.abbr).run(items)
+
+    def import_boms(self, items: list[dict]) -> ImportResult:
+        return BomImporter(self.company, self.abbr).run(items)
 
     def import_warehouses(self, warehouses: list[dict]) -> ImportResult:
         return WarehouseImporter(self.company, self.abbr).run(warehouses)

--- a/tally_migrator/erpnext/importers/prices.py
+++ b/tally_migrator/erpnext/importers/prices.py
@@ -106,7 +106,11 @@ class PriceImporter:
         # Deterministic title is the idempotency key (Pricing Rule has no natural
         # one), so a re-run finds and skips the rule rather than duplicating it.
         title = f"Tally {price_list} discount - {item_code}"[:140]
-        if frappe.db.exists("Pricing Rule", title):
+        # Pricing Rule is autonamed by series (PRLE-####), so its document `name` is
+        # NOT the title - the idempotency key must query the title FIELD, not name
+        # (frappe.db.exists("Pricing Rule", title) tests name==title, never matches,
+        # so a re-run would duplicate the rule).
+        if frappe.db.exists("Pricing Rule", {"title": title}):
             return
         # for_price_list scopes the rule to this price list, so the discount applies
         # only when selling at that level, on its Item Price rate (Retail 398 - 10%
@@ -125,9 +129,13 @@ class PriceImporter:
         max_qty = self._parse_qty(ending)
         if max_qty:
             rule["max_qty"] = max_qty
-        frappe.get_doc(rule).insert(ignore_permissions=True)
+        # Log the autonamed document `name` (PRLE-####), not the title, so the
+        # migration-log hyperlink resolves to a real Pricing Rule. Logging the title
+        # produced a dead link (no doc is named after the title).
+        doc = frappe.get_doc(rule)
+        doc.insert(ignore_permissions=True)
         frappe.db.commit()
-        result.add_created(title, "Pricing Rule")
+        result.add_created(doc.name, "Pricing Rule")
 
     # ── parsing ─────────────────────────────────────────────────────────────────
     @staticmethod

--- a/tally_migrator/erpnext/importers/prices.py
+++ b/tally_migrator/erpnext/importers/prices.py
@@ -39,8 +39,18 @@ class PriceImporter:
         item_code = safe_item_code(item_name)
         if not frappe.db.exists("Item", item_code):
             return                              # item didn't import (warned by ItemImporter)
-        if not (uom and frappe.db.exists("UOM", uom)):
-            uom = frappe.db.get_value("Item", item_code, "stock_uom")
+        # The price-level UOM must be valid FOR THE ITEM - its stock UOM or one of its
+        # additional UOMs - or ERPNext rejects the Item Price ("UOM X not found in
+        # Item"). Fall back to the item's stock UOM (and warn) rather than hard-fail.
+        stock_uom = frappe.db.get_value("Item", item_code, "stock_uom")
+        if not self._uom_valid_for_item(item_code, uom, stock_uom):
+            level = (lv.get("level") or "").strip()
+            if uom and uom != stock_uom:
+                result.add_warning(
+                    f"{item_name} ({level})",
+                    f"price-level unit '{uom}' is not a unit of item '{item_code}'; "
+                    f"used its stock unit '{stock_uom}' instead - verify the price.")
+            uom = stock_uom
         level = (lv.get("level") or "").strip()
         if not level:
             return
@@ -55,6 +65,17 @@ class PriceImporter:
         except Exception as exc:
             result.add_error(f"{item_name} ({level})", exc)
             frappe.db.rollback()
+
+    @staticmethod
+    def _uom_valid_for_item(item_code: str, uom: str, stock_uom: str) -> bool:
+        """True when ``uom`` may be used on an Item Price for this item - its stock
+        UOM or one of its additional UOMs (UOM Conversion Detail rows)."""
+        if not uom:
+            return False
+        if uom == stock_uom:
+            return True
+        return bool(frappe.db.exists(
+            "UOM Conversion Detail", {"parent": item_code, "uom": uom}))
 
     # ── upserts ────────────────────────────────────────────────────────────────
     def _ensure_price_list(self, level: str) -> str:

--- a/tally_migrator/erpnext/importers/prices.py
+++ b/tally_migrator/erpnext/importers/prices.py
@@ -1,0 +1,140 @@
+"""Price importer: Tally price levels -> ERPNext Price List + Item Price (+ a
+price-list-scoped Pricing Rule for any per-level discount)."""
+
+import frappe
+
+from tally_migrator.naming import safe_item_code
+from .base import BaseImporter, ImportResult
+
+
+class PriceImporter:
+    """Create selling Price Lists and Item Prices from Tally price levels.
+
+    Each Tally price level (Retail / Wholesale) becomes a selling Price List; the
+    level's rate becomes an Item Price on that list. A per-level discount becomes a
+    Pricing Rule scoped to that price list (for_price_list), so it applies only when
+    that list is used - mirroring Tally's "rate then discount" billing. Runs after
+    Items so the item_code/UOM links resolve. All upserts are idempotent.
+    """
+
+    doctype = "Item Price"
+
+    def __init__(self, company: str, abbr: str):
+        self.company = company
+        self.abbr = abbr
+        self.currency = frappe.get_cached_value(
+            "Company", company, "default_currency") or "INR"
+
+    def run(self, items: list[dict]) -> ImportResult:
+        result = ImportResult(self.doctype)
+        for it in items:
+            for lv in (it.get("PriceLevels") or []):
+                self._import_level(result, it.get("_name", ""), lv)
+        return result
+
+    def _import_level(self, result: ImportResult, item_name: str, lv: dict) -> None:
+        rate, uom = self._parse_rate(lv.get("rate", ""))
+        if rate is None:
+            return                              # a level with no rate carries nothing
+        item_code = safe_item_code(item_name)
+        if not frappe.db.exists("Item", item_code):
+            return                              # item didn't import (warned by ItemImporter)
+        if not (uom and frappe.db.exists("UOM", uom)):
+            uom = frappe.db.get_value("Item", item_code, "stock_uom")
+        level = (lv.get("level") or "").strip()
+        if not level:
+            return
+        try:
+            price_list = self._ensure_price_list(level)
+            valid_from = self._parse_date(lv.get("date"))
+            self._ensure_item_price(result, item_code, price_list, uom, rate, valid_from)
+            disc = BaseImporter._to_float(lv.get("discount"))
+            if disc:
+                self._ensure_pricing_rule(
+                    result, item_code, price_list, disc, valid_from, lv.get("ending"))
+        except Exception as exc:
+            result.add_error(f"{item_name} ({level})", exc)
+            frappe.db.rollback()
+
+    # ── upserts ────────────────────────────────────────────────────────────────
+    def _ensure_price_list(self, level: str) -> str:
+        if not frappe.db.exists("Price List", level):
+            frappe.get_doc({
+                "doctype": "Price List", "price_list_name": level,
+                "selling": 1, "enabled": 1, "currency": self.currency,
+            }).insert(ignore_permissions=True)
+            frappe.db.commit()
+        return level
+
+    def _ensure_item_price(self, result, item_code, price_list, uom, rate, valid_from):
+        if frappe.db.exists("Item Price", {
+                "item_code": item_code, "price_list": price_list, "uom": uom}):
+            result.skipped += 1
+            return
+        doc = frappe.get_doc({
+            "doctype": "Item Price", "item_code": item_code, "uom": uom,
+            "price_list": price_list, "price_list_rate": rate, "selling": 1,
+            "currency": self.currency, "valid_from": valid_from or None,
+        })
+        doc.insert(ignore_permissions=True)
+        frappe.db.commit()
+        result.add_created(doc.name, "Item Price")
+
+    def _ensure_pricing_rule(self, result, item_code, price_list, discount,
+                             valid_from, ending):
+        # Deterministic title is the idempotency key (Pricing Rule has no natural
+        # one), so a re-run finds and skips the rule rather than duplicating it.
+        title = f"Tally {price_list} discount - {item_code}"[:140]
+        if frappe.db.exists("Pricing Rule", title):
+            return
+        # for_price_list scopes the rule to this price list, so the discount applies
+        # only when selling at that level, on its Item Price rate (Retail 398 - 10%
+        # = 358.20) - mirroring Tally. NB: do NOT set apply_discount_on_rate: that is
+        # the "stack on an already-discounted rate" flag and would force a Priority.
+        rule = {
+            "doctype": "Pricing Rule", "title": title,
+            "apply_on": "Item Code", "items": [{"item_code": item_code}],
+            "price_or_product_discount": "Price",
+            "rate_or_discount": "Discount Percentage",
+            "discount_percentage": discount,
+            "for_price_list": price_list, "selling": 1, "company": self.company,
+            "valid_from": valid_from or None,
+        }
+        # The slab's qty ceiling (ENDINGAT "100 Ream") bounds the discount, when present.
+        max_qty = self._parse_qty(ending)
+        if max_qty:
+            rule["max_qty"] = max_qty
+        frappe.get_doc(rule).insert(ignore_permissions=True)
+        frappe.db.commit()
+        result.add_created(title, "Pricing Rule")
+
+    # ── parsing ─────────────────────────────────────────────────────────────────
+    @staticmethod
+    def _parse_rate(raw: str):
+        """'398.00/Ream' -> (398.0, 'Ream'); '360.00' -> (360.0, ''); '' -> (None, '')."""
+        raw = (raw or "").strip()
+        if not raw:
+            return None, ""
+        rate_part, _, uom = raw.partition("/")
+        try:
+            return float(rate_part.replace(",", "").strip()), uom.strip()
+        except ValueError:
+            return None, ""
+
+    @staticmethod
+    def _parse_qty(raw: str) -> float:
+        """' 100 Ream' -> 100.0; '' -> 0.0."""
+        raw = (raw or "").strip()
+        num = raw.split()[0] if raw else ""
+        try:
+            return float(num.replace(",", ""))
+        except ValueError:
+            return 0.0
+
+    @staticmethod
+    def _parse_date(raw: str):
+        """Tally 'YYYYMMDD' -> 'YYYY-MM-DD'; anything else -> ''."""
+        raw = (raw or "").strip()
+        if len(raw) == 8 and raw.isdigit():
+            return f"{raw[0:4]}-{raw[4:6]}-{raw[6:8]}"
+        return ""

--- a/tally_migrator/erpnext/importers/units.py
+++ b/tally_migrator/erpnext/importers/units.py
@@ -55,7 +55,87 @@ class UnitImporter:
         for u in units:
             if not self._is_simple(u):
                 self._ensure_conversion(result, u)
+        # Third pass: map each UOM's GST Unit Quantity Code into India Compliance's
+        # GST Settings (must run after the UOMs themselves exist).
+        self._map_uqcs(units, result)
         return result
+
+    # ── GST UQC mapping (India Compliance) ─────────────────────────────────────
+    @staticmethod
+    def _gst_uom_code_map() -> "dict | None":
+        """``{UQC code: official option string}`` derived live from the GST UOM Map
+        field's option list (e.g. ``{"NOS": "NOS (Numbers)"}``).
+
+        Derived from IC's field metadata rather than a hardcoded list so it tracks
+        whatever UQC values the installed India Compliance version supports
+        (derive-don't-enumerate). Returns ``None`` when India Compliance is absent,
+        which makes the whole UQC pass a clean no-op."""
+        if not frappe.db.exists("DocType", "GST UOM Map"):
+            return None
+        try:
+            options = frappe.get_meta("GST UOM Map").get_field("gst_uom").options or ""
+        except Exception:
+            return None
+        out = {}
+        for opt in options.splitlines():
+            opt = opt.strip()
+            if opt:
+                out[opt.split("(")[0].strip().upper()] = opt
+        return out
+
+    @staticmethod
+    def _uqc_to_gst_uom(tally_uqc: str, code_map: dict) -> "str | None":
+        """Map a Tally REPORTINGUQCNAME ('NOS-NUMBERS') to the official GST UOM
+        option ('NOS (Numbers)'), or ``None`` when blank/'Not Applicable'/no match.
+
+        Tally encodes ``CODE-DESCRIPTION``; we match on the CODE prefix against the
+        official option set. A code with no official equivalent (e.g. Tally's
+        'REM-REAMS') returns ``None`` so the caller can warn rather than write an
+        invalid value into GST returns."""
+        raw = (tally_uqc or "").replace("\x04", " ").strip()  # Tally pads with &#4;
+        if not raw or "not applicable" in raw.lower():
+            return None
+        code = raw.split("-", 1)[0].strip().upper()
+        return code_map.get(code)
+
+    def _map_uqcs(self, units: list[dict], result: ImportResult) -> None:
+        """Append missing ``GST Settings.gst_uom_map`` rows for the imported UOMs.
+
+        India Compliance stores UQC globally in GST Settings (a Single doctype),
+        not per-UOM, so this writes shared config: append-only, idempotent (skips
+        UOMs already mapped by IC's defaults or a prior run), one save. No-op when
+        India Compliance is absent. Tally codes with no official GST equivalent are
+        left unmapped with a warning rather than guessed."""
+        code_map = self._gst_uom_code_map()
+        if not code_map:
+            return
+        settings = frappe.get_doc("GST Settings")
+        already = {(m.uom or "").strip().lower() for m in settings.gst_uom_map}
+        changed = False
+        seen = set()
+        for u in units:
+            uom = (u.get("_name") or "").strip()
+            if not uom or uom.lower() in seen:
+                continue
+            seen.add(uom.lower())
+            raw_uqc = (u.get("ReportingUQC") or "").replace("\x04", " ").strip()
+            gst_uom = self._uqc_to_gst_uom(raw_uqc, code_map)
+            if not gst_uom:
+                # Only warn when Tally actually carried a UQC we couldn't place;
+                # a blank/'Not Applicable' unit is simply skipped silently.
+                if raw_uqc and "not applicable" not in raw_uqc.lower():
+                    result.add_warning(
+                        uom, f"GST UQC '{raw_uqc}' has no standard GST code; left "
+                        "unmapped - set it manually in GST Settings if needed for filing.")
+                continue
+            if uom.lower() in already or not frappe.db.exists("UOM", uom):
+                continue
+            settings.append("gst_uom_map", {"uom": uom, "gst_uom": gst_uom})
+            already.add(uom.lower())
+            changed = True
+        if changed:
+            settings.save(ignore_permissions=True)
+            frappe.db.commit()
 
     @staticmethod
     def _is_simple(u: dict) -> bool:

--- a/tally_migrator/migration/account_mapping.py
+++ b/tally_migrator/migration/account_mapping.py
@@ -126,24 +126,17 @@ def _party_openings(masters, bills) -> dict:
         the gap posts as one 'On Account' opening (a mismatch worth reviewing).
       * **lump**       - parties with an opening but no bill detail -> a single
         opening document for the whole balance.
+
+    Foreign-currency parties are posted in their own currency (one invoice per
+    foreign-amount bill, else a single invoice) and counted here too, mirroring
+    ``PartyOpeningImporter._emit_forex``; ``foreign`` reports how many there were.
     """
     by_party: dict[str, list] = {}
     for b in bills or []:
         by_party.setdefault(b.party, []).append(b)
 
-    # Tally base currency (modal ledger CurrencyName). A forex party is skipped by
-    # PartyOpeningImporter, so the preview skips it too and the doc counts match what
-    # actually posts. Equality only, never an ISO-code mapping.
-    from collections import Counter
-    _ccy = Counter(
-        (r.get("CurrencyName") or "").strip()
-        for r in (*masters.customers, *masters.suppliers)
-        if (r.get("CurrencyName") or "").strip()
-    )
-    base_ccy = _ccy.most_common(1)[0][0] if _ccy else ""
-
     invoices = advances = on_account = lump = 0
-    party_count = foreign_skipped = 0
+    party_count = foreign = 0
     mismatches: list[dict] = []
     parties_list: list[dict] = []
     for party_type, records in (("Customer", masters.customers),
@@ -155,15 +148,42 @@ def _party_openings(masters, bills) -> dict:
             party_bills = by_party.get(name, [])
             if not ledger_amt and not party_bills:
                 continue
-            # Forex party: skipped at import (currency unknown), so don't count its
-            # documents here either. Surfaced as a count so the screen can say so.
-            ccy = (record.get("CurrencyName") or "").strip()
-            if base_ccy and ccy and ccy != base_ccy:
-                foreign_skipped += 1
-                continue
             party_count += 1
-
             ledger_signed = _signed(ledger_amt, ledger_drcr)
+
+            # Forex party: posted in its own currency by PartyOpeningImporter._emit_forex
+            # (detected by CurrencyISO, resolved from the opening-string symbol - the same
+            # signal the importer uses, NOT CurrencyName, which a real export omits on a
+            # forex party). Mirror its document count: one invoice per bill that carries a
+            # foreign amount (+ a remainder), else a single consolidated invoice.
+            if (record.get("CurrencyISO") or "").strip():
+                foreign += 1
+                p_invoices = p_lump = 0
+                if _classify_party(party_type, ledger_signed, False) == "invoice":
+                    fbills = [
+                        b for b in party_bills
+                        if b.foreign_amount and _classify_party(
+                            party_type, _signed(b.amount, b.dr_cr), b.is_advance) == "invoice"]
+                    if fbills:
+                        p_invoices = len(fbills)
+                        posted = sum(_signed(b.amount, b.dr_cr) for b in fbills)
+                        residual = round(ledger_signed - posted, 2)
+                        if (abs(residual) >= _PARTY_PLUG_THRESHOLD
+                                and _classify_party(party_type, residual, False) == "invoice"):
+                            p_invoices += 1     # remainder 'Opening' invoice
+                    else:
+                        p_lump = 1              # consolidated single invoice
+                invoices += p_invoices
+                lump += p_lump
+                parties_list.append({
+                    "name": name, "party_type": party_type,
+                    "amount": round(ledger_amt, 2), "dr_cr": ledger_drcr,
+                    "invoices": p_invoices, "advances": 0, "on_account": 0,
+                    "documents": p_invoices + p_lump, "foreign": True,
+                })
+                continue
+
+            bills_signed = 0.0
             bills_signed = 0.0
             p_invoices = p_advances = 0
             for b in party_bills:
@@ -221,7 +241,10 @@ def _party_openings(masters, bills) -> dict:
         "on_account": on_account,
         "lump": lump,
         "documents": invoices + advances + on_account + lump,
-        "foreign_skipped": foreign_skipped,
+        # Foreign-currency parties (posted in their own currency, see _emit_forex).
+        # Their documents are already included in the counts above; this is just how
+        # many of the parties were foreign, so the screen can call it out.
+        "foreign": foreign,
         "mismatches": mismatches,
         "parties_list": parties_list,
     }

--- a/tally_migrator/migration/coverage.py
+++ b/tally_migrator/migration/coverage.py
@@ -45,6 +45,15 @@ _TAGS_BY_TYPE: dict[str, dict] = {
 }
 
 
+# Stock Item child structures migrated by purpose-built importers (not via the
+# ITEM_FIELDS FETCH list): price levels -> Price List + Item Price (PriceImporter),
+# and the multiple-BoM component list -> ERPNext BOM (BomImporter). Counted as
+# imported in the coverage report so they don't read as dropped data.
+_DEDICATED_IMPORTER_TAGS: dict[str, tuple] = {
+    "Stock Item": ("FULLPRICELIST.LIST", "MULTICOMPONENTLIST.LIST"),
+}
+
+
 def _read_tags(obj_type: str, fields: list) -> set[str]:
     """The set of top-level tags the parser actually reads for these fields -
     exactly mirroring ``FileTallySource.get_collection``: a field's tag override
@@ -480,8 +489,13 @@ def coverage_report(source) -> dict:
     recognized_prefixes: set = set()   # current taxes we saw but deliberately skip
     hr_fields_seen: set = set()        # employee/HR Cost-Centre tags, deliberately skip
     for obj_type, fields in MAPPED_FIELDS.items():
-        mapped = _read_tags(obj_type, fields) | {"NAME"}
-        written = _read_tags(obj_type, WRITTEN_FIELDS.get(obj_type, fields)) | {"NAME"}
+        # Tags handled by a dedicated importer rather than a FETCH-list field (their
+        # nested structure is read by a purpose-built extractor method), so they count
+        # as imported, not as dropped data.
+        extra = {_norm(t) for t in _DEDICATED_IMPORTER_TAGS.get(obj_type, ())}
+        mapped = _read_tags(obj_type, fields) | {"NAME"} | extra
+        written = (_read_tags(obj_type, WRITTEN_FIELDS.get(obj_type, fields))
+                   | {"NAME"} | extra)
         read_not_written = mapped - written
         read_leaves = _read_leaf_tags(obj_type, fields)
         tags = source.raw_tags(obj_type)

--- a/tally_migrator/migration/master_migrator.py
+++ b/tally_migrator/migration/master_migrator.py
@@ -281,6 +281,10 @@ class MasterMigrator:
             PipelineStep("Suppliers", 65, self.importer.import_suppliers, masters.suppliers),
             PipelineStep("Items", 80, self.importer.import_items, masters.items),
         ]
+        # Price levels (Retail/Wholesale) -> Price List + Item Price (+ discount
+        # Pricing Rule). After Items so item_code/UOM links resolve.
+        if any(i.get("PriceLevels") for i in masters.items):
+            steps.append(PipelineStep("Prices", 82, self.importer.import_prices, masters.items))
         # Ledger account opening balances (cash, assets, P&L) - one balanced,
         # submitted Opening Entry (JE) once every account exists. Party balances
         # NO LONGER go through this path: they post invoice-wise below, so the JE

--- a/tally_migrator/migration/master_migrator.py
+++ b/tally_migrator/migration/master_migrator.py
@@ -285,6 +285,10 @@ class MasterMigrator:
         # Pricing Rule). After Items so item_code/UOM links resolve.
         if any(i.get("PriceLevels") for i in masters.items):
             steps.append(PipelineStep("Prices", 82, self.importer.import_prices, masters.items))
+        # Bills of materials -> ERPNext BOM (submitted). After Items so the finished
+        # item and every component exist.
+        if any(i.get("Boms") for i in masters.items):
+            steps.append(PipelineStep("BOMs", 84, self.importer.import_boms, masters.items))
         # Ledger account opening balances (cash, assets, P&L) - one balanced,
         # submitted Opening Entry (JE) once every account exists. Party balances
         # NO LONGER go through this path: they post invoice-wise below, so the JE

--- a/tally_migrator/migration/reconciliation.py
+++ b/tally_migrator/migration/reconciliation.py
@@ -153,13 +153,23 @@ def erpnext_totals(company: str, abbr: str) -> dict:
         pay_acc = frappe.get_cached_value("Company", company, "default_payable_account")
         temp_acc = f"Temporary Opening - {abbr}"
         classes = _gl_by_class(company, {rec_acc, pay_acc, temp_acc})
+        # Sum opening postings across ALL receivable / payable accounts, not just the
+        # company defaults: forex party openings post to per-currency control accounts
+        # ('Debtors USD', 'Creditors USD') created during the run, and those must be
+        # included or the receivables/payables figure reads short by the forex total.
+        rec_accs = frappe.get_all(
+            "Account", filters={"company": company, "account_type": "Receivable",
+                                "is_group": 0}, pluck="name") or ([rec_acc] if rec_acc else [])
+        pay_accs = frappe.get_all(
+            "Account", filters={"company": company, "account_type": "Payable",
+                                "is_group": 0}, pluck="name") or ([pay_acc] if pay_acc else [])
         # Scope the control accounts to opening postings ONLY (this migration's opening
         # invoices + advance Payment Entries), never the account's full balance. The
         # tool supports re-runs and migrating into a company that may already hold
         # activity on Receivable/Payable/Stock; a full-balance read would fold that
         # pre-existing activity into the "ERPNext" column and show a false mismatch.
-        receivables = _opening_account_balance(company, rec_acc) if rec_acc else None
-        payables = _opening_account_balance(company, pay_acc) if pay_acc else None
+        receivables = _opening_account_balance(company, rec_accs) if rec_accs else None
+        payables = _opening_account_balance(company, pay_accs) if pay_accs else None
         stock = {"amount": _opening_stock_value(company), "dr_cr": "Dr"}
         # Temporary Opening is the contra for every opening posting, so derive it as
         # the balancing residual of the scoped figures rather than reading the GL.
@@ -206,9 +216,13 @@ def _gl_by_class(company: str, exclude: set) -> dict:
     return {cls: _side(net) for cls, net in nets.items()}
 
 
-def _opening_account_balance(company: str, account: str) -> dict:
+def _opening_account_balance(company: str, accounts) -> dict:
     """{amount, dr_cr} net (Dr-positive) of just this migration's OPENING postings on
-    an account - never the account's full balance.
+    one or more accounts - never the accounts' full balance.
+
+    Accepts a single account name or a list (forex openings post to per-currency
+    control accounts like 'Debtors USD' alongside the default, so all of them must
+    be summed for the receivables/payables figure to reconcile).
 
     Two sources, matching what the importers post against a control account:
       * opening invoices - their GL is flagged ``is_opening='Yes'``;
@@ -218,16 +232,17 @@ def _opening_account_balance(company: str, account: str) -> dict:
     activity on the account, from polluting the reconciliation figure."""
     import frappe
 
+    account_filter = ["in", accounts] if isinstance(accounts, (list, tuple, set)) else accounts
     net = 0.0
     opening_rows = frappe.get_all(
         "GL Entry",
-        filters={"company": company, "account": account, "is_cancelled": 0,
+        filters={"company": company, "account": account_filter, "is_cancelled": 0,
                  "is_opening": "Yes"},
         fields=["debit", "credit"])
     net += sum((r.debit or 0) - (r.credit or 0) for r in opening_rows)
     advance_rows = frappe.get_all(
         "GL Entry",
-        filters={"company": company, "account": account, "is_cancelled": 0,
+        filters={"company": company, "account": account_filter, "is_cancelled": 0,
                  "voucher_type": "Payment Entry",
                  "remarks": ["like", "Tally opening:%"]},
         fields=["debit", "credit"])

--- a/tally_migrator/tally/extractors.py
+++ b/tally_migrator/tally/extractors.py
@@ -14,10 +14,11 @@ LEDGER_FIELDS = [
     "CountryName", "LedgerState", "PinCode",
     # P1 standard fields Tally states explicitly on the party ledger.
     "GSTRegistrationType", "CreditLimit", "EmailCC", "LedgerContact", "MailingName",
-    # Ledger currency name. Almost always the company base currency (redundant), but
-    # a forex party ledger carries a different one - the only in-file signal that a
-    # party's opening must NOT be posted in the company currency (see
-    # PartyOpeningImporter). Compared by equality, never mapped to an ISO code.
+    # Ledger currency name. NOTE: a real Tally masters export does NOT emit this tag
+    # on the party ledger - the forex signal is the currency symbol embedded in the
+    # OpeningBalance string ("-$8500 @ ... = ..."), resolved to an ISO in
+    # _attach_currency_iso. Kept in the FETCH list for the live-connector path and
+    # older exports that may carry it.
     "CurrencyName",
     # Bank account details (→ ERPNext Bank Account, linked to the party).
     "BankAccountNo", "BankIFSC", "BankAccountHolder", "BankBranch", "BankName",

--- a/tally_migrator/tally/extractors.py
+++ b/tally_migrator/tally/extractors.py
@@ -37,8 +37,14 @@ COSTCENTRE_FIELDS = ["Name", "Parent"]
 STOCKGROUP_FIELDS = ["Name", "Parent"]
 UNIT_FIELDS       = [
     "Name", "IsSimpleUnit", "OriginalName", "DecimalPlaces",
-    "BaseUnits", "AdditionalUnits", "Conversion",
+    "BaseUnits", "AdditionalUnits", "Conversion", "ReportingUQC",
 ]
+# The GST Unit Quantity Code lives in a dated revision list
+# (REPORTINGUQCDETAILS.LIST/REPORTINGUQCNAME, e.g. "NOS-NUMBERS"); _resolve_field
+# returns the last/most-recent entry. "Not Applicable" rows are filtered downstream.
+UNIT_TAGS = {
+    "ReportingUQC": ["REPORTINGUQCDETAILS.LIST/REPORTINGUQCNAME"],
+}
 
 
 # ── Tag overrides for fields whose real Tally tag ≠ FIELD.upper() ─────────────
@@ -236,7 +242,7 @@ class TallyExtractor:
             stock_groups = self._dedup_by_name(
                 self.client.get_collection("Stock Group", STOCKGROUP_FIELDS)),
             units        = self._dedup_by_name(
-                self.client.get_collection("Unit", UNIT_FIELDS)),
+                self.client.get_collection("Unit", UNIT_FIELDS, UNIT_TAGS)),
         )
 
     @staticmethod

--- a/tally_migrator/tally/extractors.py
+++ b/tally_migrator/tally/extractors.py
@@ -249,6 +249,8 @@ class TallyExtractor:
         self._attach_item_gst_rates(masters.items)
         # Attach each item's price levels (Retail/Wholesale rates + discounts).
         self._attach_item_price_levels(masters.items)
+        # Attach each item's bills of materials (component lists).
+        self._attach_item_boms(masters.items)
         return masters
 
     def _attach_item_gst_rates(self, items: list[dict]) -> None:
@@ -268,6 +270,15 @@ class TallyExtractor:
         levels = self.client.item_price_levels()
         for it in items:
             it.setdefault("PriceLevels", levels.get(it.get("_name", ""), []))
+
+    def _attach_item_boms(self, items: list[dict]) -> None:
+        """Set ``Boms`` (list of {name, basic_qty, components}) on each item dict.
+        No-op when the source can't supply it (live client)."""
+        if not hasattr(self.client, "item_boms"):
+            return
+        boms = self.client.item_boms()
+        for it in items:
+            it.setdefault("Boms", boms.get(it.get("_name", ""), []))
 
     @staticmethod
     def _dedup_by_name(records: list[dict]) -> list[dict]:

--- a/tally_migrator/tally/extractors.py
+++ b/tally_migrator/tally/extractors.py
@@ -232,7 +232,7 @@ class TallyExtractor:
         # (repeating child lists a real export carries beyond the single primary
         # mailing address / mobile). No-op for a live client without child lists.
         self._attach_party_subrecords(ledgers)
-        return ExtractedMasters(
+        masters = ExtractedMasters(
             customers    = [l for l in ledgers if resolver.kind_of(l["_name"]) == CUSTOMER],
             suppliers    = [l for l in ledgers if resolver.kind_of(l["_name"]) == SUPPLIER],
             items        = self._dedup_by_name(
@@ -244,6 +244,19 @@ class TallyExtractor:
             units        = self._dedup_by_name(
                 self.client.get_collection("Unit", UNIT_FIELDS, UNIT_TAGS)),
         )
+        # Attach each item's combined GST rate (IGST), read per duty head from the
+        # nested rate list. No-op for a live client that can't supply it.
+        self._attach_item_gst_rates(masters.items)
+        return masters
+
+    def _attach_item_gst_rates(self, items: list[dict]) -> None:
+        """Set ``GstRate`` on each item dict from the source's per-duty-head rate
+        read. Degrades to a no-op when the source can't supply it (live client)."""
+        if not hasattr(self.client, "item_gst_rates"):
+            return
+        rates = self.client.item_gst_rates()
+        for it in items:
+            it.setdefault("GstRate", rates.get(it.get("_name", ""), ""))
 
     @staticmethod
     def _dedup_by_name(records: list[dict]) -> list[dict]:

--- a/tally_migrator/tally/extractors.py
+++ b/tally_migrator/tally/extractors.py
@@ -181,9 +181,15 @@ class BillAllocation:
     party: str             # owning ledger (the Tally party name)
     bill_no: str           # the bill reference (Tally bill NAME)
     bill_date: str         # ISO date "YYYY-MM-DD" ("" when absent/unparseable)
-    amount: float          # absolute amount
+    amount: float          # absolute amount in COMPANY (base) currency
     dr_cr: str             # "Dr" | "Cr" | ""
     is_advance: bool       # Tally's ISADVANCE flag
+    # Absolute amount in the bill's FOREIGN currency, parsed from a forex-shaped bill
+    # opening ("$600 @ 83/$ = ₹49800"); 0.0 for a plain base-currency bill. Lets the
+    # importer split a foreign-currency party's opening bill-by-bill (mirroring the
+    # base-currency path) only when the export actually carries per-bill foreign
+    # amounts - never guessed.
+    foreign_amount: float = 0.0
 
 
 @dataclass
@@ -596,9 +602,14 @@ class TallyExtractor:
             ["BillDate", "Name", "IsAdvance", "OpeningBalance"])
         bills: list[BillAllocation] = []
         for r in rows:
-            amount, drcr = self._parse_opening(r.get("OpeningBalance", ""))
+            raw = r.get("OpeningBalance", "")
+            amount, drcr = self._parse_opening(raw)
             if not amount:
                 continue
+            # A forex-shaped bill ("$600 @ 83/$ = ₹49800") yields a foreign amount too;
+            # ``amount`` above is already the base (the part after '='), so the two are
+            # consistent. A plain base-currency bill has no '='/symbol → foreign 0.
+            foreign, _sym, _base, _fdrcr = self._parse_forex_opening(raw)
             bills.append(BillAllocation(
                 party=(r.get("_parent") or "").strip(),
                 bill_no=(r.get("Name") or "").strip(),
@@ -606,6 +617,7 @@ class TallyExtractor:
                 amount=amount,
                 dr_cr=drcr,
                 is_advance=(r.get("IsAdvance") or "").strip().lower() == "yes",
+                foreign_amount=foreign,
             ))
         return bills
 

--- a/tally_migrator/tally/extractors.py
+++ b/tally_migrator/tally/extractors.py
@@ -1,3 +1,4 @@
+import unicodedata
 import re
 from dataclasses import dataclass, field
 from .mappings import TALLY_ROOT_PARENT, TALLY_SYSTEM_LEDGERS, classify_group
@@ -232,6 +233,9 @@ class TallyExtractor:
         # (repeating child lists a real export carries beyond the single primary
         # mailing address / mobile). No-op for a live client without child lists.
         self._attach_party_subrecords(ledgers)
+        # Resolve each ledger's currency symbol to an ISO code (from the CURRENCY
+        # masters), so a forex party opening can post in its real currency.
+        self._attach_currency_iso(ledgers)
         masters = ExtractedMasters(
             customers    = [l for l in ledgers if resolver.kind_of(l["_name"]) == CUSTOMER],
             suppliers    = [l for l in ledgers if resolver.kind_of(l["_name"]) == SUPPLIER],
@@ -270,6 +274,24 @@ class TallyExtractor:
         levels = self.client.item_price_levels()
         for it in items:
             it.setdefault("PriceLevels", levels.get(it.get("_name", ""), []))
+
+    def _attach_currency_iso(self, ledgers: list[dict]) -> None:
+        """Set ``CurrencyISO`` on each forex ledger, resolved from the currency symbol
+        embedded in its OpeningBalance (e.g. the '$' in "-$8500 @ ... = -₹705500")
+        via the CURRENCY masters. Tally does NOT export a CurrencyName tag on the
+        party ledger, so the symbol in the opening string is the only in-file signal.
+        Only set when a foreign symbol resolves to an ISO, so domestic parties (no
+        symbol, or the base ₹ which carries no ISO) are left untouched. No-op when
+        the source can't supply the currency map."""
+        if not hasattr(self.client, "currency_iso_map"):
+            return
+        iso = self.client.currency_iso_map()
+        if not iso:
+            return
+        for r in ledgers:
+            _f, symbol, _b, _d = self._parse_forex_opening(r.get("OpeningBalance", ""))
+            if symbol and symbol in iso:
+                r.setdefault("CurrencyISO", iso[symbol])
 
     def _attach_item_boms(self, items: list[dict]) -> None:
         """Set ``Boms`` (list of {name, basic_qty, components}) on each item dict.
@@ -506,7 +528,14 @@ class TallyExtractor:
             suffix, s = "Dr", s[:-2]
         elif upper.endswith("CR"):
             suffix, s = "Cr", s[:-2]
-        s = s.replace("$", "").replace(",", "").strip()
+        # Strip currency symbols (any Unicode currency glyph, e.g. "$", "₹") plus
+        # thousands commas and spaces, but KEEP letters so a unit-suffixed *quantity*
+        # like "55 Nos" still fails to parse here (quantities are read by
+        # _parse_quantity, not as amounts). A forex cell like
+        # "-$8500.00 @ ₹ 83/$ = -₹ 705500.00" reduces (after the '=' split above) to
+        # its base "-705500.00" instead of failing on the ₹ symbol.
+        s = "".join(ch for ch in s
+                    if ch not in (",", " ") and unicodedata.category(ch) != "Sc")
         try:
             val = float(s)
         except ValueError:
@@ -516,6 +545,33 @@ class TallyExtractor:
         if suffix:
             return abs(val), suffix
         return abs(val), "Dr" if val < 0 else "Cr"
+
+    @staticmethod
+    def _parse_forex_opening(raw) -> tuple[float, str, float, str]:
+        """Parse a multi-currency opening into (foreign_amount, symbol, base, drcr).
+
+        Handles the rich export form ``-$8500.00 @ ₹ 83/$ = -₹ 705500.00`` and the
+        older ``10.00$ = 800.00``: the foreign amount/symbol come from the part
+        before ``@`` (or before ``=``), the base from after ``=``. Sign convention
+        matches _parse_opening (negative = Dr). Returns zeros when there is no ``=``
+        (not a forex cell) or nothing parses."""
+        s = str(raw or "").strip()
+        if "=" not in s:
+            return 0.0, "", 0.0, ""
+        left, _, right = s.partition("=")
+        foreign_part = left.split("@")[0]
+        symbol = "".join(ch for ch in foreign_part
+                         if not (ch.isdigit() or ch in " .,-")).strip()
+
+        def _num(x):
+            x = re.sub(r"[^\d.\-]", "", x)
+            try:
+                return float(x)
+            except ValueError:
+                return 0.0
+        foreign, base = _num(foreign_part), _num(right)
+        drcr = "Dr" if (foreign < 0 or base < 0) else "Cr"
+        return abs(foreign), symbol, abs(base), drcr
 
     # ── Bill-wise opening balances ─────────────────────────────────────────────
     def extract_bill_allocations(self) -> list[BillAllocation]:

--- a/tally_migrator/tally/extractors.py
+++ b/tally_migrator/tally/extractors.py
@@ -247,6 +247,8 @@ class TallyExtractor:
         # Attach each item's combined GST rate (IGST), read per duty head from the
         # nested rate list. No-op for a live client that can't supply it.
         self._attach_item_gst_rates(masters.items)
+        # Attach each item's price levels (Retail/Wholesale rates + discounts).
+        self._attach_item_price_levels(masters.items)
         return masters
 
     def _attach_item_gst_rates(self, items: list[dict]) -> None:
@@ -257,6 +259,15 @@ class TallyExtractor:
         rates = self.client.item_gst_rates()
         for it in items:
             it.setdefault("GstRate", rates.get(it.get("_name", ""), ""))
+
+    def _attach_item_price_levels(self, items: list[dict]) -> None:
+        """Set ``PriceLevels`` (list of {level, date, rate, discount, ending}) on
+        each item dict. No-op when the source can't supply it (live client)."""
+        if not hasattr(self.client, "item_price_levels"):
+            return
+        levels = self.client.item_price_levels()
+        for it in items:
+            it.setdefault("PriceLevels", levels.get(it.get("_name", ""), []))
 
     @staticmethod
     def _dedup_by_name(records: list[dict]) -> list[dict]:

--- a/tally_migrator/tally/file_source.py
+++ b/tally_migrator/tally/file_source.py
@@ -293,6 +293,53 @@ class FileTallySource:
             out[name] = igst or ""
         return out
 
+    def item_price_levels(self) -> dict:
+        """``{stock item name: [{level, date, rate, discount, ending}, ...]}``.
+
+        Reads Tally price levels from FULLPRICELIST.LIST (one per price level +
+        effective DATE), each carrying PRICELEVELLIST.LIST slabs (ENDINGAT / RATE /
+        DISCOUNT). Per price level we keep the latest DATE only (price revisions
+        collapse to the current price) and the first slab (single-slab is the norm).
+        Raw strings are returned; the importer parses rate/uom/qty."""
+        out: dict = {}
+        for elem in self._by_tag.get("STOCKITEM", ()):
+            name = (elem.get("NAME") or elem.findtext("NAME") or "").strip()
+            if not name:
+                continue
+            by_level: dict = {}     # level -> (date, slab dict)
+            for fp in elem.iter():
+                if fp.tag.split("}")[-1].upper() != "FULLPRICELIST.LIST":
+                    continue
+                date = level = ""
+                slabs = []
+                for ch in fp:
+                    t = ch.tag.split("}")[-1].upper()
+                    if t == "DATE":
+                        date = (ch.text or "").strip()
+                    elif t == "PRICELEVEL":
+                        level = (ch.text or "").strip()
+                    elif t == "PRICELEVELLIST.LIST":
+                        row = {}
+                        for c in ch:
+                            ct = c.tag.split("}")[-1].upper()
+                            if ct in ("ENDINGAT", "RATE", "DISCOUNT"):
+                                row[ct.lower()] = (c.text or "").strip()
+                        if row:
+                            slabs.append(row)
+                if not level or not slabs:
+                    continue
+                prev = by_level.get(level)
+                # YYYYMMDD strings sort chronologically; keep the latest revision.
+                if prev is None or date > prev[0]:
+                    by_level[level] = (date, slabs[0])
+            if by_level:
+                out[name] = [
+                    {"level": lvl, "date": d, "rate": s.get("rate", ""),
+                     "discount": s.get("discount", ""), "ending": s.get("endingat", "")}
+                    for lvl, (d, s) in by_level.items()
+                ]
+        return out
+
     # ── Field resolution (tag overrides + nested .LIST descent) ────────────────
     @classmethod
     def _resolve_field(cls, elem, candidates: list) -> str:

--- a/tally_migrator/tally/file_source.py
+++ b/tally_migrator/tally/file_source.py
@@ -255,6 +255,44 @@ class FileTallySource:
         self._collection_cache[cache_key] = rows
         return [dict(r) for r in rows]
 
+    def item_gst_rates(self) -> dict:
+        """``{stock item name: combined GST rate string}`` read per duty head.
+
+        The rate lives nested under GSTDETAILS.LIST/STATEWISEDETAILS.LIST/
+        RATEDETAILS.LIST, one entry per duty head (CGST/SGST-UTGST/IGST/Cess). The
+        combined GST rate is IGST (== CGST + SGST); we read by duty head rather than
+        relying on tag order, so a Cess rate can never be mistaken for the GST rate.
+        Empty string when the item carries no rate (nil/exempt/non-GST)."""
+        out: dict = {}
+        for elem in self._by_tag.get("STOCKITEM", ()):
+            name = (elem.get("NAME") or elem.findtext("NAME") or "").strip()
+            if not name:
+                continue
+            heads: dict = {}
+            for node in elem.iter():
+                if node.tag.split("}")[-1].upper() != "RATEDETAILS.LIST":
+                    continue
+                duty = rate = ""
+                for ch in node:
+                    local = ch.tag.split("}")[-1].upper()
+                    if local == "GSTRATEDUTYHEAD":
+                        duty = (ch.text or "").strip().upper()
+                    elif local == "GSTRATE":
+                        rate = (ch.text or "").strip()
+                if duty and rate:
+                    heads[duty] = rate
+            igst = heads.get("IGST")
+            if not igst:
+                cgst = heads.get("CGST")
+                sgst = heads.get("SGST/UTGST") or heads.get("SGST")
+                if cgst or sgst:
+                    try:
+                        igst = f"{float(cgst or 0) + float(sgst or 0):g}"
+                    except ValueError:
+                        igst = ""
+            out[name] = igst or ""
+        return out
+
     # ── Field resolution (tag overrides + nested .LIST descent) ────────────────
     @classmethod
     def _resolve_field(cls, elem, candidates: list) -> str:

--- a/tally_migrator/tally/file_source.py
+++ b/tally_migrator/tally/file_source.py
@@ -340,6 +340,46 @@ class FileTallySource:
                 ]
         return out
 
+    def item_boms(self) -> dict:
+        """``{stock item name: [{name, basic_qty, components:[...]}]}``.
+
+        Reads Tally bills of materials from MULTICOMPONENTLIST.LIST (Tally supports
+        multiple BOMs per item), each carrying COMPONENTLISTNAME, COMPONENTBASICQTY
+        ("1 Nos" = qty the BOM makes) and MULTICOMPONENTITEMLIST.LIST components
+        (NATUREOFITEM / STOCKITEMNAME / GODOWNNAME / ACTUALQTY "1 Ream"). The legacy
+        empty COMPONENTLIST.LIST is ignored. Raw strings; the importer parses qty/uom."""
+        out: dict = {}
+        for elem in self._by_tag.get("STOCKITEM", ()):
+            name = (elem.get("NAME") or elem.findtext("NAME") or "").strip()
+            if not name:
+                continue
+            boms = []
+            for mc in elem.iter():
+                if mc.tag.split("}")[-1].upper() != "MULTICOMPONENTLIST.LIST":
+                    continue
+                bom_name = basic_qty = ""
+                comps = []
+                for ch in mc:
+                    t = ch.tag.split("}")[-1].upper()
+                    if t == "COMPONENTLISTNAME":
+                        bom_name = (ch.text or "").strip()
+                    elif t == "COMPONENTBASICQTY":
+                        basic_qty = (ch.text or "").strip()
+                    elif t == "MULTICOMPONENTITEMLIST.LIST":
+                        row = {}
+                        for c in ch:
+                            ct = c.tag.split("}")[-1].upper()
+                            if ct in ("NATUREOFITEM", "STOCKITEMNAME", "GODOWNNAME", "ACTUALQTY"):
+                                row[ct.lower()] = (c.text or "").strip()
+                        if row.get("stockitemname"):
+                            comps.append(row)
+                if comps:
+                    boms.append({"name": bom_name or name, "basic_qty": basic_qty,
+                                 "components": comps})
+            if boms:
+                out[name] = boms
+        return out
+
     # ── Field resolution (tag overrides + nested .LIST descent) ────────────────
     @classmethod
     def _resolve_field(cls, elem, candidates: list) -> str:

--- a/tally_migrator/tally/file_source.py
+++ b/tally_migrator/tally/file_source.py
@@ -14,7 +14,7 @@ import frappe
 # (``upper().replace(" ", "")``), so "Stock Item" → STOCKITEM, etc.
 MASTER_RECORD_TAGS = (
     "GROUP", "LEDGER", "STOCKITEM", "GODOWN",
-    "COSTCENTRE", "STOCKGROUP", "UNIT",
+    "COSTCENTRE", "STOCKGROUP", "UNIT", "CURRENCY",
 )
 
 
@@ -338,6 +338,18 @@ class FileTallySource:
                      "discount": s.get("discount", ""), "ending": s.get("endingat", "")}
                     for lvl, (d, s) in by_level.items()
                 ]
+        return out
+
+    def currency_iso_map(self) -> dict:
+        """``{currency NAME (Tally symbol): ISO code}`` from the CURRENCY masters,
+        e.g. ``{"$": "USD"}``. Used to resolve a forex party's CurrencyName to an
+        ERPNext currency. Only entries that carry an ISOCURRENCYCODE are returned."""
+        out: dict = {}
+        for elem in self._by_tag.get("CURRENCY", ()):
+            name = (elem.get("NAME") or elem.findtext("NAME") or "").strip()
+            iso = (elem.findtext("ISOCURRENCYCODE") or "").strip()
+            if name and iso:
+                out[name] = iso
         return out
 
     def item_boms(self) -> dict:

--- a/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
+++ b/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
@@ -1772,16 +1772,17 @@ class TallyMigratorPage {
 			</div>`
 			: "";
 
-		// Foreign-currency parties are skipped at import (their exchange rate is
-		// unknown), so say so plainly rather than letting the doc count look short.
-		const foreignNote = p.foreign_skipped
+		// Foreign-currency parties are posted in their own currency (against a
+		// per-currency Debtors/Creditors account at Tally's stated rate), so note them
+		// for visibility rather than implying the doc count is short.
+		const foreignNote = p.foreign
 			? `<div style="margin-top:12px;">${TallyMigratorPage.callout(
 					"info",
 					TallyMigratorPage.iconRow(
 						"info",
-						`<strong>${fmt(p.foreign_skipped)} part${
-							p.foreign_skipped === 1 ? "y" : "ies"
-						} use a currency other than the company currency.</strong> Their opening balances are not posted automatically - the exchange rate isn't in the file. Enter these openings manually in ERPNext so the rate is correct.`
+						`<strong>${fmt(p.foreign)} part${
+							p.foreign === 1 ? "y" : "ies"
+						} use a foreign currency.</strong> Their opening balances are posted in that currency at the rate recorded in Tally - bill-by-bill when the file carries per-bill amounts, otherwise as a single opening invoice.`
 					)
 			  )}</div>`
 			: "";

--- a/tally_migrator/tests/test_account_mapping.py
+++ b/tally_migrator/tests/test_account_mapping.py
@@ -125,23 +125,63 @@ class TestAccountMapping(unittest.TestCase):
         self.assertTrue(m["opening"]["clean"])
         self.assertEqual(m["opening"]["plug_dr_cr"], "")
 
-    def test_foreign_currency_party_is_skipped_from_preview(self):
-        # The base currency is the modal ledger CurrencyName (INR here); a party in a
-        # different currency is skipped at import, so the preview skips it too and
-        # reports it as foreign_skipped rather than counting its documents.
-        def _c(name, ob, ccy):
-            return {"_name": name, "Parent": "Sundry Debtors",
-                    "OpeningBalance": ob, "CurrencyName": ccy}
-        ledgers = [
-            _c("Acme India", "15000.00 Dr", "INR"),
-            _c("Bharat Traders", "8000.00 Dr", "INR"),
-            _c("Foreign Buyer LLC", "9000.00 Dr", "USD"),
-        ]
-        p = account_mapping(_Src(GROUPS, ledgers))["party_openings"]
-        self.assertEqual(p["foreign_skipped"], 1)
-        self.assertEqual(p["parties"], 2)        # the two INR parties only
-        names = [r["name"] for r in p["parties_list"]]
-        self.assertNotIn("Foreign Buyer LLC", names)
+    def test_foreign_currency_party_is_posted_and_counted(self):
+        # A forex party is detected by the currency SYMBOL in its opening string (which
+        # resolves to CurrencyISO), NOT by CurrencyName (a real export omits it on a
+        # forex party). It is posted in its own currency, so the preview counts it and
+        # reports `foreign`, rather than skipping it. No per-bill detail here → 1 lump.
+        from tally_migrator.tally.file_source import FileTallySource
+
+        xml = (
+            '<ENVELOPE><BODY><IMPORTDATA><REQUESTDATA>'
+            '<TALLYMESSAGE><GROUP NAME="Sundry Debtors"><NAME>Sundry Debtors</NAME>'
+            '<PARENT>Primary</PARENT></GROUP></TALLYMESSAGE>'
+            '<TALLYMESSAGE><CURRENCY NAME="$"><NAME>$</NAME>'
+            '<ISOCURRENCYCODE>USD</ISOCURRENCYCODE></CURRENCY></TALLYMESSAGE>'
+            '<TALLYMESSAGE><LEDGER NAME="Acme India"><NAME>Acme India</NAME>'
+            '<PARENT>Sundry Debtors</PARENT><OPENINGBALANCE>-15000.00</OPENINGBALANCE>'
+            '</LEDGER></TALLYMESSAGE>'
+            '<TALLYMESSAGE><LEDGER NAME="Foreign Buyer LLC"><NAME>Foreign Buyer LLC</NAME>'
+            '<PARENT>Sundry Debtors</PARENT>'
+            '<OPENINGBALANCE>-$9000.00 @ ₹ 83/$ = -₹ 747000.00</OPENINGBALANCE>'
+            '</LEDGER></TALLYMESSAGE>'
+            '</REQUESTDATA></IMPORTDATA></BODY></ENVELOPE>'
+        )
+        p = account_mapping(FileTallySource(xml))["party_openings"]
+        self.assertEqual(p["foreign"], 1)
+        self.assertEqual(p["parties"], 2)              # BOTH parties counted now
+        row = next(r for r in p["parties_list"] if r["name"] == "Foreign Buyer LLC")
+        self.assertTrue(row["foreign"])
+        self.assertEqual(row["documents"], 1)          # no per-bill detail → one invoice
+
+    def test_foreign_party_with_per_bill_amounts_splits_in_preview(self):
+        # When the export carries per-bill foreign amounts, the preview counts one
+        # invoice per bill (mirroring the importer's per-bill forex split).
+        from tally_migrator.tally.file_source import FileTallySource
+
+        def _bill(nm, ob):
+            return (f'<BILLALLOCATIONS.LIST><NAME>{nm}</NAME><BILLDATE>20260401</BILLDATE>'
+                    f'<ISADVANCE>No</ISADVANCE><OPENINGBALANCE>{ob}</OPENINGBALANCE>'
+                    '</BILLALLOCATIONS.LIST>')
+        xml = (
+            '<ENVELOPE><BODY><IMPORTDATA><REQUESTDATA>'
+            '<TALLYMESSAGE><GROUP NAME="Sundry Debtors"><NAME>Sundry Debtors</NAME>'
+            '<PARENT>Primary</PARENT></GROUP></TALLYMESSAGE>'
+            '<TALLYMESSAGE><CURRENCY NAME="$"><NAME>$</NAME>'
+            '<ISOCURRENCYCODE>USD</ISOCURRENCYCODE></CURRENCY></TALLYMESSAGE>'
+            '<TALLYMESSAGE><LEDGER NAME="Globex USD"><NAME>Globex USD</NAME>'
+            '<PARENT>Sundry Debtors</PARENT>'
+            '<OPENINGBALANCE>-$1000.00 @ ₹ 83/$ = -₹ 83000.00</OPENINGBALANCE>'
+            + _bill("USD-1", "-$600.00 @ ₹ 83/$ = -₹ 49800.00")
+            + _bill("USD-2", "-$400.00 @ ₹ 83/$ = -₹ 33200.00")
+            + '</LEDGER></TALLYMESSAGE>'
+            '</REQUESTDATA></IMPORTDATA></BODY></ENVELOPE>'
+        )
+        p = account_mapping(FileTallySource(xml))["party_openings"]
+        self.assertEqual(p["foreign"], 1)
+        row = next(r for r in p["parties_list"] if r["name"] == "Globex USD")
+        self.assertEqual(row["invoices"], 2)           # one per bill, not one lump
+        self.assertEqual(row["documents"], 2)
 
 
 if __name__ == "__main__":

--- a/tally_migrator/tests/test_bom.py
+++ b/tally_migrator/tests/test_bom.py
@@ -1,0 +1,141 @@
+"""
+Phase 5 tests: Tally multi-component lists -> ERPNext BOM.
+
+Covers the two guards live re-validation proved necessary: a component UOM that
+differs from the item's stock UOM is kept but WARNED (ERPNext silently assumes
+1:1, so it needs review), and a self-referential component is explicitly skipped
+(ERPNext does not reject it). Plus skip-if-exists idempotency and skip+warn for
+non-Component natures.
+"""
+import types
+import unittest
+from unittest import mock
+
+from tally_migrator.tally.file_source import FileTallySource
+from tally_migrator.erpnext.importers.bom import BomImporter
+from tally_migrator.erpnext.importers import ImportResult
+
+
+class TestBomExtraction(unittest.TestCase):
+    def test_reads_multicomponent_ignores_empty_legacy_list(self):
+        xml = (
+            '<ENVELOPE><BODY><IMPORTDATA><REQUESTDATA><TALLYMESSAGE>'
+            '<STOCKITEM NAME="Kit"><NAME>Kit</NAME>'
+            '<COMPONENTLIST.LIST>      </COMPONENTLIST.LIST>'        # legacy empty - ignored
+            '<MULTICOMPONENTLIST.LIST><COMPONENTLISTNAME>Kit</COMPONENTLISTNAME>'
+            '<COMPONENTBASICQTY> 1 Nos</COMPONENTBASICQTY>'
+            '<MULTICOMPONENTITEMLIST.LIST><NATUREOFITEM>Component</NATUREOFITEM>'
+            '<STOCKITEMNAME>A4 Paper Ream</STOCKITEMNAME><GODOWNNAME>Main</GODOWNNAME>'
+            '<ACTUALQTY> 1 Ream</ACTUALQTY></MULTICOMPONENTITEMLIST.LIST>'
+            '</MULTICOMPONENTLIST.LIST></STOCKITEM>'
+            '</TALLYMESSAGE></REQUESTDATA></IMPORTDATA></BODY></ENVELOPE>'
+        )
+        boms = FileTallySource(xml).item_boms()["Kit"]
+        self.assertEqual(len(boms), 1)
+        self.assertEqual(boms[0]["basic_qty"], "1 Nos")
+        self.assertEqual(boms[0]["components"][0]["stockitemname"], "A4 Paper Ream")
+        self.assertEqual(boms[0]["components"][0]["actualqty"], "1 Ream")
+
+
+class TestParseQtyUom(unittest.TestCase):
+    def test_parse(self):
+        self.assertEqual(BomImporter._parse_qty_uom(" 1 Ream"), (1.0, "Ream"))
+        self.assertEqual(BomImporter._parse_qty_uom("2 Box"), (2.0, "Box"))
+        self.assertEqual(BomImporter._parse_qty_uom("5"), (5.0, ""))
+        self.assertEqual(BomImporter._parse_qty_uom(""), (0.0, ""))
+
+
+class TestComponentRows(unittest.TestCase):
+    def _imp(self):
+        with mock.patch("frappe.get_cached_value", return_value="INR"):
+            return BomImporter("Frappe Tech", "FT")
+
+    def test_guards(self):
+        imp = self._imp()
+        comps = [
+            {"natureofitem": "Component",  "stockitemname": "A", "actualqty": "2 Box"},
+            {"natureofitem": "By-Product", "stockitemname": "BP", "actualqty": "1 Nos"},
+            {"natureofitem": "Component",  "stockitemname": "Missing", "actualqty": "1 Nos"},
+            {"natureofitem": "Component",  "stockitemname": "Kit", "actualqty": "1 Nos"},   # self
+            {"natureofitem": "Component",  "stockitemname": "C", "actualqty": "1 Nos"},     # uom mismatch
+            {"natureofitem": "Component",  "stockitemname": "D", "actualqty": ""},          # no qty
+        ]
+        existing = {"A", "C", "Kit", "D"}
+        stock = {"A": "Box", "C": "Box", "Kit": "Nos", "D": "Nos"}
+
+        def fake_exists(dt, name=None):
+            if dt == "Item":
+                return name in existing
+            if dt == "UOM":
+                return True
+            return False
+        with mock.patch("frappe.db.exists", side_effect=fake_exists), \
+                mock.patch("frappe.db.get_value", side_effect=lambda d, n, f: stock.get(n)):
+            rows, warns = imp._component_rows("Kit", comps)
+
+        self.assertEqual(rows, [
+            {"item_code": "A", "qty": 2.0, "uom": "Box"},
+            {"item_code": "C", "qty": 1.0, "uom": "Nos"},     # kept, but warned
+        ])
+        joined = " ".join(warns)
+        self.assertIn("By-Product", joined)          # non-Component skipped
+        self.assertIn("Missing", joined)             # missing item skipped
+        self.assertIn("self-reference", joined)      # self skipped
+        self.assertIn("stock unit is 'Box'", joined)  # C uom mismatch warned
+        self.assertIn("no quantity", joined)         # D skipped
+
+
+class TestBomImporterRun(unittest.TestCase):
+    def _imp(self):
+        with mock.patch("frappe.get_cached_value", return_value="INR"):
+            return BomImporter("Frappe Tech", "FT")
+
+    def _items(self):
+        return [{"_name": "Kit", "Boms": [{"name": "Kit BOM", "basic_qty": "1 Nos",
+                 "components": [{"natureofitem": "Component", "stockitemname": "A",
+                                 "actualqty": "2 Nos"}]}]}]
+
+    def test_creates_submitted_default_bom(self):
+        imp = self._imp()
+        captured = {}
+
+        def fake_get_doc(d):
+            captured["doc"] = d
+            return types.SimpleNamespace(name="BOM-Kit-001",
+                                         insert=lambda **k: None, submit=lambda: None)
+
+        def fake_exists(dt, filt=None):
+            if dt == "Item":
+                return True
+            if dt == "BOM":
+                return False         # none yet -> create
+            if dt == "UOM":
+                return True
+            return False
+        with mock.patch("frappe.db.exists", side_effect=fake_exists), \
+                mock.patch("frappe.db.get_value", return_value="Nos"), \
+                mock.patch("frappe.get_doc", side_effect=fake_get_doc), \
+                mock.patch("frappe.db.commit"):
+            res = imp.run(self._items())
+
+        self.assertEqual(res.created, 1)
+        d = captured["doc"]
+        self.assertEqual((d["item"], d["is_active"], d["is_default"], d["quantity"]),
+                         ("Kit", 1, 1, 1.0))
+        self.assertEqual(d["items"], [{"item_code": "A", "qty": 2.0, "uom": "Nos"}])
+
+    def test_idempotent_skip_when_bom_exists(self):
+        imp = self._imp()
+
+        def fake_exists(dt, filt=None):
+            return True              # Item + BOM both exist
+        with mock.patch("frappe.db.exists", side_effect=fake_exists), \
+                mock.patch("frappe.get_doc") as gd, \
+                mock.patch("frappe.db.commit"):
+            res = imp.run(self._items())
+        gd.assert_not_called()
+        self.assertEqual(res.skipped, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tally_migrator/tests/test_coverage.py
+++ b/tally_migrator/tests/test_coverage.py
@@ -418,6 +418,19 @@ class TestStep2Classification(unittest.TestCase):
         self.assertEqual(c["shape"], "freetext")
         self.assertEqual(c["fill_rate"], 0.0)
 
+    def test_dedicated_importer_tags_count_as_imported(self):
+        # Price levels (FULLPRICELIST.LIST) and the BoM component list
+        # (MULTICOMPONENTLIST.LIST) are migrated by dedicated importers (Price /
+        # BOM), so they must read as imported, not as dropped data, in the no-loss
+        # report - otherwise the tool under-reports what it actually migrates.
+        tags = {
+            "FULLPRICELIST.LIST": _rich(5, 2, ["Retail", "Wholesale"]),
+            "MULTICOMPONENTLIST.LIST": _rich(3, 1, ["Kit"]),
+        }
+        report = coverage_report(_Src({"Stock Item": tags}))
+        self.assertEqual(report["unmapped_field_count"], 0)
+        self.assertGreaterEqual(report["imported_field_count"], 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tally_migrator/tests/test_forex_openings.py
+++ b/tally_migrator/tests/test_forex_openings.py
@@ -127,5 +127,28 @@ class TestEmitForexGuards(unittest.TestCase):
         self.assertTrue(any("advance" in w["reason"] for w in res.warnings))
 
 
+class TestReconciliationIncludesForexAccounts(unittest.TestCase):
+    """The reconciliation receivables/payables figure must sum opening postings across
+    ALL receivable/payable accounts, so the per-currency forex control accounts
+    (Debtors USD / Creditors USD) are not missed - otherwise forex migrations show a
+    false variance."""
+
+    def test_opening_account_balance_accepts_account_list(self):
+        from tally_migrator.migration import reconciliation as R
+        captured = {}
+
+        import frappe
+
+        def fake_get_all(doctype, filters=None, fields=None, **kw):
+            captured.setdefault("filters", []).append(filters)
+            # one opening row of 705500 Dr on the (forex) account
+            return [frappe._dict(debit=705500.0, credit=0.0)] if filters.get("is_opening") else []
+        with mock.patch("frappe.get_all", side_effect=fake_get_all):
+            out = R._opening_account_balance("FT", ["Debtors - FT", "Debtors USD - FT"])
+        self.assertEqual(out, {"amount": 705500.0, "dr_cr": "Dr"})
+        # the account filter is an 'in' over the full list, not a single account
+        self.assertEqual(captured["filters"][0]["account"], ["in", ["Debtors - FT", "Debtors USD - FT"]])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tally_migrator/tests/test_forex_openings.py
+++ b/tally_migrator/tests/test_forex_openings.py
@@ -1,0 +1,131 @@
+"""
+Phase 6 tests: foreign-currency party openings (Option B - true multi-currency AR/AP).
+
+A forex party is detected from the currency symbol embedded in its opening balance
+(Tally exports no CurrencyName tag), resolved to an ISO via the CURRENCY masters.
+Its opening posts as one invoice in the foreign currency (conversion_rate derived
+from Tally's stated base / foreign amount, so the base reconciles exactly) against a
+currency-denominated receivable/payable account.
+"""
+import types
+import unittest
+from unittest import mock
+
+from tally_migrator.tally.file_source import FileTallySource
+from tally_migrator.tally.extractors import TallyExtractor
+from tally_migrator.erpnext.importers.openings import PartyOpeningImporter
+from tally_migrator.erpnext.importers import ImportResult
+
+
+class TestParseForexOpening(unittest.TestCase):
+    def test_rich_and_legacy_forms(self):
+        P = TallyExtractor._parse_forex_opening
+        self.assertEqual(P("-$8500.00 @ ₹ 83/$ = -₹ 705500.00"), (8500.0, "$", 705500.0, "Dr"))
+        self.assertEqual(P("10.00$ = 800.00"), (10.0, "$", 800.0, "Cr"))
+        self.assertEqual(P("-2500.00"), (0.0, "", 0.0, ""))      # no '=' -> not forex
+        self.assertEqual(P(""), (0.0, "", 0.0, ""))
+
+
+class TestCurrencyIsoExtraction(unittest.TestCase):
+    def test_symbol_in_opening_resolves_to_iso(self):
+        xml = (
+            '<ENVELOPE><BODY><IMPORTDATA><REQUESTDATA>'
+            '<TALLYMESSAGE><CURRENCY NAME="$"><NAME>$</NAME>'
+            '<ISOCURRENCYCODE>USD</ISOCURRENCYCODE></CURRENCY></TALLYMESSAGE>'
+            '<TALLYMESSAGE><LEDGER NAME="FX Co"><NAME>FX Co</NAME>'
+            '<PARENT>Sundry Debtors</PARENT>'
+            '<OPENINGBALANCE>-$8500.00 @ ₹ 83/$ = -₹ 705500.00</OPENINGBALANCE>'
+            '</LEDGER></TALLYMESSAGE>'
+            '<TALLYMESSAGE><LEDGER NAME="Local Co"><NAME>Local Co</NAME>'
+            '<PARENT>Sundry Debtors</PARENT>'
+            '<OPENINGBALANCE>-50000.00</OPENINGBALANCE></LEDGER></TALLYMESSAGE>'
+            '</REQUESTDATA></IMPORTDATA></BODY></ENVELOPE>'
+        )
+        masters = TallyExtractor(FileTallySource(xml)).extract_all()
+        by_name = {c["_name"]: c for c in masters.customers}
+        self.assertEqual(by_name["FX Co"].get("CurrencyISO"), "USD")
+        self.assertIsNone(by_name["Local Co"].get("CurrencyISO"))   # domestic untouched
+
+
+class TestForexInvoiceDict(unittest.TestCase):
+    def _imp(self):
+        imp = PartyOpeningImporter.__new__(PartyOpeningImporter)
+        imp.company, imp.abbr, imp.posting_date = "Frappe Tech", "FT", "2026-04-01"
+        imp._stock_uom = lambda: "Nos"
+        imp._temp_account = lambda: "Temporary Opening - FT"
+        imp._cost_center = lambda: "Main - FT"
+        return imp
+
+    def test_customer_invoice(self):
+        d = self._imp()._forex_invoice_dict(
+            "Customer", "FX Co", 8500.0, "USD", 83.0, "Debtors USD - FT", "mk")
+        self.assertEqual(d["doctype"], "Sales Invoice")
+        self.assertEqual((d["currency"], d["conversion_rate"], d["debit_to"]),
+                         ("USD", 83.0, "Debtors USD - FT"))
+        self.assertEqual(d["items"][0]["rate"], 8500.0)             # foreign amount
+        self.assertEqual(d["items"][0]["income_account"], "Temporary Opening - FT")
+        self.assertEqual(d["is_opening"], "Yes")
+
+    def test_supplier_invoice_uses_credit_to(self):
+        d = self._imp()._forex_invoice_dict(
+            "Supplier", "FX Sup", 6000.0, "USD", 83.0, "Creditors USD - FT", "mk")
+        self.assertEqual(d["doctype"], "Purchase Invoice")
+        self.assertEqual(d["credit_to"], "Creditors USD - FT")
+        self.assertEqual(d["items"][0]["expense_account"], "Temporary Opening - FT")
+        self.assertEqual(d["bill_no"], "Opening")
+
+
+class TestEnsureCurrencyAccount(unittest.TestCase):
+    def _imp(self):
+        imp = PartyOpeningImporter.__new__(PartyOpeningImporter)
+        imp.company, imp.abbr = "Frappe Tech", "FT"
+        imp._party_account = lambda pt: "Debtors - FT"
+        return imp
+
+    def test_reuses_existing(self):
+        with mock.patch("frappe.db.exists", return_value=True), \
+                mock.patch("frappe.get_doc") as gd:
+            name = self._imp()._ensure_currency_account("Customer", "USD")
+        self.assertEqual(name, "Debtors USD - FT")
+        gd.assert_not_called()
+
+    def test_creates_with_currency_and_type(self):
+        captured = {}
+
+        def fake_get_doc(d):
+            captured.update(d)
+            return types.SimpleNamespace(name="Debtors USD - FT", insert=lambda **k: None)
+        with mock.patch("frappe.db.exists", return_value=False), \
+                mock.patch("frappe.db.get_value", return_value="Accounts Receivable - FT"), \
+                mock.patch("frappe.get_doc", side_effect=fake_get_doc), \
+                mock.patch("frappe.db.commit"):
+            self._imp()._ensure_currency_account("Customer", "USD")
+        self.assertEqual(captured["account_currency"], "USD")
+        self.assertEqual(captured["account_type"], "Receivable")
+        self.assertEqual(captured["parent_account"], "Accounts Receivable - FT")
+
+
+class TestEmitForexGuards(unittest.TestCase):
+    def _imp(self):
+        imp = PartyOpeningImporter.__new__(PartyOpeningImporter)
+        imp.company, imp.abbr, imp.posting_date = "Frappe Tech", "FT", "2026-04-01"
+        imp._company_currency = lambda: "INR"
+        return imp
+
+    def test_skips_when_no_iso(self):
+        res = ImportResult("Opening Invoice")
+        self._imp()._emit_forex("Customer", "FX", "FX", {"CurrencyISO": ""}, [], set(), res)
+        self.assertEqual(res.created, 0)
+        self.assertTrue(any("couldn't resolve" in w["reason"] for w in res.warnings))
+
+    def test_skips_forex_advance(self):
+        res = ImportResult("Opening Invoice")
+        # A customer credit (Cr) opening is an advance -> not migrated (v1)
+        rec = {"CurrencyISO": "USD", "OpeningBalance": "$1000.00 @ ₹ 83/$ = ₹ 83000.00"}
+        self._imp()._emit_forex("Customer", "FX", "FX", rec, [], set(), res)
+        self.assertEqual(res.created, 0)
+        self.assertTrue(any("advance" in w["reason"] for w in res.warnings))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tally_migrator/tests/test_forex_openings.py
+++ b/tally_migrator/tests/test_forex_openings.py
@@ -47,6 +47,36 @@ class TestCurrencyIsoExtraction(unittest.TestCase):
         self.assertIsNone(by_name["Local Co"].get("CurrencyISO"))   # domestic untouched
 
 
+class TestBillForeignAmount(unittest.TestCase):
+    """A forex-shaped bill carries its foreign amount (base in ``amount``), so the
+    importer can split a forex party bill-by-bill; a plain bill carries foreign 0."""
+
+    def test_forex_and_plain_bills(self):
+        def _bill(nm, ob):
+            return (f'<BILLALLOCATIONS.LIST><NAME>{nm}</NAME><BILLDATE>20260401</BILLDATE>'
+                    f'<ISADVANCE>No</ISADVANCE><OPENINGBALANCE>{ob}</OPENINGBALANCE>'
+                    '</BILLALLOCATIONS.LIST>')
+        xml = (
+            '<ENVELOPE><BODY><IMPORTDATA><REQUESTDATA>'
+            '<TALLYMESSAGE><LEDGER NAME="FX Co"><NAME>FX Co</NAME>'
+            '<PARENT>Sundry Debtors</PARENT>'
+            '<OPENINGBALANCE>-$1000.00 @ ₹ 83/$ = -₹ 83000.00</OPENINGBALANCE>'
+            + _bill("USD-1", "-$600.00 @ ₹ 83/$ = -₹ 49800.00")
+            + '</LEDGER></TALLYMESSAGE>'
+            '<TALLYMESSAGE><LEDGER NAME="Local Co"><NAME>Local Co</NAME>'
+            '<PARENT>Sundry Debtors</PARENT><OPENINGBALANCE>-5000.00</OPENINGBALANCE>'
+            + _bill("INR-1", "-5000.00")
+            + '</LEDGER></TALLYMESSAGE>'
+            '</REQUESTDATA></IMPORTDATA></BODY></ENVELOPE>'
+        )
+        bills = {b.bill_no: b for b in
+                 TallyExtractor(FileTallySource(xml)).extract_bill_allocations()}
+        self.assertEqual(bills["USD-1"].foreign_amount, 600.0)
+        self.assertEqual(bills["USD-1"].amount, 49800.0)          # base after '='
+        self.assertEqual(bills["INR-1"].foreign_amount, 0.0)      # plain bill, no forex
+        self.assertEqual(bills["INR-1"].amount, 5000.0)
+
+
 class TestForexInvoiceDict(unittest.TestCase):
     def _imp(self):
         imp = PartyOpeningImporter.__new__(PartyOpeningImporter)

--- a/tally_migrator/tests/test_forex_openings.py
+++ b/tally_migrator/tests/test_forex_openings.py
@@ -95,14 +95,17 @@ class TestEnsureCurrencyAccount(unittest.TestCase):
         def fake_get_doc(d):
             captured.update(d)
             return types.SimpleNamespace(name="Debtors USD - FT", insert=lambda **k: None)
+        res = ImportResult("Opening Invoice")
         with mock.patch("frappe.db.exists", return_value=False), \
                 mock.patch("frappe.db.get_value", return_value="Accounts Receivable - FT"), \
                 mock.patch("frappe.get_doc", side_effect=fake_get_doc), \
                 mock.patch("frappe.db.commit"):
-            self._imp()._ensure_currency_account("Customer", "USD")
+            self._imp()._ensure_currency_account("Customer", "USD", res)
         self.assertEqual(captured["account_currency"], "USD")
         self.assertEqual(captured["account_type"], "Receivable")
         self.assertEqual(captured["parent_account"], "Accounts Receivable - FT")
+        # The created control account is logged to the manifest so an undo removes it.
+        self.assertIn("Debtors USD - FT", res.created_names)
 
 
 class TestEmitForexGuards(unittest.TestCase):

--- a/tally_migrator/tests/test_item_tax_template.py
+++ b/tally_migrator/tests/test_item_tax_template.py
@@ -1,0 +1,113 @@
+"""
+Phase 3 tests: item GST rate -> India Compliance GST Item Tax Template.
+
+The combined GST rate is read per duty head (IGST == CGST + SGST), so a Cess
+rate can never be mistaken for the GST rate. Each item is then linked to the
+company's seeded template (matched by gst_treatment + gst_rate, not by name);
+a taxable rate with no template warns rather than guessing.
+"""
+import unittest
+from unittest import mock
+
+from tally_migrator.tally.file_source import FileTallySource
+from tally_migrator.erpnext.importers.items import ItemImporter
+from tally_migrator.erpnext.importers import ImportResult
+
+
+def _item_xml(name, rate_rows):
+    rd = "".join(
+        f"<RATEDETAILS.LIST><GSTRATEDUTYHEAD>{h}</GSTRATEDUTYHEAD>"
+        + (f"<GSTRATE>{r}</GSTRATE>" if r is not None else "")
+        + "</RATEDETAILS.LIST>"
+        for h, r in rate_rows)
+    return (f'<TALLYMESSAGE><STOCKITEM NAME="{name}"><NAME>{name}</NAME>'
+            f'<GSTDETAILS.LIST><STATEWISEDETAILS.LIST><STATENAME>Any</STATENAME>'
+            f'{rd}</STATEWISEDETAILS.LIST></GSTDETAILS.LIST></STOCKITEM></TALLYMESSAGE>')
+
+
+class TestGstRateExtraction(unittest.TestCase):
+    def _rates(self, *items):
+        xml = "<ENVELOPE><BODY><IMPORTDATA><REQUESTDATA>" + "".join(items) + \
+              "</REQUESTDATA></IMPORTDATA></BODY></ENVELOPE>"
+        return FileTallySource(xml).item_gst_rates()
+
+    def test_picks_igst_not_cess(self):
+        rates = self._rates(_item_xml("Widget", [
+            ("CGST", " 9"), ("SGST/UTGST", " 9"), ("IGST", " 18"),
+            ("Cess", " 1"),            # must NOT be mistaken for the GST rate
+        ]))
+        self.assertEqual(rates["Widget"], "18")
+
+    def test_falls_back_to_cgst_plus_sgst_when_no_igst(self):
+        rates = self._rates(_item_xml("Gadget", [("CGST", "6"), ("SGST/UTGST", "6")]))
+        self.assertEqual(rates["Gadget"], "12")
+
+    def test_no_rate_for_exempt_item(self):
+        rates = self._rates(_item_xml("Rice", [("IGST", None)]))   # head present, no rate
+        self.assertEqual(rates["Rice"], "")
+
+
+class TestTreatmentLabel(unittest.TestCase):
+    def test_labels(self):
+        L = ItemImporter._gst_treatment_label
+        self.assertEqual(L({"GSTTaxability": "Taxable"}), "Taxable")
+        self.assertEqual(L({"GSTTaxability": "Nil Rated"}), "Nil-Rated")
+        self.assertEqual(L({"GSTTaxability": "Exempt"}), "Exempted")
+        self.assertEqual(L({"GSTTaxability": "Non-GST"}), "Non-GST")
+        self.assertEqual(L({"GstApplicable": "Not Applicable"}), "Non-GST")
+        self.assertEqual(L({"GSTTaxability": ""}), "Taxable")
+        self.assertIsNone(L({"GSTTaxability": "Weird Value"}))
+
+
+class TestTaxTemplateResolution(unittest.TestCase):
+    def _imp(self):
+        imp = ItemImporter(company="Frappe Tech", abbr="FT")
+        imp._india_compliance = True
+        return imp
+
+    def test_resolves_links_and_warns_on_missing(self):
+        imp = self._imp()
+        res = ImportResult("Item")
+        records = [
+            {"_name": "A", "GSTTaxability": "Taxable", "GstRate": "18"},   # -> template
+            {"_name": "B", "GSTTaxability": "Taxable", "GstRate": "3"},    # -> no template, warn
+            {"_name": "C", "GSTTaxability": "Exempt",  "GstRate": ""},     # -> Exempted template
+        ]
+
+        def fake_get_all(doctype, filters=None, **kw):
+            if filters.get("gst_treatment") == "Taxable" and filters.get("gst_rate") == 18:
+                return ["GST 18% - FT"]
+            if filters.get("gst_treatment") == "Exempted":
+                return ["Exempted - FT"]
+            return []
+        with mock.patch("frappe.get_all", side_effect=fake_get_all):
+            imp._resolve_tax_templates(records, res)
+
+        self.assertEqual(imp._tax_templates.get("A"), "GST 18% - FT")
+        self.assertEqual(imp._tax_templates.get("C"), "Exempted - FT")
+        self.assertNotIn("B", imp._tax_templates)
+        self.assertTrue(any(w["name"] == "B" and "3%" in w["reason"] for w in res.warnings))
+
+    def test_no_india_compliance_is_noop(self):
+        imp = ItemImporter(company="Frappe Tech", abbr="FT")
+        imp._india_compliance = False
+        res = ImportResult("Item")
+        imp._resolve_tax_templates([{"_name": "A", "GSTTaxability": "Taxable", "GstRate": "18"}], res)
+        self.assertEqual(imp._tax_templates, {})
+        self.assertEqual(res.warnings, [])
+
+    def test_build_doc_adds_resolved_template(self):
+        imp = self._imp()
+        imp._tax_templates = {"Pen": "GST 18% - FT"}
+        doc = imp.build_doc({"_name": "Pen", "BaseUnits": "Nos", "GSTTaxability": "Taxable"})
+        self.assertEqual(doc["taxes"], [{"item_tax_template": "GST 18% - FT"}])
+
+    def test_build_doc_no_template_no_taxes_key(self):
+        imp = self._imp()
+        imp._tax_templates = {}
+        doc = imp.build_doc({"_name": "Pen", "BaseUnits": "Nos", "GSTTaxability": "Taxable"})
+        self.assertNotIn("taxes", doc)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tally_migrator/tests/test_item_tax_template.py
+++ b/tally_migrator/tests/test_item_tax_template.py
@@ -109,5 +109,21 @@ class TestTaxTemplateResolution(unittest.TestCase):
         self.assertNotIn("taxes", doc)
 
 
+class TestItemUomResolution(unittest.TestCase):
+    """An item must adopt its Tally base unit when a UOM by that name exists (the
+    unit importer created it) - matching the pre-flight resolver - instead of
+    silently defaulting to 'Nos', which would mismatch its price levels / BOM."""
+
+    def test_resolve_uom_order(self):
+        from tally_migrator.tally.mappings import DEFAULT_UOM
+        imp = ItemImporter(company="X", abbr="X", uom_overrides={"Dz": "Dozen"})
+        self.assertEqual(imp._resolve_uom("Dz"), "Dozen")            # override wins
+        with mock.patch("frappe.db.exists", return_value=True):
+            self.assertEqual(imp._resolve_uom("Ream"), "Ream")      # UOM exists -> its name
+        with mock.patch("frappe.db.exists", return_value=False):
+            self.assertEqual(imp._resolve_uom("Zzz"), DEFAULT_UOM)  # unknown -> default
+        self.assertEqual(imp._resolve_uom(""), DEFAULT_UOM)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tally_migrator/tests/test_prices.py
+++ b/tally_migrator/tests/test_prices.py
@@ -1,0 +1,126 @@
+"""
+Phase 4 tests: Tally price levels -> Price List + Item Price + (discount) Pricing Rule.
+
+Per price level the latest dated revision wins; the rate becomes an Item Price on
+a selling Price List named after the level, and any per-level discount becomes a
+Pricing Rule scoped to that price list (for_price_list) so it mirrors Tally's
+"rate then discount" billing.
+"""
+import types
+import unittest
+from unittest import mock
+
+from tally_migrator.tally.file_source import FileTallySource
+from tally_migrator.erpnext.importers.prices import PriceImporter
+from tally_migrator.erpnext.importers import ImportResult
+
+
+class TestPriceLevelExtraction(unittest.TestCase):
+    def test_latest_date_wins_and_slabs_parsed(self):
+        xml = (
+            '<ENVELOPE><BODY><IMPORTDATA><REQUESTDATA><TALLYMESSAGE>'
+            '<STOCKITEM NAME="A4"><NAME>A4</NAME>'
+            '<FULLPRICELIST.LIST><DATE>20250401</DATE><PRICELEVEL>Retail</PRICELEVEL>'
+            '<PRICELEVELLIST.LIST><ENDINGAT> 100 Ream</ENDINGAT><RATE>398.00/Ream</RATE>'
+            '<DISCOUNT> 10</DISCOUNT></PRICELEVELLIST.LIST></FULLPRICELIST.LIST>'
+            '<FULLPRICELIST.LIST><DATE>20260401</DATE><PRICELEVEL>Retail</PRICELEVEL>'
+            '<PRICELEVELLIST.LIST><RATE>420.00/Ream</RATE><DISCOUNT> 12</DISCOUNT>'
+            '</PRICELEVELLIST.LIST></FULLPRICELIST.LIST>'
+            '<FULLPRICELIST.LIST><DATE>20260401</DATE><PRICELEVEL>Wholesale</PRICELEVEL>'
+            '<PRICELEVELLIST.LIST><RATE>360.00/Ream</RATE><DISCOUNT> 15</DISCOUNT>'
+            '</PRICELEVELLIST.LIST></FULLPRICELIST.LIST>'
+            '</STOCKITEM></TALLYMESSAGE></REQUESTDATA></IMPORTDATA></BODY></ENVELOPE>'
+        )
+        levels = {l["level"]: l for l in FileTallySource(xml).item_price_levels()["A4"]}
+        self.assertEqual(set(levels), {"Retail", "Wholesale"})
+        self.assertEqual(levels["Retail"]["rate"], "420.00/Ream")     # latest date, not 398
+        self.assertEqual(levels["Retail"]["discount"], "12")
+        self.assertEqual(levels["Wholesale"]["rate"], "360.00/Ream")
+
+
+class TestParsers(unittest.TestCase):
+    def test_parse_rate(self):
+        self.assertEqual(PriceImporter._parse_rate("398.00/Ream"), (398.0, "Ream"))
+        self.assertEqual(PriceImporter._parse_rate("360.00"), (360.0, ""))
+        self.assertEqual(PriceImporter._parse_rate(""), (None, ""))
+        self.assertEqual(PriceImporter._parse_rate("x/Ream"), (None, ""))
+
+    def test_parse_qty_and_date(self):
+        self.assertEqual(PriceImporter._parse_qty(" 100 Ream"), 100.0)
+        self.assertEqual(PriceImporter._parse_qty(""), 0.0)
+        self.assertEqual(PriceImporter._parse_date("20260401"), "2026-04-01")
+        self.assertEqual(PriceImporter._parse_date("bad"), "")
+
+
+class TestPriceImporter(unittest.TestCase):
+    def _imp(self):
+        with mock.patch("frappe.get_cached_value", return_value="INR"):
+            return PriceImporter("Frappe Tech", "FT")
+
+    def test_creates_price_list_item_price_and_discount_rule(self):
+        imp = self._imp()
+        res = ImportResult("Item Price")
+        created = []
+
+        def fake_get_doc(d):
+            created.append(d)
+            return types.SimpleNamespace(
+                name=d.get("title") or d.get("price_list_name") or "IP-1",
+                insert=lambda **k: None)
+
+        exists_state = {"Price List": False, "Item Price": False, "Pricing Rule": False}
+
+        def fake_exists(dt, filt=None):
+            if dt == "Item":
+                return True
+            if dt == "UOM":
+                return True
+            return exists_state.get(dt, False)
+
+        with mock.patch("frappe.db.exists", side_effect=fake_exists), \
+                mock.patch("frappe.get_doc", side_effect=fake_get_doc), \
+                mock.patch("frappe.db.commit"), \
+                mock.patch("frappe.db.get_value", return_value="Ream"):
+            imp._import_level(res, "A4 Paper Ream", {
+                "level": "Retail", "date": "20260401",
+                "rate": "398.00/Ream", "discount": "10", "ending": " 100 Ream"})
+
+        kinds = [d["doctype"] for d in created]
+        self.assertEqual(kinds, ["Price List", "Item Price", "Pricing Rule"])
+        ip = next(d for d in created if d["doctype"] == "Item Price")
+        self.assertEqual((ip["price_list"], ip["price_list_rate"], ip["uom"], ip["selling"]),
+                         ("Retail", 398.0, "Ream", 1))
+        self.assertEqual(ip["valid_from"], "2026-04-01")
+        pr = next(d for d in created if d["doctype"] == "Pricing Rule")
+        self.assertEqual(pr["for_price_list"], "Retail")
+        self.assertEqual(pr["rate_or_discount"], "Discount Percentage")
+        self.assertEqual(pr["discount_percentage"], 10.0)
+        self.assertNotIn("apply_discount_on_rate", pr)       # would force a Priority
+        self.assertEqual(pr["max_qty"], 100.0)               # ENDINGAT bound carried
+        self.assertEqual(pr["items"], [{"item_code": "A4 Paper Ream"}])
+
+    def test_idempotent_skips_existing(self):
+        imp = self._imp()
+        res = ImportResult("Item Price")
+        created = []
+        with mock.patch("frappe.db.exists", return_value=True), \
+                mock.patch("frappe.get_doc", side_effect=lambda d: created.append(d)), \
+                mock.patch("frappe.db.commit"), \
+                mock.patch("frappe.db.get_value", return_value="Ream"):
+            imp._import_level(res, "A4 Paper Ream", {
+                "level": "Retail", "date": "20260401",
+                "rate": "398.00/Ream", "discount": "10", "ending": ""})
+        # Price List exists (reused), Item Price exists (skipped), Pricing Rule exists (skipped)
+        self.assertEqual(created, [])
+        self.assertEqual(res.skipped, 1)
+
+    def test_no_rate_creates_nothing(self):
+        imp = self._imp()
+        res = ImportResult("Item Price")
+        with mock.patch("frappe.get_doc") as gd:
+            imp._import_level(res, "X", {"level": "Retail", "rate": "", "discount": "5"})
+        gd.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tally_migrator/tests/test_prices.py
+++ b/tally_migrator/tests/test_prices.py
@@ -114,6 +114,35 @@ class TestPriceImporter(unittest.TestCase):
         self.assertEqual(created, [])
         self.assertEqual(res.skipped, 1)
 
+    def test_falls_back_to_stock_uom_when_price_uom_invalid_for_item(self):
+        imp = self._imp()
+        res = ImportResult("Item Price")
+        created = []
+
+        def fake_get_doc(d):
+            created.append(d)
+            return types.SimpleNamespace(name="IP", insert=lambda **k: None)
+
+        def fake_exists(dt, filt=None):
+            if dt == "Item":
+                return True
+            if dt == "UOM Conversion Detail":
+                return False          # 'Ream' is NOT an additional uom of the item
+            if dt in ("Price List", "Item Price"):
+                return False
+            return False
+        with mock.patch("frappe.db.exists", side_effect=fake_exists), \
+                mock.patch("frappe.db.get_value", return_value="Nos"), \
+                mock.patch("frappe.get_doc", side_effect=fake_get_doc), \
+                mock.patch("frappe.db.commit"):
+            imp._import_level(res, "A4 Paper Ream", {
+                "level": "Retail", "date": "20260401",
+                "rate": "398.00/Ream", "discount": "", "ending": ""})
+
+        ip = next(d for d in created if d["doctype"] == "Item Price")
+        self.assertEqual(ip["uom"], "Nos")               # fell back to stock uom, no hard fail
+        self.assertTrue(any("not a unit of item" in w["reason"] for w in res.warnings))
+
     def test_no_rate_creates_nothing(self):
         imp = self._imp()
         res = ImportResult("Item Price")

--- a/tally_migrator/tests/test_prices.py
+++ b/tally_migrator/tests/test_prices.py
@@ -64,17 +64,23 @@ class TestPriceImporter(unittest.TestCase):
 
         def fake_get_doc(d):
             created.append(d)
-            return types.SimpleNamespace(
-                name=d.get("title") or d.get("price_list_name") or "IP-1",
-                insert=lambda **k: None)
+            # A Pricing Rule is autonamed by series (PRLE-####), so its `name` is NOT
+            # its title - mimic that here so the test would catch logging the title as
+            # the (dead) hyperlink target, or keying idempotency on name==title.
+            name = ("PRLE-0001" if d["doctype"] == "Pricing Rule"
+                    else d.get("price_list_name") or "8mc65uqma1")
+            return types.SimpleNamespace(name=name, insert=lambda **k: None)
 
         exists_state = {"Price List": False, "Item Price": False, "Pricing Rule": False}
+        pricing_rule_filters = []
 
         def fake_exists(dt, filt=None):
             if dt == "Item":
                 return True
             if dt == "UOM":
                 return True
+            if dt == "Pricing Rule":
+                pricing_rule_filters.append(filt)
             return exists_state.get(dt, False)
 
         with mock.patch("frappe.db.exists", side_effect=fake_exists), \
@@ -98,6 +104,13 @@ class TestPriceImporter(unittest.TestCase):
         self.assertNotIn("apply_discount_on_rate", pr)       # would force a Priority
         self.assertEqual(pr["max_qty"], 100.0)               # ENDINGAT bound carried
         self.assertEqual(pr["items"], [{"item_code": "A4 Paper Ream"}])
+        # Idempotency must key on the title FIELD, not name (Pricing Rule autonames
+        # by series, so name != title; a bare-title exists() never matches -> dupes).
+        self.assertEqual(pricing_rule_filters, [{"title": "Tally Retail discount - A4 Paper Ream"}])
+        # The logged hyperlink target is the real autonamed doc, not the title, so
+        # the migration-log link resolves (the title is no document's name).
+        self.assertIn("PRLE-0001", res.created_names)
+        self.assertNotIn("Tally Retail discount - A4 Paper Ream", res.created_names)
 
     def test_idempotent_skips_existing(self):
         imp = self._imp()

--- a/tally_migrator/tests/test_uqc.py
+++ b/tally_migrator/tests/test_uqc.py
@@ -1,0 +1,105 @@
+"""
+Phase 1 (UQC) tests.
+
+India Compliance stores the GST Unit Quantity Code globally in
+GST Settings.gst_uom_map (uom -> gst_uom), not per-UOM. UnitImporter maps each
+imported Tally UOM's REPORTINGUQCNAME ("NOS-NUMBERS") to the official GST option
+("NOS (Numbers)"), appending only missing rows. Codes with no official match
+(e.g. Tally's "REM-REAMS") are left unmapped with a warning, never guessed.
+"""
+import types
+import unittest
+from unittest import mock
+
+from tally_migrator.erpnext.importers.units import UnitImporter
+from tally_migrator.erpnext.importers import ImportResult
+
+OPTIONS = "NOS (Numbers)\nKGS (Kilograms)\nBOX (Box)\nDOZ (Dozens)\nPCS (Pieces)\nOTH (Others)"
+
+
+def _code_map():
+    return {o.split("(")[0].strip().upper(): o for o in OPTIONS.splitlines()}
+
+
+class TestUqcMapping(unittest.TestCase):
+    def test_matches_by_code_case_insensitive(self):
+        cm = _code_map()
+        self.assertEqual(UnitImporter._uqc_to_gst_uom("NOS-NUMBERS", cm), "NOS (Numbers)")
+        self.assertEqual(UnitImporter._uqc_to_gst_uom("KGS-KILOGRAMS", cm), "KGS (Kilograms)")
+        self.assertEqual(UnitImporter._uqc_to_gst_uom("box-boxes", cm), "BOX (Box)")
+
+    def test_blank_not_applicable_and_unmatched_return_none(self):
+        cm = _code_map()
+        self.assertIsNone(UnitImporter._uqc_to_gst_uom("REM-REAMS", cm))      # no official code
+        self.assertIsNone(UnitImporter._uqc_to_gst_uom("", cm))
+        self.assertIsNone(UnitImporter._uqc_to_gst_uom("\x04 Not Applicable", cm))
+        self.assertIsNone(UnitImporter._uqc_to_gst_uom("Not Applicable", cm))
+
+    def _fake_settings(self, existing=()):
+        s = types.SimpleNamespace(
+            gst_uom_map=[types.SimpleNamespace(uom=u, gst_uom=g) for u, g in existing],
+            saved=False)
+        s.append = lambda table, row: s.gst_uom_map.append(
+            types.SimpleNamespace(uom=row["uom"], gst_uom=row["gst_uom"]))
+
+        def _save(**kw):
+            s.saved = True
+        s.save = _save
+        return s
+
+    def test_map_uqcs_appends_missing_skips_existing_warns_unmatched(self):
+        imp = UnitImporter("_T Co", "TC")
+        res = ImportResult("UOM")
+        units = [
+            {"_name": "Nos",  "ReportingUQC": "NOS-NUMBERS"},
+            {"_name": "Kg",   "ReportingUQC": "KGS-KILOGRAMS"},
+            {"_name": "Ream", "ReportingUQC": "REM-REAMS"},          # no match -> warn
+            {"_name": "Box",  "ReportingUQC": "\x04 Not Applicable"},  # skipped silently
+            {"_name": "Pcs",  "ReportingUQC": "PCS-PIECES"},          # already mapped -> skip
+        ]
+        settings = self._fake_settings(existing=[("Pcs", "PCS (Pieces)")])
+        meta = types.SimpleNamespace(
+            get_field=lambda f: types.SimpleNamespace(options=OPTIONS))
+        with mock.patch("frappe.db.exists", return_value=True), \
+                mock.patch("frappe.get_meta", return_value=meta), \
+                mock.patch("frappe.get_doc", return_value=settings), \
+                mock.patch("frappe.db.commit"):
+            imp._map_uqcs(units, res)
+
+        mapped = {(r.uom, r.gst_uom) for r in settings.gst_uom_map}
+        self.assertIn(("Nos", "NOS (Numbers)"), mapped)
+        self.assertIn(("Kg", "KGS (Kilograms)"), mapped)
+        self.assertFalse(any(r.uom == "Box" for r in settings.gst_uom_map))      # skipped
+        self.assertEqual(sum(1 for r in settings.gst_uom_map if r.uom == "Pcs"), 1)  # not duped
+        self.assertTrue(any(w["name"] == "Ream" for w in res.warnings))          # warned
+        self.assertTrue(settings.saved)
+
+    def test_no_india_compliance_is_noop(self):
+        imp = UnitImporter("_T Co", "TC")
+        res = ImportResult("UOM")
+        with mock.patch("frappe.db.exists", return_value=False):
+            imp._map_uqcs([{"_name": "Nos", "ReportingUQC": "NOS-NUMBERS"}], res)
+        self.assertEqual(res.warnings, [])
+
+
+class TestUqcExtraction(unittest.TestCase):
+    def test_extraction_reads_latest_reporting_uqc(self):
+        from tally_migrator.tally.file_source import FileTallySource
+        from tally_migrator.tally.extractors import UNIT_FIELDS, UNIT_TAGS
+        # Dated list with two entries; the most recent (last) wins.
+        xml = (
+            '<ENVELOPE><BODY><IMPORTDATA><REQUESTDATA>'
+            '<TALLYMESSAGE><UNIT NAME="Nos"><NAME>Nos</NAME>'
+            '<REPORTINGUQCDETAILS.LIST><APPLICABLEFROM>20200401</APPLICABLEFROM>'
+            '<REPORTINGUQCNAME>OTH-OTHERS</REPORTINGUQCNAME></REPORTINGUQCDETAILS.LIST>'
+            '<REPORTINGUQCDETAILS.LIST><APPLICABLEFROM>20260401</APPLICABLEFROM>'
+            '<REPORTINGUQCNAME>NOS-NUMBERS</REPORTINGUQCNAME></REPORTINGUQCDETAILS.LIST>'
+            '</UNIT></TALLYMESSAGE>'
+            '</REQUESTDATA></IMPORTDATA></BODY></ENVELOPE>'
+        )
+        rows = FileTallySource(xml).get_collection("Unit", UNIT_FIELDS, UNIT_TAGS)
+        self.assertEqual(rows[0]["ReportingUQC"], "NOS-NUMBERS")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Counts the new price-level and BOM tags as imported in the coverage report, fixes item UOM resolution so price levels and BOM components match, and the Pricing Rule idempotency + migration-log link.

Top of the stack; merge last.