### PR TITLE
Derive party groups from Tally and split opening stock per godown

### DIFF
--- a/tally_migrator/erpnext/importers/openings.py
+++ b/tally_migrator/erpnext/importers/openings.py
@@ -918,98 +918,20 @@ class StockOpeningImporter:
             result.add_error("Opening Stock", "no warehouse found to hold opening stock")
             return result
 
-        # Aggregate by item_code: a masters export can list the same Stock Item more
-        # than once (Tally names are unique, so duplicate tags are the same item), and
-        # all opening stock lands in one warehouse - so two rows for the same item
-        # would trip ERPNext's "Same item and warehouse combination should be unique"
-        # and fail the whole document. Keep one row per item; on a genuine quantity
-        # conflict keep the larger and warn rather than silently picking one.
-        by_code: dict[str, dict] = {}
+        # Aggregate by (item_code, warehouse): a masters export can list the same
+        # Stock Item more than once (Tally names are unique, so duplicate tags are
+        # the same item) and two rows for the same item+warehouse would trip
+        # ERPNext's "Same item and warehouse combination should be unique" and fail
+        # the whole document. Keep one row per item+warehouse; on a genuine quantity
+        # conflict keep the larger and warn. The warehouse key (not item alone) lets
+        # an item legitimately carry opening stock in several godowns.
+        by_key: dict[tuple, dict] = {}
         for it in items:
-            raw_qty = it.get("OpeningBalance")
-            qty = TallyExtractor._parse_quantity(raw_qty)
-            if qty < 0:
-                # Tally can carry a negative opening quantity (e.g. oversold stock);
-                # an 'Opening Stock' reconciliation cannot hold a negative qty and
-                # would fail the whole document. Drop this line with a warning rather
-                # than silently or fatally.
-                result.add_warning(
-                    it["_name"],
-                    f"opening stock not posted - Tally reports a negative opening "
-                    f"quantity '{raw_qty}'. ERPNext opening stock cannot be negative; "
-                    "review the item in Tally and set its opening stock manually.")
-                continue
-            if qty == 0:
-                # A non-empty cell that parses to zero is a real opening quantity we
-                # failed to read (e.g. an unexpected format) - surface it instead of
-                # dropping the item's opening stock silently.
-                if str(raw_qty or "").strip():
-                    result.add_warning(
-                        it["_name"],
-                        f"opening stock not posted - could not read quantity "
-                        f"'{raw_qty}'. Set this item's opening stock manually.")
-                continue
-            # Valuation: prefer the opening rate (unit-suffixed, e.g. "1.00/Nos"), then
-            # the value Tally already computed (OpeningValue ÷ qty - sign is direction,
-            # so abs), then the item's standard cost. _to_float can't read the unit
-            # suffix, hence _parse_rate.
-            opening_rate = TallyExtractor._parse_rate(it.get("OpeningRate"))
-            opening_value = abs(BaseImporter._to_float(it.get("OpeningValue")))
-            rate = opening_rate
-            if rate == 0 and opening_value:
-                rate = opening_value / qty
-            if rate == 0:
-                rate = TallyExtractor._parse_rate(it.get("StandardCost"))
-            # Item Master Rule 1: when Tally gives BOTH an opening rate and value they
-            # must satisfy value = qty x rate (Tally derives one from the other). A
-            # divergence beyond rounding means the source is internally inconsistent;
-            # we post using the opening rate, but flag that the posted value will not
-            # match Tally's recorded value rather than letting it diverge silently.
-            if opening_rate and opening_value:
-                expected = qty * opening_rate
-                if abs(opening_value - expected) > max(1.0, 0.01 * expected):
-                    result.add_warning(
-                        it["_name"],
-                        f"opening stock value does not reconcile - Tally reports a "
-                        f"value of {opening_value:,.2f}, but quantity x rate is "
-                        f"{qty:g} x {opening_rate:g} = {expected:,.2f}. Posted using "
-                        "the opening rate; verify this item's opening stock in Tally.")
-
-            code = safe_item_code(it["_name"])
-            prev = by_code.get(code)
-            if prev is not None:
-                if abs(prev["qty"] - qty) > 1e-9:
-                    result.add_warning(
-                        it["_name"],
-                        f"item appears more than once in the export with different "
-                        f"opening quantities ({prev['qty']:g} vs {qty:g}); kept the "
-                        f"larger. Verify the item's opening stock in Tally.")
-                    if qty <= prev["qty"]:
-                        continue
-                else:
-                    continue  # exact duplicate tag - same item exported twice
-            row = {
-                "item_code": code,
-                "warehouse": warehouse,
-                "qty": qty,
-                "valuation_rate": rate,
-            }
-            if rate == 0:
-                # ERPNext rejects a positive opening qty at a zero rate
-                # ("Valuation Rate required for Item …") unless the row explicitly
-                # allows it. Tally itself carries no value for these items, so we
-                # post the quantity faithfully at zero value rather than blocking
-                # the whole reconciliation. One warning per item, with identical
-                # text - the log groups same-reason rows into a single line.
-                row["allow_zero_valuation_rate"] = 1
-                result.add_warning(
-                    it["_name"],
-                    "opening stock posted with a zero valuation rate - Tally carries "
-                    "no opening rate, value or standard cost for this item, so its "
-                    "opening stock has no book value. Set a valuation rate in ERPNext "
-                    "if it should carry value.")
-            by_code[code] = row
-        rows = list(by_code.values())
+            for wh, raw_qty, raw_rate, raw_value in self._placements(it, warehouse):
+                self._add_opening_row(
+                    by_key, it["_name"], wh, raw_qty, raw_rate, raw_value,
+                    it.get("StandardCost"), result)
+        rows = list(by_key.values())
         if not rows:
             return result  # no opening stock to post
 
@@ -1031,6 +953,144 @@ class StockOpeningImporter:
             result.add_error("Opening Stock", exc)
             frappe.db.rollback()
         return result
+
+    def _placements(self, it: dict, default_wh: str) -> list[tuple]:
+        """Where this item's opening stock lands → list of
+        ``(warehouse, raw_qty, raw_rate, raw_value)`` buckets fed to
+        :meth:`_add_opening_row`.
+
+        - No godown-wise detail (``GodownOpenings`` empty, e.g. a live client or an
+          older export) → one bucket at the default warehouse using the item-level
+          OpeningBalance/Rate/Value, i.e. exactly the legacy behaviour.
+        - Godown-wise detail present → one bucket per resolved warehouse. Several
+          godowns that map to the same warehouse (e.g. both fall back to the default
+          because they weren't migrated) are summed, so nothing is lost and the rows
+          stay unique. A warehouse fed by a single godown keeps that godown's raw
+          rate (preserving the unit-suffixed rate and the value/rate cross-check);
+          a summed bucket derives its rate from value÷qty.
+        """
+        godowns = it.get("GodownOpenings") or []
+        if not godowns:
+            return [(default_wh, it.get("OpeningBalance"),
+                     it.get("OpeningRate"), it.get("OpeningValue"))]
+        buckets: dict[str, list] = {}
+        for g in godowns:
+            wh = self._warehouse_for_godown(g.get("godown", ""), default_wh)
+            buckets.setdefault(wh, []).append(g)
+        placements: list[tuple] = []
+        for wh, gs in buckets.items():
+            if len(gs) == 1:
+                g = gs[0]
+                placements.append((wh, g.get("qty"), g.get("rate"), g.get("value")))
+            else:
+                qsum = sum(TallyExtractor._parse_quantity(g.get("qty")) for g in gs)
+                vsum = sum(abs(BaseImporter._to_float(g.get("value"))) for g in gs)
+                placements.append((wh, str(qsum), "", str(vsum)))
+        return placements
+
+    def _warehouse_for_godown(self, godown: str, default_wh: str) -> str:
+        """Map a Tally godown name to its migrated ERPNext warehouse
+        (``"<Godown> - <ABBR>"``), falling back to the default warehouse when that
+        godown was not migrated (e.g. Tally's implicit "Main Location")."""
+        g = (godown or "").strip()
+        if g:
+            cand = company_scoped(g, self.abbr)
+            if frappe.db.exists(
+                    "Warehouse", {"name": cand, "is_group": 0, "company": self.company}):
+                return cand
+        return default_wh
+
+    def _add_opening_row(self, by_key: dict, name: str, warehouse: str, raw_qty,
+                         raw_rate, raw_value, raw_std_cost, result: ImportResult) -> None:
+        """Build and dedupe one opening-stock row for ``name`` at ``warehouse``.
+
+        Carries the full per-row treatment (negative/unreadable-quantity drops, the
+        rate cascade, the value/rate cross-check, the zero-rate allowance, and the
+        item+warehouse de-duplication), so both the legacy single-warehouse path and
+        the per-godown path share identical behaviour."""
+        qty = TallyExtractor._parse_quantity(raw_qty)
+        if qty < 0:
+            # Tally can carry a negative opening quantity (e.g. oversold stock);
+            # an 'Opening Stock' reconciliation cannot hold a negative qty and
+            # would fail the whole document. Drop this line with a warning rather
+            # than silently or fatally.
+            result.add_warning(
+                name,
+                f"opening stock not posted - Tally reports a negative opening "
+                f"quantity '{raw_qty}'. ERPNext opening stock cannot be negative; "
+                "review the item in Tally and set its opening stock manually.")
+            return
+        if qty == 0:
+            # A non-empty cell that parses to zero is a real opening quantity we
+            # failed to read (e.g. an unexpected format) - surface it instead of
+            # dropping the item's opening stock silently.
+            if str(raw_qty or "").strip():
+                result.add_warning(
+                    name,
+                    f"opening stock not posted - could not read quantity "
+                    f"'{raw_qty}'. Set this item's opening stock manually.")
+            return
+        # Valuation: prefer the opening rate (unit-suffixed, e.g. "1.00/Nos"), then
+        # the value Tally already computed (OpeningValue ÷ qty - sign is direction,
+        # so abs), then the item's standard cost. _to_float can't read the unit
+        # suffix, hence _parse_rate.
+        opening_rate = TallyExtractor._parse_rate(raw_rate)
+        opening_value = abs(BaseImporter._to_float(raw_value))
+        rate = opening_rate
+        if rate == 0 and opening_value:
+            rate = opening_value / qty
+        if rate == 0:
+            rate = TallyExtractor._parse_rate(raw_std_cost)
+        # Item Master Rule 1: when Tally gives BOTH an opening rate and value they
+        # must satisfy value = qty x rate (Tally derives one from the other). A
+        # divergence beyond rounding means the source is internally inconsistent;
+        # we post using the opening rate, but flag that the posted value will not
+        # match Tally's recorded value rather than letting it diverge silently.
+        if opening_rate and opening_value:
+            expected = qty * opening_rate
+            if abs(opening_value - expected) > max(1.0, 0.01 * expected):
+                result.add_warning(
+                    name,
+                    f"opening stock value does not reconcile - Tally reports a "
+                    f"value of {opening_value:,.2f}, but quantity x rate is "
+                    f"{qty:g} x {opening_rate:g} = {expected:,.2f}. Posted using "
+                    "the opening rate; verify this item's opening stock in Tally.")
+
+        code = safe_item_code(name)
+        key = (code, warehouse)
+        prev = by_key.get(key)
+        if prev is not None:
+            if abs(prev["qty"] - qty) > 1e-9:
+                result.add_warning(
+                    name,
+                    f"item appears more than once in the export with different "
+                    f"opening quantities ({prev['qty']:g} vs {qty:g}); kept the "
+                    f"larger. Verify the item's opening stock in Tally.")
+                if qty <= prev["qty"]:
+                    return
+            else:
+                return  # exact duplicate tag - same item exported twice
+        row = {
+            "item_code": code,
+            "warehouse": warehouse,
+            "qty": qty,
+            "valuation_rate": rate,
+        }
+        if rate == 0:
+            # ERPNext rejects a positive opening qty at a zero rate
+            # ("Valuation Rate required for Item …") unless the row explicitly
+            # allows it. Tally itself carries no value for these items, so we
+            # post the quantity faithfully at zero value rather than blocking
+            # the whole reconciliation. One warning per item, with identical
+            # text - the log groups same-reason rows into a single line.
+            row["allow_zero_valuation_rate"] = 1
+            result.add_warning(
+                name,
+                "opening stock posted with a zero valuation rate - Tally carries "
+                "no opening rate, value or standard cost for this item, so its "
+                "opening stock has no book value. Set a valuation rate in ERPNext "
+                "if it should carry value.")
+        by_key[key] = row
 
     def _existing_opening_stock(self) -> bool:
         """True when a non-cancelled Opening Stock reconciliation exists for the company."""

--- a/tally_migrator/erpnext/importers/party.py
+++ b/tally_migrator/erpnext/importers/party.py
@@ -32,6 +32,65 @@ from .banks import _ensure_bank, _insert_bank_account
 class PartyImporter(BaseImporter):
     """Shared behaviour for Customers and Suppliers: billing address + payment terms."""
 
+    # ── Party group derivation (set by each subclass) ──────────────────────────
+    # ERPNext stores a party's group in a separate doctype (Customer Group /
+    # Supplier Group). Tally states the group on the ledger itself (its PARENT,
+    # e.g. "Trade Debtors - Domestic"), so we recreate that group as a leaf under
+    # the standard root and assign it - mirroring how ItemImporter recreates Item
+    # Groups from an item's Parent. A blank/uncreatable group falls back to the
+    # standard default, so a party is never left without a (valid) group.
+    group_doctype: str = ""        # "Customer Group" / "Supplier Group"
+    group_name_field: str = ""     # "customer_group_name" / "supplier_group_name"
+    group_parent_field: str = ""   # "parent_customer_group" / "parent_supplier_group"
+    group_root: str = ""           # standard root group to nest new leaves under
+    default_group: str = ""        # fallback when Tally carries no usable group
+
+    def before_run(self, records: list[dict], result: "ImportResult") -> None:
+        self._ensure_party_groups(
+            {(r.get("Parent") or "").strip() for r in records}, result)
+
+    def _ensure_party_groups(self, names: set, result: "ImportResult") -> None:
+        """Create any missing party groups (as leaves under the standard root).
+
+        Best-effort and non-fatal: a group that can't be created just means those
+        parties fall back to ``default_group`` (recorded as a warning so the lost
+        grouping is visible), never a failed party. Mirrors
+        ``ItemImporter._ensure_item_groups``: created groups are NOT added to the
+        run's manifest, exactly like Item Groups, so they are not company-scoped
+        and a revert leaves shared masters untouched."""
+        if not self.group_doctype:
+            return
+        for name in names:
+            if not name or name == self.default_group:
+                continue
+            if frappe.db.exists(self.group_doctype, name):
+                continue
+            try:
+                doc = frappe.new_doc(self.group_doctype)
+                doc.set(self.group_name_field, name)
+                # A party group must be a leaf - ERPNext rejects assigning a group
+                # node to a party - so create it flat under the standard root.
+                doc.set(self.group_parent_field, self.group_root)
+                doc.is_group = 0
+                doc.insert(ignore_permissions=True)
+                frappe.db.commit()
+            except Exception as exc:
+                frappe.db.rollback()
+                frappe.log_error(
+                    "Tally Migrator", f"{self.group_doctype} creation failed: {name}: {exc}")
+                result.add_warning(
+                    name,
+                    f"{self.group_doctype.lower()} '{name}' not created; parties in it "
+                    f"fall back to '{self.default_group}': {exc}")
+
+    def _resolve_group(self, record: dict) -> str:
+        """The party's ERPNext group: its Tally PARENT when that group exists (it was
+        created in ``before_run``), else the standard default."""
+        name = (record.get("Parent") or "").strip()
+        if name and self.group_doctype and frappe.db.exists(self.group_doctype, name):
+            return name
+        return self.default_group
+
     def after_insert(self, name: str, record: dict, result: "ImportResult") -> None:
         self._save_address(name, self.doctype, record, result)
         self._save_extra_addresses(name, self.doctype, record, result)
@@ -338,12 +397,17 @@ class PartyImporter(BaseImporter):
 class CustomerImporter(PartyImporter):
     doctype = "Customer"
     key_field = "customer_name"
+    group_doctype = "Customer Group"
+    group_name_field = "customer_group_name"
+    group_parent_field = "parent_customer_group"
+    group_root = "All Customer Groups"
+    default_group = DEFAULT_CUSTOMER_GROUP
 
     def build_doc(self, record: dict) -> dict:
         doc = {
             "doctype": "Customer",
             "customer_name": record["_name"],
-            "customer_group": DEFAULT_CUSTOMER_GROUP,
+            "customer_group": self._resolve_group(record),
             "territory": DEFAULT_TERRITORY,
             "customer_type": "Company",
             "tax_id": record.get("GSTRegistrationNumber") or "",
@@ -362,12 +426,17 @@ class CustomerImporter(PartyImporter):
 class SupplierImporter(PartyImporter):
     doctype = "Supplier"
     key_field = "supplier_name"
+    group_doctype = "Supplier Group"
+    group_name_field = "supplier_group_name"
+    group_parent_field = "parent_supplier_group"
+    group_root = "All Supplier Groups"
+    default_group = DEFAULT_SUPPLIER_GROUP
 
     def build_doc(self, record: dict) -> dict:
         doc = {
             "doctype": "Supplier",
             "supplier_name": record["_name"],
-            "supplier_group": DEFAULT_SUPPLIER_GROUP,
+            "supplier_group": self._resolve_group(record),
             "supplier_type": "Company",
             "tax_id": record.get("GSTRegistrationNumber") or "",
             "pan": record.get("INCOMETAXNumber") or "",

--- a/tally_migrator/tally/extractors.py
+++ b/tally_migrator/tally/extractors.py
@@ -265,6 +265,9 @@ class TallyExtractor:
         self._attach_item_price_levels(masters.items)
         # Attach each item's bills of materials (component lists).
         self._attach_item_boms(masters.items)
+        # Attach each item's godown-wise opening stock (BATCHALLOCATIONS), so opening
+        # stock can post per warehouse instead of collapsing into one default godown.
+        self._attach_item_godown_openings(masters.items)
         return masters
 
     def _attach_item_gst_rates(self, items: list[dict]) -> None:
@@ -311,6 +314,15 @@ class TallyExtractor:
         boms = self.client.item_boms()
         for it in items:
             it.setdefault("Boms", boms.get(it.get("_name", ""), []))
+
+    def _attach_item_godown_openings(self, items: list[dict]) -> None:
+        """Set ``GodownOpenings`` (list of {godown, qty, rate, value}) on each item
+        dict. No-op when the source can't supply it (live client)."""
+        if not hasattr(self.client, "item_godown_openings"):
+            return
+        godowns = self.client.item_godown_openings()
+        for it in items:
+            it.setdefault("GodownOpenings", godowns.get(it.get("_name", ""), []))
 
     @staticmethod
     def _dedup_by_name(records: list[dict]) -> list[dict]:

--- a/tally_migrator/tally/file_source.py
+++ b/tally_migrator/tally/file_source.py
@@ -392,6 +392,42 @@ class FileTallySource:
                 out[name] = boms
         return out
 
+    def item_godown_openings(self) -> dict:
+        """``{stock item name: [{godown, qty, rate, value}, ...]}``.
+
+        Tally stores an item's opening stock godown-wise (and batch-wise) under
+        repeating ``BATCHALLOCATIONS.LIST`` rows, each carrying GODOWNNAME plus the
+        allocation's own OPENINGBALANCE ("118 Ream") / OPENINGRATE ("265.50/Ream") /
+        OPENINGVALUE ("-31329.00"). The item-level OPENINGBALANCE is their sum, so
+        without this the whole opening collapses into one default warehouse. Raw
+        strings are returned; the importer parses qty/rate/value and maps the godown
+        to an ERPNext warehouse. Only rows that carry both a godown and an opening
+        balance are returned (an empty stub contributes nothing)."""
+        out: dict = {}
+        for elem in self._by_tag.get("STOCKITEM", ()):
+            name = (elem.get("NAME") or elem.findtext("NAME") or "").strip()
+            if not name:
+                continue
+            rows = []
+            for ba in elem:
+                if ba.tag.split("}")[-1].upper() != "BATCHALLOCATIONS.LIST":
+                    continue
+                d = {}
+                for c in ba:
+                    t = c.tag.split("}")[-1].upper()
+                    if t in ("GODOWNNAME", "OPENINGBALANCE", "OPENINGRATE", "OPENINGVALUE"):
+                        d[t.lower()] = (c.text or "").strip()
+                if d.get("godownname") and d.get("openingbalance"):
+                    rows.append({
+                        "godown": d["godownname"],
+                        "qty": d.get("openingbalance", ""),
+                        "rate": d.get("openingrate", ""),
+                        "value": d.get("openingvalue", ""),
+                    })
+            if rows:
+                out[name] = rows
+        return out
+
     # ── Field resolution (tag overrides + nested .LIST descent) ────────────────
     @classmethod
     def _resolve_field(cls, elem, candidates: list) -> str:

--- a/tally_migrator/tests/test_file_source.py
+++ b/tally_migrator/tests/test_file_source.py
@@ -169,6 +169,66 @@ class TestRealTallyTags(unittest.TestCase):
         self.assertEqual(item["StandardCost"], "72.00")
 
 
+# A Stock Item whose opening stock is split godown-wise: Tally carries each godown's
+# allocation in a repeating BATCHALLOCATIONS.LIST (GODOWNNAME + the allocation's own
+# OPENINGBALANCE / OPENINGRATE / OPENINGVALUE); the item-level OPENINGBALANCE is their
+# sum. Without reading these the whole opening collapses into one default warehouse.
+GODOWN_OPENING_XML = """<ENVELOPE>
+  <BODY><IMPORTDATA><REQUESTDATA>
+    <TALLYMESSAGE>
+      <STOCKITEM NAME="Pen"><PARENT>Primary</PARENT>
+        <OPENINGBALANCE>30 Nos</OPENINGBALANCE>
+        <BATCHALLOCATIONS.LIST>
+          <GODOWNNAME>Bangalore Godown</GODOWNNAME>
+          <BATCHNAME>Primary Batch</BATCHNAME>
+          <OPENINGBALANCE>20 Nos</OPENINGBALANCE>
+          <OPENINGRATE>10.00/Nos</OPENINGRATE>
+          <OPENINGVALUE>-200.00</OPENINGVALUE>
+        </BATCHALLOCATIONS.LIST>
+        <BATCHALLOCATIONS.LIST>
+          <GODOWNNAME>Delhi Godown</GODOWNNAME>
+          <BATCHNAME>Primary Batch</BATCHNAME>
+          <OPENINGBALANCE>10 Nos</OPENINGBALANCE>
+          <OPENINGRATE>10.00/Nos</OPENINGRATE>
+          <OPENINGVALUE>-100.00</OPENINGVALUE>
+        </BATCHALLOCATIONS.LIST></STOCKITEM>
+    </TALLYMESSAGE>
+    <TALLYMESSAGE>
+      <STOCKITEM NAME="NoBatch"><PARENT>Primary</PARENT>
+        <OPENINGBALANCE>5 Nos</OPENINGBALANCE></STOCKITEM>
+    </TALLYMESSAGE>
+  </REQUESTDATA></IMPORTDATA></BODY>
+</ENVELOPE>"""
+
+
+class TestGodownOpenings(unittest.TestCase):
+    """Item opening stock is read godown-wise from BATCHALLOCATIONS.LIST."""
+
+    def setUp(self):
+        self.source = FileTallySource(GODOWN_OPENING_XML)
+
+    def test_godown_openings_parsed_per_godown(self):
+        out = self.source.item_godown_openings()
+        self.assertIn("Pen", out)
+        rows = out["Pen"]
+        self.assertEqual(len(rows), 2)
+        by_godown = {r["godown"]: r for r in rows}
+        self.assertEqual(by_godown["Bangalore Godown"]["qty"], "20 Nos")
+        self.assertEqual(by_godown["Bangalore Godown"]["value"], "-200.00")
+        self.assertEqual(by_godown["Delhi Godown"]["rate"], "10.00/Nos")
+
+    def test_item_without_batch_allocations_absent(self):
+        out = self.source.item_godown_openings()
+        self.assertNotIn("NoBatch", out)
+
+    def test_extractor_attaches_godown_openings(self):
+        masters = TallyExtractor(self.source).extract_all()
+        pen = next(i for i in masters.items if i["_name"] == "Pen")
+        self.assertEqual(len(pen["GodownOpenings"]), 2)
+        nobatch = next(i for i in masters.items if i["_name"] == "NoBatch")
+        self.assertEqual(nobatch["GodownOpenings"], [])
+
+
 # A real Tally Prime export nests the ledger's bank account under PAYMENTDETAILS.LIST
 # (ACCOUNTNUMBER / IFSCODE / BANKNAME), not the older flat <BANKDETAILS> tag. Before
 # the nested path was mapped, every such party's bank account silently dropped.

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -346,6 +346,41 @@ class TestERPNextImporter(unittest.TestCase):
             cat = imp._gst_category({"CountryName": "", "GSTRegistrationNumber": ""})
         self.assertEqual(cat, "Overseas")
 
+    # ── Party group derivation (no DB - existence stubbed) ──────────────────────
+    def test_customer_group_derived_from_tally_parent(self):
+        """The customer's Tally group (its PARENT, e.g. 'Trade Debtors - Domestic')
+        becomes its ERPNext Customer Group when that group exists - not the hardcoded
+        default. (Tier-1 fix: groups were collapsed into 'Commercial'.)"""
+        from unittest import mock
+        from tally_migrator.erpnext.importers import CustomerImporter
+        imp = CustomerImporter("_TMTest Co", "TC")
+        with mock.patch("frappe.db.exists", return_value=True):
+            doc = imp.build_doc({"_name": "Acme", "Parent": "Trade Debtors - Domestic"})
+        self.assertEqual(doc["customer_group"], "Trade Debtors - Domestic")
+
+    def test_supplier_group_derived_from_tally_parent(self):
+        from unittest import mock
+        from tally_migrator.erpnext.importers import SupplierImporter
+        imp = SupplierImporter("_TMTest Co", "TC")
+        with mock.patch("frappe.db.exists", return_value=True):
+            doc = imp.build_doc({"_name": "Zeta", "Parent": "Trade Creditors - Goods"})
+        self.assertEqual(doc["supplier_group"], "Trade Creditors - Goods")
+
+    def test_party_group_falls_back_to_default_when_absent(self):
+        """A blank Tally group, or one that couldn't be created, falls back to the
+        standard default so the party always gets a valid (leaf) group."""
+        from unittest import mock
+        from tally_migrator.erpnext.importers import CustomerImporter
+        from tally_migrator.tally.mappings import DEFAULT_CUSTOMER_GROUP
+        imp = CustomerImporter("_TMTest Co", "TC")
+        # blank parent -> default, no existence check needed
+        self.assertEqual(imp.build_doc({"_name": "Acme", "Parent": ""})["customer_group"],
+                         DEFAULT_CUSTOMER_GROUP)
+        # parent set but group doesn't exist (creation failed) -> default
+        with mock.patch("frappe.db.exists", return_value=False):
+            doc = imp.build_doc({"_name": "Acme", "Parent": "Trade Debtors - Domestic"})
+        self.assertEqual(doc["customer_group"], DEFAULT_CUSTOMER_GROUP)
+
     # ── Re-run idempotency guards (no DB - guard stubbed) ───────────────────────
 
     def test_opening_balance_skipped_when_entry_exists(self):
@@ -853,6 +888,95 @@ class TestERPNextImporter(unittest.TestCase):
                         "OpeningRate": "5.00/Nos", "OpeningValue": "-50.00"}],
                 posting_date="2024-04-01")
         self.assertFalse(any("does not reconcile" in w["reason"] for w in result.warnings))
+
+    def test_opening_stock_splits_across_godowns(self):
+        """An item whose opening stock spans two migrated godowns posts one row per
+        warehouse (Tier-1 fix: it used to collapse into a single default warehouse)."""
+        from unittest import mock
+        from tally_migrator.erpnext.importers import StockOpeningImporter
+
+        imp = StockOpeningImporter("_TMTest Co", "TC")
+        imp._existing_opening_stock = lambda: False
+        imp._default_warehouse = lambda: "Stores - TC"
+        captured = {}
+
+        def fake_get_doc(d):
+            captured["items"] = d["items"]
+            raise Exception("stop")
+
+        # Both godowns are "migrated" (warehouse exists); the default isn't consulted.
+        with mock.patch("frappe.db.exists", return_value=True), \
+                mock.patch("frappe.get_doc", side_effect=fake_get_doc):
+            imp.run(items=[{
+                "_name": "Pen", "OpeningBalance": "30 Nos",
+                "GodownOpenings": [
+                    {"godown": "Bangalore Godown", "qty": "20 Nos",
+                     "rate": "10.00/Nos", "value": "-200.00"},
+                    {"godown": "Delhi Godown", "qty": "10 Nos",
+                     "rate": "10.00/Nos", "value": "-100.00"},
+                ]}], posting_date="2024-04-01")
+        rows = {r["warehouse"]: r for r in captured["items"]}
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows["Bangalore Godown - TC"]["qty"], 20.0)
+        self.assertEqual(rows["Delhi Godown - TC"]["qty"], 10.0)
+        self.assertEqual(rows["Bangalore Godown - TC"]["valuation_rate"], 10.0)
+
+    def test_opening_stock_godown_falls_back_to_default_warehouse(self):
+        """A godown that wasn't migrated (e.g. Tally's implicit 'Main Location')
+        falls back to the default warehouse - so the current single-godown exports
+        behave exactly as before."""
+        from unittest import mock
+        from tally_migrator.erpnext.importers import StockOpeningImporter
+
+        imp = StockOpeningImporter("_TMTest Co", "TC")
+        imp._existing_opening_stock = lambda: False
+        imp._default_warehouse = lambda: "Stores - TC"
+        captured = {}
+
+        def fake_get_doc(d):
+            captured["items"] = d["items"]
+            raise Exception("stop")
+
+        # No warehouse exists for the godown -> fall back to the default.
+        with mock.patch("frappe.db.exists", return_value=False), \
+                mock.patch("frappe.get_doc", side_effect=fake_get_doc):
+            imp.run(items=[{
+                "_name": "Pen", "OpeningBalance": "30 Nos",
+                "GodownOpenings": [
+                    {"godown": "Main Location", "qty": "30 Nos",
+                     "rate": "10.00/Nos", "value": "-300.00"},
+                ]}], posting_date="2024-04-01")
+        self.assertEqual(len(captured["items"]), 1)
+        self.assertEqual(captured["items"][0]["warehouse"], "Stores - TC")
+        self.assertEqual(captured["items"][0]["qty"], 30.0)
+
+    def test_opening_stock_unmigrated_godowns_sum_into_default(self):
+        """Two godowns that both fall back to the default warehouse are summed into
+        one row (not flagged as a spurious duplicate)."""
+        from unittest import mock
+        from tally_migrator.erpnext.importers import StockOpeningImporter
+
+        imp = StockOpeningImporter("_TMTest Co", "TC")
+        imp._existing_opening_stock = lambda: False
+        imp._default_warehouse = lambda: "Stores - TC"
+        captured = {}
+
+        def fake_get_doc(d):
+            captured["items"] = d["items"]
+            raise Exception("stop")
+
+        with mock.patch("frappe.db.exists", return_value=False), \
+                mock.patch("frappe.get_doc", side_effect=fake_get_doc):
+            result = imp.run(items=[{
+                "_name": "Pen", "OpeningBalance": "30 Nos",
+                "GodownOpenings": [
+                    {"godown": "A", "qty": "20 Nos", "rate": "", "value": "-200.00"},
+                    {"godown": "B", "qty": "10 Nos", "rate": "", "value": "-100.00"},
+                ]}], posting_date="2024-04-01")
+        self.assertEqual(len(captured["items"]), 1)
+        self.assertEqual(captured["items"][0]["qty"], 30.0)           # 20 + 10
+        self.assertEqual(captured["items"][0]["valuation_rate"], 10.0)  # 300 / 30
+        self.assertFalse(any("more than once" in w["reason"] for w in result.warnings))
 
     # ── Opening-balance batching (no DB - residual maths only) ──────────────────
 


### PR DESCRIPTION
## Tier 1 fixes

Two cases where data the Tally export already carries was being discarded on import, in favour of a hardcoded default.

### 1. Customer / Supplier group
The party's Tally group (its `PARENT`, e.g. `Trade Debtors - Domestic`, `Trade Creditors - Goods`) is now mapped to an ERPNext Customer/Supplier Group — auto-created as a **leaf** under the standard root, mirroring how `ItemImporter` recreates Item Groups. Previously every party collapsed into a hardcoded default (`Commercial` / `All Supplier Groups`).

### 2. Opening stock per godown
Item opening quantities are read godown-wise from `BATCHALLOCATIONS.LIST` and posted as one Stock Reconciliation row per `(item, warehouse)`, mapping each Tally godown to its migrated warehouse. Previously all opening stock collapsed into a single default warehouse.

### Behaviour: real data wins, defaults only fill the gap
- Group present → assigned; blank/uncreatable → default, with a warning.
- Godown maps to a migrated warehouse → posts there; missing/unmigrated (e.g. Tally's implicit "Main Location") → falls back to (and sums into) the default warehouse.
- The no-godown path is factored to be **byte-identical** to the previous behaviour.

### Safety
- Auto-created party groups are **not** added to the run manifest (same as Item Groups), so a revert leaves shared masters untouched.
- Adds 9 tests (party-group derivation, per-godown opening split, parser). **Full bench suite passes.**