### PR TITLE
Always offer Undo This Migration, drop the site-config opt-in

### DIFF
--- a/tally_migrator/migration/rollback.py
+++ b/tally_migrator/migration/rollback.py
@@ -6,11 +6,12 @@ This is a self-contained, optional feature. It reads the authoritative
 deletes precisely those documents - nothing scoped by company, so a company's
 manually-entered data and any *other* migration's data are never touched.
 
-Isolation (so the feature can be hidden or removed cleanly)
-----------------------------------------------------------
-* Hidden at runtime by the ``tally_migrator_enable_rollback`` site-config flag -
-  :func:`is_enabled` gates both this endpoint and the form button, so even a
-  crafted API call cannot reach the deletion logic when the flag is off.
+Isolation (so the feature can be removed cleanly)
+-------------------------------------------------
+* The action is always available to a user with a migration role, but it is
+  still safe by construction: it only deletes the documents in a run's
+  ``created_records`` manifest, re-checks the company name server-side, and keeps
+  anything since re-linked by later activity.
 * All server logic lives in this one module; the heavy per-revert detail lives in
   the bolt-on ``Tally Migration Revert`` doctype. The import pipeline
   (``master_migrator.py`` / ``api.py``) is never touched.
@@ -49,23 +50,6 @@ _LABEL_DOCTYPE = {
     "Opening Balances": "Journal Entry",
     "Opening Stock": "Stock Reconciliation",
 }
-
-
-def is_enabled() -> bool:
-    """True only when the site explicitly opts in via site_config.
-
-    Defaults to off: rollback permanently deletes posted documents, so it ships
-    dormant and a site owner turns it on deliberately
-    (``bench set-config tally_migrator_enable_rollback 1``).
-    """
-    return bool(frappe.conf.get("tally_migrator_enable_rollback"))
-
-
-@frappe.whitelist()
-def rollback_enabled() -> bool:
-    """Client-facing read of the feature flag, so the form button renders only
-    when rollback is switched on for this site."""
-    return is_enabled()
 
 
 def _protected_doctypes() -> set:
@@ -221,9 +205,6 @@ def revert_migration(log_name: str, company_confirmation: str):
     watch progress.
     """
     frappe.only_for(ALLOWED_ROLES)
-    if not is_enabled():
-        frappe.throw(_("Migration rollback is not enabled on this site."),
-                     frappe.PermissionError)
 
     log = frappe.get_doc("Tally Migration Log", log_name)
 

--- a/tally_migrator/tally_migration/doctype/tally_migration_log/tally_migration_log.js
+++ b/tally_migrator/tally_migration/doctype/tally_migration_log/tally_migration_log.js
@@ -1035,9 +1035,8 @@ function rerun(frm) {
  * ---------------------------------------------------------------------------
  * Self-contained: this whole block plus the single tally_rollback_attach(frm)
  * call in refresh() is the entire client footprint. Delete both to remove the
- * feature's UI. The button only appears when the server flag
- * tally_migrator_enable_rollback is on (checked via rollback_enabled), so the
- * code is inert on sites that haven't opted in.
+ * feature's UI. The button appears on any saved migration that created records
+ * and has not already been reverted.
  * ========================================================================== */
 function tally_rollback_attach(frm) {
 	if (frm.is_new()) return;
@@ -1052,20 +1051,13 @@ function tally_rollback_attach(frm) {
 	const total = Object.values(created).reduce((n, names) => n + (names || []).length, 0);
 	if (!total || frm.doc.status === "Reverted") return;
 
-	// Server-authoritative gate: render the button only when the site opts in.
-	frappe.call({
-		method: "tally_migrator.migration.rollback.rollback_enabled",
-		callback: (r) => {
-			if (!r.message) return;
-			// Tucked inside the standard "Actions" menu rather than a loud
-			// standalone button - it's a rare, destructive operation.
-			frm.add_custom_button(
-				__("Undo This Migration"),
-				() => tally_rollback_confirm(frm, total),
-				__("Actions")
-			);
-		},
-	});
+	// Tucked inside the standard "Actions" menu rather than a loud standalone
+	// button - it's a rare, destructive operation.
+	frm.add_custom_button(
+		__("Undo This Migration"),
+		() => tally_rollback_confirm(frm, total),
+		__("Actions")
+	);
 }
 
 function tally_rollback_confirm(frm, total) {

--- a/tally_migrator/tests/test_rollback.py
+++ b/tally_migrator/tests/test_rollback.py
@@ -122,14 +122,6 @@ class TestDeleteOneSafety(unittest.TestCase):
         self.assertIn("SI-9", reason)                          # kept + reported, not deleted
 
 
-class TestFeatureFlag(unittest.TestCase):
-    def test_is_enabled_reads_site_config(self):
-        with mock.patch.object(rollback.frappe, "conf", {"tally_migrator_enable_rollback": 1}):
-            self.assertTrue(rollback.is_enabled())
-        with mock.patch.object(rollback.frappe, "conf", {}):
-            self.assertFalse(rollback.is_enabled())
-
-
 class TestRevertGuards(unittest.TestCase):
     """revert_migration must refuse before deleting anything."""
 
@@ -139,22 +131,15 @@ class TestRevertGuards(unittest.TestCase):
         self._only_for.start()
         self.addCleanup(self._only_for.stop)
 
-    def test_disabled_flag_raises_permission_error(self):
-        with mock.patch.object(rollback, "is_enabled", return_value=False):
-            with self.assertRaises(frappe.PermissionError):
-                rollback.revert_migration("TML-0001", "Frappe Tech")
-
     def test_company_mismatch_aborts(self):
         log = mock.Mock(company="Frappe Tech", status="Completed", created_records="{}")
-        with mock.patch.object(rollback, "is_enabled", return_value=True), \
-             mock.patch.object(rollback.frappe, "get_doc", return_value=log):
+        with mock.patch.object(rollback.frappe, "get_doc", return_value=log):
             with self.assertRaises(frappe.exceptions.ValidationError):
                 rollback.revert_migration("TML-0001", "Wrong Co")
 
     def test_already_reverted_aborts(self):
         log = mock.Mock(company="Frappe Tech", status="Reverted", created_records="{}")
-        with mock.patch.object(rollback, "is_enabled", return_value=True), \
-             mock.patch.object(rollback.frappe, "get_doc", return_value=log):
+        with mock.patch.object(rollback.frappe, "get_doc", return_value=log):
             with self.assertRaises(frappe.exceptions.ValidationError):
                 rollback.revert_migration("TML-0001", "Frappe Tech")
 


### PR DESCRIPTION
Rollback was gated behind the `tally_migrator_enable_rollback` site-config flag, so the "Undo This Migration" button never appeared unless a site owner set the flag (and on managed Frappe Cloud that meant editing Site Config). This removes the gate so the option is always available to a user with a migration role.

## Changes
- `rollback.py` - removed `is_enabled()`, the whitelisted `rollback_enabled()`, and the server-side flag check in `revert_migration`.
- `tally_migration_log.js` - the button is added directly (no server round-trip to read the flag) whenever a saved migration created records and is not already "Reverted".
- `test_rollback.py` - dropped the feature-flag tests, kept the real safety guards.

## Why it is still safe
The opt-in added friction, not safety. Undo still:
- deletes only the documents in that run's `created_records` manifest (nothing scoped by company, nothing a human or another migration created),
- re-checks the typed company name server-side,
- keeps anything since re-linked by later activity and lists it,
- is restricted to migration roles.

Full suite: 382 tests pass.