### PR TITLE
Derive account type from Tally group nature flags, not a constant default

### DIFF
--- a/tally_migrator/migration/account_mapping.py
+++ b/tally_migrator/migration/account_mapping.py
@@ -5,10 +5,11 @@ COA extraction already computes (root_type / account_type / parent / opening
 balance) plus two derived signals the user actually cares about before they
 commit:
 
-  * **inferred** - the ledger's group had no reserved Tally ancestor, so its
-    nature was *defaulted* (``FALLBACK_NATURE``) rather than read from Tally's
-    own group spec. These are the rows worth eyeballing; everything else mapped
-    by Tally's documented groups and is high-confidence.
+  * **inferred** - the ledger's group is not a named standard Tally group, so its
+    type was either *derived* from the group's own nature flags (ISREVENUE /
+    ISDEEMEDPOSITIVE) or, failing that, left *unknown* (shown as "--"). These are
+    the rows worth eyeballing; everything else mapped by Tally's documented groups
+    and is high-confidence.
   * **the Temporary Opening plug** - the residual across the *whole* opening
     trial balance (accounts + customers + suppliers). ERPNext absorbs any
     imbalance into 'Temporary Opening', so a large plug is the single most
@@ -25,7 +26,7 @@ from __future__ import annotations
 from tally_migrator.tally.extractors import (
     TallyExtractor, GROUP_FIELDS, LEDGER_FIELDS, LEDGER_TAGS,
 )
-from tally_migrator.tally.resolver import LedgerResolver, FALLBACK_NATURE
+from tally_migrator.tally.resolver import LedgerResolver
 
 # ERPNext's canonical root-type order - how an accountant reads a trial balance.
 _ROOT_ORDER = ["Asset", "Liability", "Equity", "Income", "Expense"]
@@ -54,10 +55,11 @@ def account_mapping(source) -> dict:
     by_root: dict[str, list[dict]] = {r: [] for r in _ROOT_ORDER}
     inferred: list[dict] = []
     for a in ledger_accounts:
-        # The resolver returns the module-level FALLBACK_NATURE object *by
-        # identity* when no reserved ancestor was found - a clean, derived
-        # "we had to guess" signal with no hand-maintained list behind it.
-        is_inferred = resolver.group_nature(a.parent) is FALLBACK_NATURE
+        # source: "reserved" = mapped by a named standard group (high confidence);
+        # "derived" = inferred from the group's own Tally nature flags; "unknown" =
+        # neither, so the type is unresolved and shown as "--" for the user to set.
+        source = resolver.group_nature(a.parent).get("source")
+        is_inferred = source != "reserved"
         row = {
             "name": a.name,
             "root_type": a.root_type,
@@ -66,6 +68,7 @@ def account_mapping(source) -> dict:
             "amount": round(a.opening_balance, 2),
             "dr_cr": a.opening_dr_cr,
             "inferred": is_inferred,
+            "uncertain": source == "unknown",
         }
         by_root.setdefault(a.root_type, []).append(row)
         if is_inferred:

--- a/tally_migrator/tally/extractors.py
+++ b/tally_migrator/tally/extractors.py
@@ -34,7 +34,10 @@ ITEM_FIELDS = [
 ]
 
 GODOWN_FIELDS     = ["Name", "Parent", "Address"]
-GROUP_FIELDS      = ["Name", "Parent"]
+# IsRevenue / IsDeemedPositive are Tally's own group nature flags (tags ISREVENUE /
+# ISDEEMEDPOSITIVE); the resolver derives a root_type from them for custom groups
+# with no reserved ancestor (see LedgerResolver.group_nature).
+GROUP_FIELDS      = ["Name", "Parent", "IsRevenue", "IsDeemedPositive"]
 COSTCENTRE_FIELDS = ["Name", "Parent"]
 STOCKGROUP_FIELDS = ["Name", "Parent"]
 UNIT_FIELDS       = [

--- a/tally_migrator/tally/resolver.py
+++ b/tally_migrator/tally/resolver.py
@@ -16,15 +16,45 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .mappings import ASSET, CREDITOR_ROOTS, DEBTOR_ROOTS, classify_group
+from .mappings import (
+    ASSET,
+    CREDITOR_ROOTS,
+    DEBTOR_ROOTS,
+    EXPENSE,
+    INCOME,
+    LIABILITY,
+    classify_group,
+)
 
 CUSTOMER = "customer"
 SUPPLIER = "supplier"
 ACCOUNT = "account"
 
-# Used when a ledger's group chain has no reserved ancestor (shouldn't happen in
-# real Tally, where every group descends from a primary group).
+# Last resort when a ledger's group has neither a reserved ancestor nor its own
+# nature flags. We still create the account (ERPNext needs *some* root_type), but
+# default it to Asset and mark the nature "unknown" so the preview shows it as
+# unresolved ("--") rather than asserting a type we don't actually know.
 FALLBACK_NATURE = {"root": ASSET, "account_type": "", "erpnext_group": "Current Assets"}
+
+# Tally stamps every group - reserved or custom - with two booleans that together
+# *are* its nature, and which Tally itself uses to place the group on the balance
+# sheet vs the P&L and to set its debit/credit side:
+#   ISREVENUE        - Yes = P&L (Income/Expense), No = Balance Sheet (Asset/Liability)
+#   ISDEEMEDPOSITIVE - Yes = debit-nature (Asset/Expense), No = credit-nature
+# This 2x2 recovers the ERPNext root_type with no name list - the derive-don't-
+# enumerate path - for any custom group with no reserved ancestor. Equity is not
+# distinguishable from Liability by these flags (Capital is credit-nature balance
+# sheet too), but equity lives under the reserved "Capital Account" group, which the
+# reserved map already classifies, so a *custom* group resolving here is a liability.
+# Income/Expense leaves carry the matching ERPNext account_type; Asset/Liability
+# leaves stay ordinary ("").
+_DERIVED_NATURE = {
+    #  (is_revenue, is_deemed_positive)
+    (False, True):  {"root": ASSET,     "account_type": "",                "erpnext_group": "Current Assets"},
+    (False, False): {"root": LIABILITY, "account_type": "",                "erpnext_group": "Current Liabilities"},
+    (True,  True):  {"root": EXPENSE,   "account_type": "Expense Account", "erpnext_group": "Indirect Expenses"},
+    (True,  False): {"root": INCOME,    "account_type": "Income Account",  "erpnext_group": "Indirect Income"},
+}
 
 
 @dataclass
@@ -38,6 +68,15 @@ class LedgerTarget:
 class LedgerResolver:
     def __init__(self, groups: list[dict], ledgers: list[dict] | None = None):
         self._parent_of = {g["_name"]: g.get("Parent", "").strip() for g in groups}
+        # Each group's own Tally nature flags, normalised to "yes"/"no"/"" - used to
+        # derive a root_type when no reserved ancestor exists (see group_nature).
+        self._flags_of = {
+            g["_name"]: (
+                (g.get("IsRevenue") or "").strip().lower(),
+                (g.get("IsDeemedPositive") or "").strip().lower(),
+            )
+            for g in groups
+        }
         self._debtor_groups = self._descendants(DEBTOR_ROOTS)
         self._creditor_groups = self._descendants(CREDITOR_ROOTS)
         self._by_name: dict[str, LedgerTarget] = {}
@@ -56,16 +95,30 @@ class LedgerResolver:
         return target.kind if target else None
 
     def group_nature(self, group_name: str) -> dict:
-        """Classify a group by walking up to its nearest reserved ancestor."""
+        """Classify a group, most-confident signal first. The returned dict carries a
+        ``source``: ``reserved`` (a named standard Tally group - high confidence),
+        ``derived`` (inferred from the group's own ISREVENUE/ISDEEMEDPOSITIVE flags),
+        or ``unknown`` (neither available - defaults to Asset, flagged for review)."""
+        # 1. nearest reserved ancestor - a named standard group, high confidence.
         seen: set[str] = set()
         cur = group_name
         while cur and cur not in seen:
             seen.add(cur)
             cls = classify_group(cur)
             if cls:
-                return cls
+                return {**cls, "source": "reserved"}
             cur = self._parent_of.get(cur, "")
-        return FALLBACK_NATURE
+        # 2. derive from the nearest ancestor carrying Tally's own nature flags.
+        seen, cur = set(), group_name
+        while cur and cur not in seen:
+            seen.add(cur)
+            rev, pos = self._flags_of.get(cur, ("", ""))
+            if rev in ("yes", "no") and pos in ("yes", "no"):
+                nature = _DERIVED_NATURE[(rev == "yes", pos == "yes")]
+                return {**nature, "source": "derived"}
+            cur = self._parent_of.get(cur, "")
+        # 3. genuinely unresolved.
+        return {**FALLBACK_NATURE, "source": "unknown"}
 
     # ── Internals ────────────────────────────────────────────────────────────
 

--- a/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
+++ b/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
@@ -1505,8 +1505,12 @@ class TallyMigratorPage {
 			r.amount
 				? `<span style="white-space:nowrap;">${fmt(r.amount)} <span class="text-muted">${esc(r.dr_cr)}</span></span>`
 				: `<span class="text-muted">0</span>`;
+		// "--" when the type is genuinely unresolved (no standard group and no Tally
+		// nature flags); otherwise the derived/standard root type (+ account type).
 		const classifiedAs = (r) =>
-			esc(r.root_type) + (r.account_type ? ` · ${esc(r.account_type)}` : "");
+			r.uncertain
+				? `<span class="text-muted">--</span>`
+				: esc(r.root_type) + (r.account_type ? ` · ${esc(r.account_type)}` : "");
 
 		// ── Summary cards ──────────────────────────────────────────────────────
 		// Same card language as Step 3: regular-black number, status carried by a
@@ -1542,7 +1546,7 @@ class TallyMigratorPage {
 					inferred ? "please check" : "none",
 					inferred ? BLUE_BG : GRAY_BG,
 					inferred
-						? "These ledgers sit under a custom Tally group with no standard ancestor, so we defaulted their account type. Open the list below to confirm each one is right."
+						? "These ledgers sit under a custom Tally group, so we inferred each type from the group's own nature. Open the list below to confirm - any shown as \"--\" we couldn't determine."
 						: ""
 				)}
 				${plugCard}
@@ -1566,7 +1570,7 @@ class TallyMigratorPage {
 				.join("");
 			$("#review-exceptions").html(`
 				<div style="margin:0; background:var(--blue-100, #edf6fd); border:1px solid var(--blue-200, #e3f1fd); border-radius:8px; padding:12px 14px;">
-					${TallyMigratorPage.iconRow("info", `<strong>${fmt(inferred)} account${inferred === 1 ? "" : "s"} we inferred - please confirm.</strong> These ledgers sit under a custom Tally group with no standard ancestor, so we defaulted their type. Only you know if that's right - it's easy to fix the group in Tally and re-upload.`)}
+					${TallyMigratorPage.iconRow("info", `<strong>${fmt(inferred)} account${inferred === 1 ? "" : "s"} we inferred - please confirm.</strong> These ledgers sit under a custom Tally group, so we inferred each type from the group's own nature (income/expense/asset/liability). A type shown as "--" is one we couldn't determine. Confirm these, or fix the group in Tally and re-upload.`)}
 					<div style="margin-top:10px; border:1px solid var(--border-color, #e0e6ed); border-radius:6px; background:var(--card-bg, #fff);">
 						<table class="table table-condensed" style="margin:0; font-size:13px; table-layout:fixed;">
 							${REVIEW_COLGROUP}

--- a/tally_migrator/tests/test_coa.py
+++ b/tally_migrator/tests/test_coa.py
@@ -79,6 +79,65 @@ class TestResolver(unittest.TestCase):
         self.assertEqual(self.r.kind_of("Acme Corp"), CUSTOMER)
 
 
+def _gf(name, parent, is_revenue, is_deemed_positive):
+    """A group carrying Tally's own nature flags (ISREVENUE / ISDEEMEDPOSITIVE)."""
+    return {"_name": name, "Parent": parent,
+            "IsRevenue": is_revenue, "IsDeemedPositive": is_deemed_positive}
+
+
+class TestDerivedNature(unittest.TestCase):
+    """A custom group with no reserved ancestor must derive its root_type from its
+    own ISREVENUE/ISDEEMEDPOSITIVE flags, not blindly default to Asset."""
+
+    # Top-level custom groups (empty parent) renamed away from Tally's reserved
+    # names, exactly like the Bbb.xml fixture - so only their flags reveal the nature.
+    GROUPS = [
+        _gf("Trade Debtors", "", "No", "Yes"),       # balance-sheet, debit  → Asset
+        _gf("Trade Creditors", "", "No", "No"),      # balance-sheet, credit → Liability
+        _gf("Operating Income", "", "Yes", "No"),    # P&L, credit           → Income
+        _gf("Office Expenses", "", "Yes", "Yes"),    # P&L, debit            → Expense
+        _gf("Branch Office", "Office Expenses", "", ""),  # no own flags → inherit parent
+        _g("Mystery Group", ""),                     # no flags, no ancestor → unknown
+    ]
+
+    def setUp(self):
+        self.r = LedgerResolver(self.GROUPS, [])
+
+    def test_credit_balance_sheet_is_liability(self):
+        n = self.r.group_nature("Trade Creditors")
+        self.assertEqual(n["root"], "Liability")
+        self.assertEqual(n["source"], "derived")
+
+    def test_debit_balance_sheet_is_asset(self):
+        self.assertEqual(self.r.group_nature("Trade Debtors")["root"], "Asset")
+
+    def test_credit_pnl_is_income(self):
+        n = self.r.group_nature("Operating Income")
+        self.assertEqual(n["root"], "Income")
+        self.assertEqual(n["account_type"], "Income Account")
+
+    def test_debit_pnl_is_expense(self):
+        n = self.r.group_nature("Office Expenses")
+        self.assertEqual(n["root"], "Expense")
+        self.assertEqual(n["account_type"], "Expense Account")
+
+    def test_flags_inherited_from_parent(self):
+        # "Branch Office" carries no flags of its own; it must walk up to its parent.
+        self.assertEqual(self.r.group_nature("Branch Office")["root"], "Expense")
+
+    def test_unresolvable_is_unknown_defaulting_to_asset(self):
+        n = self.r.group_nature("Mystery Group")
+        self.assertEqual(n["source"], "unknown")
+        self.assertEqual(n["root"], "Asset")  # still creatable, but flagged "--" in UI
+
+    def test_reserved_still_wins_over_flags(self):
+        # A reserved group must classify as reserved even though it also has flags.
+        r = LedgerResolver([_gf("Bank Accounts", "Primary", "No", "Yes")], [])
+        n = r.group_nature("Bank Accounts")
+        self.assertEqual(n["source"], "reserved")
+        self.assertEqual(n["account_type"], "Bank")
+
+
 class TestBuildCOA(unittest.TestCase):
     def setUp(self):
         self.coa = TallyExtractor(_Src(GROUPS, LEDGERS, CENTRES)).extract_coa()


### PR DESCRIPTION
## Summary

A ledger under a *custom* Tally group with no reserved ancestor was defaulted to **Asset** and shown that way in the Step-4 preview — misleading, and wrong for most real ledgers. On a sample file (`Bbb.xml`), **13 of 15** inferred rows were mis-typed: income, payables, and expenses all displayed as Asset.

Tally stamps every group — reserved or custom — with `ISREVENUE` and `ISDEEMEDPOSITIVE`, which together *are* its nature (P&L vs balance sheet, debit vs credit). The resolver now derives the ERPNext `root_type` from these flags when no reserved ancestor exists, walking up the parent chain for inheritance. This is the **derive-don't-enumerate** path — no name lists.

## Changes
- `resolver.group_nature()` returns a `source`: **reserved** (named standard group, high confidence) | **derived** (from the group's own flags) | **unknown** (neither).
- The 2×2 covers all roots: No/Yes→Asset, No/No→Liability, Yes/Yes→Expense, Yes/No→Income. Income/Expense leaves get their ERPNext `account_type`; Equity stays via the reserved Capital Account map (flags can't distinguish it from Liability, and custom equity groups don't occur in practice).
- Extractor pulls the two flags (`GROUP_FIELDS`).
- Genuinely unresolvable ledgers (no flags, no reserved ancestor) are marked **unknown**: still created as Asset so the account exists, but the preview shows **`--`** instead of asserting a type. Banner copy updated to "inferred from the group's nature."

## Verified on Bbb.xml
The 15 formerly all-Asset rows now resolve to **Expense ×5, Liability ×7, Income ×1, Asset ×2, none uncertain** — exactly the manual 2×2.

## Tests
Added `TestDerivedNature` (each quadrant, parent-chain inheritance, unknown→`--`, reserved-wins). Full suite **393 pass**.