### PR TITLE
Harden migration revert: lifecycle, safety, and audit fixes

### DIFF
--- a/tally_migrator/migration/rollback.py
+++ b/tally_migrator/migration/rollback.py
@@ -26,9 +26,24 @@ Supplier, UOM, Item Group) a migration creates. We reuse its safety helpers
 
 import frappe
 from frappe import _
-from frappe.utils import get_link_to_form
+from frappe.utils import get_link_to_form, now_datetime, time_diff_in_seconds
 
 from tally_migrator.api import ALLOWED_ROLES
+
+# The background job's own timeout (see ``enqueue`` below). A revert still flagged
+# Queued/In Progress for longer than this, plus a margin, cannot still be running -
+# the worker was killed, timed out, or OOM'd before its ``except`` could mark it
+# Failed - so a fresh revert is allowed to supersede it (see ``revert_migration``).
+_JOB_TIMEOUT = 3600
+_STALE_AFTER = _JOB_TIMEOUT + 600
+
+# Commit completed deletions in batches rather than holding the whole revert in one
+# transaction (ERPNext's Transaction Deletion Record does the same): a large
+# migration would otherwise hold row locks for the entire run and risk lock-wait
+# timeouts, and a crash near the end would roll back everything. Each record is
+# atomic via its own savepoint, so committing between records is safe; a crash mid-run
+# leaves a prefix deleted, and a re-run is idempotent (already-gone records are skipped).
+_COMMIT_BATCH = 50
 
 # Maps a legacy log's bare-string entries (older runs stored just a name per
 # pipeline label) to a doctype. New runs store ``{name, doctype}`` and don't need
@@ -131,6 +146,23 @@ def _deletion_order(created: dict) -> list[dict]:
 # can be deleted. They are scoped by voucher_no, so only this voucher's entries go.
 _LEDGER_DOCTYPES = ("GL Entry", "Payment Ledger Entry", "Stock Ledger Entry")
 
+# Derived records ERPNext auto-generates around a master - recompute queues and
+# unit-conversion rows - that link the master but are NOT business data and never
+# enter our manifest. They block an unforced delete (e.g. a Repost Item Valuation
+# queued when the opening Stock Reconciliation is cancelled keeps every item alive;
+# a UOM Conversion Factor for an imported compound unit keeps its UOMs alive). We
+# clear only the rows tied to the master being removed - the same records ERPNext's
+# Transaction Deletion Record purges - so deletion is not blocked by our own
+# import's side effects. Maps master doctype -> (side-effect doctype, field) pairs.
+_SIDE_EFFECTS = {
+    "Item": (("Repost Item Valuation", "item_code"),),
+    "UOM": (("UOM Conversion Factor", "from_uom"),
+            ("UOM Conversion Factor", "to_uom"),
+            # India Compliance's GST Settings child rows the UQC step writes; absent
+            # on a site without india_compliance, so the purge is table-guarded.
+            ("GST UOM Map", "uom")),
+}
+
 
 def _drop_queued_messages(mark: int) -> None:
     """Discard framework messages queued since ``mark``.
@@ -143,6 +175,81 @@ def _drop_queued_messages(mark: int) -> None:
     log = getattr(frappe.local, "message_log", None)
     if isinstance(log, list) and len(log) > mark:
         del log[mark:]
+
+
+def _safe_savepoint_rollback(savepoint: str) -> None:
+    """Roll back this record's savepoint; fall back to a full rollback if it's gone.
+
+    The per-record safety guarantee rests on this savepoint. It is normally present,
+    but a doctype's ``on_cancel`` handler *could* commit mid-record (some stock/repost
+    paths do), which silently discards the savepoint and makes ``ROLLBACK TO SAVEPOINT``
+    raise. Rather than let that abort the whole revert, fall back to rolling back the
+    open transaction - safe because the loop batch-commits completed records, so this
+    discards at most the current partial record and any others since the last commit,
+    all of which a re-run will simply redo (deletion is idempotent)."""
+    try:
+        frappe.db.rollback(save_point=savepoint)
+    except Exception:
+        frappe.db.rollback()
+
+
+def _purge_party_links(party_type: str, party: str) -> list[dict]:
+    """Release the Address/Contact/Bank Account records that keep a party undeletable.
+
+    A party's contact info is created alongside it (from Tally party data), is not
+    in the manifest, and is linked by a Dynamic Link row (a child of the Address /
+    Contact) that keeps the party undeletable - ERPNext does not cascade it.
+
+    Critical safety rule: an Address/Contact can be linked to *several* parties, and
+    because the link lives on the address side, ``delete_doc`` would NOT refuse to
+    delete a shared one - it would succeed and silently strip the record from a
+    party this migration never touched. So we only delete a record that links to no
+    party other than this one; if it is shared, we drop just this party's own link
+    row, leaving the record intact for the others. Either way the party can then be
+    removed. Deleting an unshared record stays unforced, so if some *other* document
+    (e.g. a later user invoice's ``customer_address``) still references it, the
+    delete raises, propagates to the caller, and the party is kept and reported
+    rather than the record being force-removed.
+
+    Returns the business records it deleted (``[{doctype, name}]``) so the caller can
+    list them in the revert report - these are real Tally data (a party's addresses,
+    contacts, bank accounts), not silent plumbing, so the audit must show them.
+    """
+    purged: list[dict] = []
+    for linked_dt in ("Contact", "Address"):
+        names = frappe.get_all(
+            "Dynamic Link",
+            filters={"link_doctype": party_type, "link_name": party,
+                     "parenttype": linked_dt},
+            pluck="parent")
+        for nm in set(names):
+            if not frappe.db.exists(linked_dt, nm):
+                continue
+            links = frappe.get_all(
+                "Dynamic Link",
+                filters={"parent": nm, "parenttype": linked_dt},
+                fields=["link_doctype", "link_name"])
+            shared = any((l.link_doctype, l.link_name) != (party_type, party)
+                         for l in links)
+            if shared:
+                # Keep the record for the other party; remove only our own link so
+                # this party stops being referenced and can be deleted.
+                frappe.db.delete("Dynamic Link",
+                                 {"parent": nm, "parenttype": linked_dt,
+                                  "link_doctype": party_type, "link_name": party})
+            else:
+                frappe.delete_doc(linked_dt, nm, ignore_permissions=True)
+                purged.append({"doctype": linked_dt, "name": nm})
+    # A Bank Account created for the party (from Tally bank details) links it via its
+    # own party_type/party fields and blocks the delete too. It belongs to exactly one
+    # party (not a shared child-link record), so there is no shared-record case here.
+    for nm in frappe.get_all("Bank Account",
+                             filters={"party_type": party_type, "party": party},
+                             pluck="name"):
+        if frappe.db.exists("Bank Account", nm):
+            frappe.delete_doc("Bank Account", nm, ignore_permissions=True)
+            purged.append({"doctype": "Bank Account", "name": nm})
+    return purged
 
 
 def _delete_one(row: dict, protected: set) -> str | None:
@@ -171,6 +278,21 @@ def _delete_one(row: dict, protected: set) -> str | None:
             doc.cancel()
             for ledger in _LEDGER_DOCTYPES:
                 frappe.db.delete(ledger, {"voucher_no": name})
+        # Clear ERPNext's derived side-effect rows for this master (Repost Item
+        # Valuation, UOM Conversion Factor, GST UOM Map) before the delete, so they
+        # don't block it. Scoped to this master's name, inside the savepoint, so a
+        # failure here rolls back with the rest of this record's attempt. Guarded by
+        # table_exists so a doctype an optional app owns (GST UOM Map) is simply
+        # skipped when that app is not installed.
+        for se_doctype, field in _SIDE_EFFECTS.get(doctype, ()):
+            if frappe.db.table_exists(se_doctype):
+                frappe.db.delete(se_doctype, {field: name})
+        # A party's Address/Contact (created from Tally party data) is dynamically
+        # linked and blocks its delete; ERPNext never cascades them. Remove them so
+        # the party can go - unforced, so one shared with another party stays and the
+        # party is reported kept rather than corrupting the shared record.
+        if doctype in ("Customer", "Supplier"):
+            row["_purged"] = _purge_party_links(doctype, name)
         # force=False is deliberate: it keeps frappe's link-existence check, which is
         # the ONLY thing protecting a master (Item/Customer/Supplier/Cost Center -
         # whose on_trash does NOT guard against linked transactions) from being deleted
@@ -183,7 +305,7 @@ def _delete_one(row: dict, protected: set) -> str | None:
         frappe.delete_doc(doctype, name, ignore_permissions=True)
         return None
     except Exception as exc:
-        frappe.db.rollback(save_point=savepoint)
+        _safe_savepoint_rollback(savepoint)
         # Almost always a link from activity created *after* the migration (a later
         # invoice/payment, stock still in a warehouse). Keep the record and tell the
         # user why, rather than forcing the delete and corrupting their books.
@@ -215,14 +337,27 @@ def revert_migration(log_name: str, company_confirmation: str):
         frappe.throw(_("This migration has already been reverted."))
 
     # One revert at a time per log - block a double-click, pointing at the run
-    # already in flight (the same guard ERPNext's TDR uses).
+    # already in flight (the same guard ERPNext's TDR uses). But a revert flagged
+    # Queued/In Progress past the job timeout cannot still be running (the worker was
+    # killed/timed out before its except could mark it Failed); mark such a corpse
+    # Failed and let this new revert proceed, so a crash never wedges the feature.
     in_flight = frappe.get_all(
         "Tally Migration Revert",
         filters={"migration_log": log.name, "status": ("in", ["Queued", "In Progress"])},
-        pluck="name")
-    if in_flight:
+        fields=["name", "modified"])
+    live = []
+    for r in in_flight:
+        if time_diff_in_seconds(now_datetime(), r.modified) > _STALE_AFTER:
+            frappe.db.set_value("Tally Migration Revert", r.name, {
+                "status": "Failed",
+                "error_log": _("Marked Failed: the background job exceeded its timeout "
+                               "without completing (worker killed, timed out, or OOM)."),
+            })
+        else:
+            live.append(r.name)
+    if live:
         frappe.throw(_("An undo is already in progress for this migration: {0}.").format(
-            get_link_to_form("Tally Migration Revert", in_flight[0])))
+            get_link_to_form("Tally Migration Revert", live[0])))
 
     created = frappe.parse_json(log.created_records or "{}")
     if not _deletion_order(created):
@@ -238,10 +373,34 @@ def revert_migration(log_name: str, company_confirmation: str):
     frappe.enqueue(
         "tally_migrator.migration.rollback.run_revert",
         queue="long",
-        timeout=3600,
+        timeout=_JOB_TIMEOUT,
         revert_name=revert.name,
     )
     return {"revert": revert.name}
+
+
+@frappe.whitelist()
+def preview_revert(log_name: str) -> dict:
+    """Read-only dry summary of what an undo *would* delete, for the confirm dialog.
+
+    Reads the manifest and breaks the would-delete documents down by doctype, so the
+    user sees ``12 Item, 5 Customer, 3 Journal Entry...`` before arming the action,
+    not just a bare total. Deletes nothing and writes nothing - the heavy cancel/delete
+    work only happens in the enqueued run after confirmation.
+    """
+    frappe.only_for(ALLOWED_ROLES)
+    log = frappe.get_doc("Tally Migration Log", log_name)
+    rows = _deletion_order(frappe.parse_json(log.created_records or "{}"))
+    by_doctype: dict[str, int] = {}
+    for r in rows:
+        by_doctype[r["doctype"]] = by_doctype.get(r["doctype"], 0) + 1
+    return {
+        "total": len(rows),
+        "company": log.company,
+        "already_reverted": log.status == "Reverted",
+        # Most-numerous doctype first, so the dialog leads with the bulk of the work.
+        "by_doctype": dict(sorted(by_doctype.items(), key=lambda kv: -kv[1])),
+    }
 
 
 def run_revert(revert_name: str) -> None:
@@ -259,20 +418,75 @@ def run_revert(revert_name: str) -> None:
         rows = _deletion_order(frappe.parse_json(log.created_records or "{}"))
         protected = _protected_doctypes()
 
+        # Records absent before we start (manifest entries this run never actually
+        # created, or ones a user removed earlier) are reported honestly as "already
+        # absent" rather than counted among this undo's deletions. Snapshot now,
+        # before the loop, so a record that genuinely cascades with a parent we delete
+        # this run is NOT mistaken for one that was already gone.
+        pre_absent = {id(r) for r in rows
+                      if not frappe.db.exists(r["doctype"], r["name"])}
+
+        # Delete in dependency order, then retry whatever was kept. A record can be
+        # blocked on the first pass by a sibling removed later in the same run (a UOM
+        # still held by an Item deleted afterwards; a party still linked by a voucher
+        # processed later). Repeat until a pass deletes nothing new, so only records
+        # genuinely re-linked by post-migration activity are left kept. Completed
+        # deletions are committed in batches (see _COMMIT_BATCH) to release locks and
+        # bound how much a crash can roll back.
+        done_ids: set[int] = set()
+        since_commit = 0
+        pending = list(rows)
+        while pending:
+            still, progressed = [], False
+            for row in pending:
+                reason = _delete_one(row, protected)
+                if reason:
+                    row["_reason"] = reason
+                    still.append(row)
+                else:
+                    progressed = True
+                    done_ids.add(id(row))
+                    since_commit += 1
+                    if since_commit >= _COMMIT_BATCH:
+                        frappe.db.commit()
+                        since_commit = 0
+            pending = still
+            if not progressed:
+                break
+        frappe.db.commit()  # flush the final, partial batch of deletions
+
         deleted = kept = 0
         for row in rows:
-            reason = _delete_one(row, protected)
-            revert.append("records", {
-                "deleted": 0 if reason else 1,
-                "reference_doctype": row["doctype"],
-                "reference_name": row["name"],
-                "entity": row["label"],
-                "reason": reason or "",
-            })
-            if reason:
-                kept += 1
-            else:
+            rid = id(row)
+            # Checked before done_ids: a record absent at the start also returns "no
+            # reason" from _delete_one (nothing to delete), so it lands in done_ids too -
+            # but it must be reported as already-absent, not counted as a deletion.
+            if rid in pre_absent:
+                revert.append("records", {
+                    "deleted": 0, "reference_doctype": row["doctype"],
+                    "reference_name": row["name"], "entity": row["label"],
+                    "reason": _("Already absent before this undo - not created by this "
+                                "run, or removed earlier.")})
+            elif rid in done_ids:
+                revert.append("records", {
+                    "deleted": 1, "reference_doctype": row["doctype"],
+                    "reference_name": row["name"], "entity": row["label"], "reason": ""})
                 deleted += 1
+                # Party-attached business data (addresses, contacts, bank accounts)
+                # removed alongside the party - listed so the audit shows them too.
+                for p in row.get("_purged", []):
+                    revert.append("records", {
+                        "deleted": 1, "reference_doctype": p["doctype"],
+                        "reference_name": p["name"],
+                        "entity": _("{0} (linked to {1})").format(row["label"], row["name"]),
+                        "reason": ""})
+                    deleted += 1
+            else:
+                revert.append("records", {
+                    "deleted": 0, "reference_doctype": row["doctype"],
+                    "reference_name": row["name"], "entity": row["label"],
+                    "reason": row.get("_reason", "")})
+                kept += 1
 
         revert.deleted_count = deleted
         revert.kept_count = kept
@@ -280,8 +494,11 @@ def run_revert(revert_name: str) -> None:
         revert.save(ignore_permissions=True)
 
         # The one honest edit to the log: its status must tell the truth everywhere
-        # (list view, form, filters). The import path never sets this value.
-        log.db_set("status", "Reverted")
+        # (list view, form, filters). The import path never sets this value. A clean
+        # undo is the terminal "Reverted" (the action is then withdrawn); one that kept
+        # records becomes "Reverted with Errors", which deliberately stays re-runnable
+        # so the user can retry after fixing the cause (a re-run is idempotent).
+        log.db_set("status", "Reverted with Errors" if kept else "Reverted")
         frappe.db.commit()
     except Exception:
         frappe.db.rollback()
@@ -291,6 +508,9 @@ def run_revert(revert_name: str) -> None:
         frappe.db.commit()
         raise
     finally:
+        # Notify the user who launched the undo (the revert's owner) - in a background
+        # job frappe.session.user is the worker's, not theirs, so it would not reach
+        # the form they are watching.
         frappe.publish_realtime(
             "tally_revert_updated", {"revert": revert_name},
-            user=frappe.session.user)
+            user=frappe.db.get_value("Tally Migration Revert", revert_name, "owner"))

--- a/tally_migrator/tally_migration/doctype/tally_migration_log/tally_migration_log.js
+++ b/tally_migrator/tally_migration/doctype/tally_migration_log/tally_migration_log.js
@@ -1049,12 +1049,16 @@ function tally_rollback_attach(frm) {
 		created = {};
 	}
 	const total = Object.values(created).reduce((n, names) => n + (names || []).length, 0);
+	// A clean undo flips the log to "Reverted" and the action is withdrawn. One that
+	// kept records becomes "Reverted with Errors" and stays offered, relabelled, so the
+	// user can retry after fixing the cause (the re-run is idempotent server-side).
 	if (!total || frm.doc.status === "Reverted") return;
+	const retry = frm.doc.status === "Reverted with Errors";
 
 	// Tucked inside the standard "Actions" menu rather than a loud standalone
 	// button - it's a rare, destructive operation.
 	frm.add_custom_button(
-		__("Undo This Migration"),
+		retry ? __("Retry Undo (records remained)") : __("Undo This Migration"),
 		() => tally_rollback_confirm(frm, total),
 		__("Actions")
 	);
@@ -1062,6 +1066,26 @@ function tally_rollback_attach(frm) {
 
 function tally_rollback_confirm(frm, total) {
 	const company = frm.doc.company || "";
+	// Pull a server-authoritative breakdown of what will be deleted, so the dialog
+	// shows "12 Item, 5 Customer, 3 Journal Entry..." rather than a bare count. Purely
+	// read-only; nothing is deleted until the user confirms below.
+	frappe.call({
+		method: "tally_migrator.migration.rollback.preview_revert",
+		args: { log_name: frm.doc.name },
+		callback: (r) => tally_rollback_dialog(frm, company, r.message || { total }),
+	});
+}
+
+function tally_rollback_dialog(frm, company, preview) {
+	const total = preview.total || 0;
+	const breakdown = Object.entries(preview.by_doctype || {})
+		.map(
+			([dt, n]) =>
+				`<li><strong>${n}</strong> ${frappe.utils.escape_html(
+					__(dt)
+				)}${n === 1 ? "" : "s"}</li>`
+		)
+		.join("");
 	const d = new frappe.ui.Dialog({
 		title: __("Undo This Migration"),
 		fields: [
@@ -1072,6 +1096,11 @@ function tally_rollback_confirm(frm, total) {
 						<p>This will <strong>permanently delete</strong> the
 						<strong>${total}</strong> ERPNext document(s) this import created -
 						including any opening entries, invoices and stock reconciliations.</p>
+						${
+							breakdown
+								? `<ul style="padding-left:18px; columns:2; color:var(--text-muted); margin-bottom:8px;">${breakdown}</ul>`
+								: ""
+						}
 						<ul style="padding-left:18px; color:var(--text-muted);">
 							<li>Submitted entries are cancelled first, then deleted.</li>
 							<li>Anything now linked to activity created <em>after</em> this

--- a/tally_migrator/tally_migration/doctype/tally_migration_log/tally_migration_log.json
+++ b/tally_migrator/tally_migration/doctype/tally_migration_log/tally_migration_log.json
@@ -97,7 +97,7 @@
    "fieldname": "status",
    "fieldtype": "Select",
    "label": "Status",
-   "options": "\nRunning\nCompleted\nCompleted with Errors\nFailed\nReverted",
+   "options": "\nRunning\nCompleted\nCompleted with Errors\nFailed\nReverted\nReverted with Errors",
    "default": "Running",
    "in_list_view": 1,
    "in_standard_filter": 1,

--- a/tally_migrator/tests/test_rollback.py
+++ b/tally_migrator/tests/test_rollback.py
@@ -95,6 +95,11 @@ class TestDeleteOneSafety(unittest.TestCase):
             mock.patch.object(rollback.frappe.db, "exists", return_value=True),
             mock.patch.object(rollback.frappe.db, "savepoint", lambda *a, **k: None),
             mock.patch.object(rollback.frappe.db, "rollback", lambda *a, **k: None),
+            # Neutralise the pre-delete steps so the test isolates the link-check:
+            # no side-effect tables, no party links to purge.
+            mock.patch.object(rollback.frappe.db, "table_exists", return_value=False),
+            mock.patch.object(rollback.frappe.db, "delete", lambda *a, **k: None),
+            mock.patch.object(rollback.frappe, "get_all", return_value=[]),
             mock.patch.object(rollback.frappe, "get_doc",
                               return_value=mock.Mock(docstatus=0)),
             mock.patch.object(rollback.frappe, "delete_doc", side_effect=fake_delete_doc),
@@ -122,6 +127,78 @@ class TestDeleteOneSafety(unittest.TestCase):
         self.assertIn("SI-9", reason)                          # kept + reported, not deleted
 
 
+class TestPurgePartyLinks(unittest.TestCase):
+    """_purge_party_links must never strip a record shared with another party, and
+    must report the business records it does delete so the audit can list them."""
+
+    def _run(self, dynamic_links, link_rows_by_parent, bank_accounts):
+        """Drive _purge_party_links against a fake Dynamic Link / Bank Account store.
+
+        ``dynamic_links`` -> the parents linked to OUR party per linked_dt query;
+        ``link_rows_by_parent`` -> every link row on a given parent (to detect sharing);
+        ``bank_accounts`` -> names returned for the Bank Account query.
+        """
+        deleted, dl_deletes = [], []
+
+        def fake_get_all(doctype, filters=None, pluck=None, fields=None):
+            if doctype == "Dynamic Link" and "link_name" in (filters or {}):
+                return list(dynamic_links.get(filters["parenttype"], []))
+            if doctype == "Dynamic Link":  # all links on a parent (share check)
+                return [frappe._dict(r) for r in link_rows_by_parent.get(filters["parent"], [])]
+            if doctype == "Bank Account":
+                return list(bank_accounts)
+            return []
+
+        def fake_db_delete(doctype, filters):
+            dl_deletes.append((doctype, filters))
+
+        patches = [
+            mock.patch.object(rollback.frappe, "get_all", side_effect=fake_get_all),
+            mock.patch.object(rollback.frappe.db, "exists", return_value=True),
+            mock.patch.object(rollback.frappe.db, "delete", side_effect=fake_db_delete),
+            mock.patch.object(rollback.frappe, "delete_doc",
+                              side_effect=lambda dt, nm, **k: deleted.append((dt, nm))),
+        ]
+        for p in patches:
+            p.start()
+        self.addCleanup(lambda: [p.stop() for p in patches])
+        purged = rollback._purge_party_links("Customer", "ACME")
+        return purged, deleted, dl_deletes
+
+    def test_unshared_records_deleted_and_reported(self):
+        purged, deleted, dl_deletes = self._run(
+            dynamic_links={"Address": ["ADDR-1"], "Contact": ["CON-1"]},
+            link_rows_by_parent={
+                "ADDR-1": [{"link_doctype": "Customer", "link_name": "ACME"}],
+                "CON-1": [{"link_doctype": "Customer", "link_name": "ACME"}],
+            },
+            bank_accounts=["ACME - HDFC"],
+        )
+        self.assertIn(("Address", "ADDR-1"), deleted)
+        self.assertIn(("Contact", "CON-1"), deleted)
+        self.assertIn(("Bank Account", "ACME - HDFC"), deleted)
+        self.assertEqual(dl_deletes, [])  # nothing shared -> no link-row surgery
+        # All three reported so the revert audit can list them.
+        self.assertEqual(len(purged), 3)
+
+    def test_shared_address_is_not_deleted_only_unlinked(self):
+        purged, deleted, dl_deletes = self._run(
+            dynamic_links={"Address": ["SHARED"], "Contact": []},
+            link_rows_by_parent={
+                "SHARED": [
+                    {"link_doctype": "Customer", "link_name": "ACME"},
+                    {"link_doctype": "Customer", "link_name": "OTHER"},  # another party!
+                ],
+            },
+            bank_accounts=[],
+        )
+        # The shared address must survive; only OUR link row is removed.
+        self.assertNotIn(("Address", "SHARED"), deleted)
+        self.assertEqual(len(dl_deletes), 1)
+        self.assertEqual(dl_deletes[0][1]["link_name"], "ACME")
+        self.assertEqual(purged, [])  # nothing actually deleted -> nothing to report
+
+
 class TestRevertGuards(unittest.TestCase):
     """revert_migration must refuse before deleting anything."""
 
@@ -142,6 +219,50 @@ class TestRevertGuards(unittest.TestCase):
         with mock.patch.object(rollback.frappe, "get_doc", return_value=log):
             with self.assertRaises(frappe.exceptions.ValidationError):
                 rollback.revert_migration("TML-0001", "Frappe Tech")
+
+    @staticmethod
+    def _log_get_doc(log):
+        """get_doc that returns our fake log for the migration log, but delegates
+        everything else (e.g. the internal System Settings read in now_datetime) to
+        the real implementation - patching it globally would cache a Mock and crash."""
+        real = rollback.frappe.get_doc
+
+        def _gd(doctype, *a, **k):
+            return log if doctype == "Tally Migration Log" else real(doctype, *a, **k)
+
+        return _gd
+
+    def test_reverted_with_errors_is_rerunnable(self):
+        # A partial revert ("Reverted with Errors") must NOT be treated as already
+        # reverted - the user has to be able to retry after fixing the cause.
+        log = mock.Mock(company="Frappe Tech", status="Reverted with Errors",
+                        name="TML-1", created_records='{"Items": [{"name": "W", "doctype": "Item"}]}')
+        new_revert = mock.Mock()
+        with mock.patch.object(rollback.frappe, "get_doc", side_effect=self._log_get_doc(log)), \
+             mock.patch.object(rollback.frappe, "get_all", return_value=[]), \
+             mock.patch.object(rollback.frappe, "new_doc", return_value=new_revert), \
+             mock.patch.object(rollback.frappe.db, "commit", lambda *a, **k: None), \
+             mock.patch.object(rollback.frappe, "enqueue", lambda *a, **k: None):
+            rollback.revert_migration("TML-1", "Frappe Tech")
+            self.assertTrue(new_revert.insert.called)   # proceeded to queue a revert
+
+    def test_stale_in_flight_is_superseded(self):
+        # An In Progress revert older than the job timeout is a corpse: mark it Failed
+        # and allow a new one, so a killed worker never wedges the feature forever.
+        log = mock.Mock(company="Frappe Tech", status="Reverted with Errors",
+                        name="TML-1", created_records='{"Items": [{"name": "W", "doctype": "Item"}]}')
+        stale = frappe._dict(name="REV-OLD", modified="2000-01-01 00:00:00")
+        set_calls = {}
+        with mock.patch.object(rollback.frappe, "get_doc", side_effect=self._log_get_doc(log)), \
+             mock.patch.object(rollback.frappe, "get_all", return_value=[stale]), \
+             mock.patch.object(rollback.frappe, "new_doc", return_value=mock.Mock()), \
+             mock.patch.object(rollback.frappe.db, "commit", lambda *a, **k: None), \
+             mock.patch.object(rollback.frappe, "enqueue", lambda *a, **k: None), \
+             mock.patch.object(rollback.frappe.db, "set_value",
+                               side_effect=lambda dt, nm, vals: set_calls.update({nm: vals})):
+            rollback.revert_migration("TML-1", "Frappe Tech")
+        # The corpse was flagged Failed rather than blocking the new revert.
+        self.assertEqual(set_calls.get("REV-OLD", {}).get("status"), "Failed")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

A critical review of the "Undo This Migration" (revert) feature surfaced lifecycle and safety issues, the most important being that a revert which kept any record left the migration in a **dead-end state** — the log flipped to terminal `Reverted`, hiding the Undo button and blocking any retry. This PR fixes the full set.

## Lifecycle
- **Re-runnable partial reverts** — a revert that keeps records now sets the new `Reverted with Errors` status (not terminal `Reverted`), so the user can retry after fixing the cause. Both the JS button and `revert_migration` honour it. A re-run is idempotent.
- **No more stuck "In Progress"** — a killed/timed-out worker leaves a corpse; `revert_migration` now marks any in-flight revert older than the job timeout `Failed` and lets a new one proceed.
- **Batch commits** — completed deletions commit every 50 records instead of one giant transaction, bounding lock duration and crash rollback (mirrors ERPNext's Transaction Deletion Record).

## Safety
- **Shared Address/Contact never hard-deleted** — a record linked to another party keeps that link; only this party's own link row is dropped. (A party→address link lives on the address side, so `delete_doc` would otherwise silently strip a shared record from another party.)
- **Side-effect purges** (Repost Item Valuation, UOM Conversion Factor, GST UOM Map) are scoped to the master and run inside the per-record savepoint, so they only persist when the master itself is deleted.
- **Defensive savepoint rollback** — falls back to a full rollback if an `on_cancel` handler commits mid-record, rather than aborting the whole run.
- The master delete itself stays `force=False`: anything re-linked by post-migration activity is kept and reported, never force-deleted.

## Audit / UX
- Party-attached records removed with a party (addresses, contacts, bank accounts) are now **listed in the revert report** instead of vanishing silently.
- Records absent before the undo are reported **"already absent"**, not counted as deletions.
- New read-only `preview_revert` powers a per-doctype breakdown in the confirm dialog; the completion realtime event targets the revert's owner.

## Testing
- Added `TestPurgePartyLinks` (shared vs unshared) and re-runnable / stale-recovery guard tests.
- Full app suite: **386 tests pass.**
- Live end-to-end on a dev site verified both paths (clean → `Reverted`, kept → `Reverted with Errors`), purge reporting, and already-absent handling; all fixtures cleaned up.