### PR TITLE
Migrate item batch tracking, expiry, and MRP (Tier 2)

### DIFF
--- a/tally_migrator/erpnext/importers/batch.py
+++ b/tally_migrator/erpnext/importers/batch.py
@@ -1,0 +1,100 @@
+"""Batch importer: Tally batch-wise opening detail -> ERPNext Batch masters."""
+
+from datetime import datetime
+
+import frappe
+
+from tally_migrator.naming import safe_item_code
+from tally_migrator.tally.extractors import TallyExtractor
+from .base import ImportResult
+
+
+class BatchImporter:
+    """Create ERPNext Batch masters from Tally's batch-wise opening detail.
+
+    A batch-tracked Tally item (``ISBATCHWISEON=Yes``) carries its opening stock
+    per batch inside ``BATCHALLOCATIONS.LIST`` (extracted onto each item as
+    ``GodownOpenings`` rows with a ``batch`` / ``mfg_date`` / ``expiry``). Each
+    distinct batch becomes an ERPNext Batch (``batch_id`` = the Tally batch name,
+    linked to the item, with manufacturing/expiry dates), so the batch-wise opening
+    Stock Reconciliation can post against a real Batch.
+
+    Runs after Items (the item must exist and carry ``has_batch_no``) and before
+    Opening Stock (the reconciliation references the batch). Idempotent: a Batch
+    whose id already exists is skipped. ``batch_id`` is global in ERPNext, so a name
+    already used by a *different* item is skipped with a warning rather than
+    hijacked.
+    """
+
+    doctype = "Batch"
+
+    def __init__(self, company: str, abbr: str):
+        self.company = company
+        self.abbr = abbr
+
+    def run(self, items: list[dict]) -> ImportResult:
+        result = ImportResult(self.doctype)
+        for it in items:
+            # Tally stamps every item's opening with an implicit "Primary Batch", so
+            # only genuinely batch-tracked items (ISBATCHWISEON=Yes) get Batch masters -
+            # otherwise we'd create a batch for every non-batch item too.
+            if (it.get("IsBatchWiseOn") or "").strip().lower() != "yes":
+                continue
+            code = safe_item_code(it.get("_name", ""))
+            seen: set[str] = set()
+            for row in (it.get("GodownOpenings") or []):
+                batch = (row.get("batch") or "").strip()
+                if not batch or batch in seen:
+                    continue
+                seen.add(batch)
+                self._upsert(result, code, it.get("_name", ""), batch, row)
+        return result
+
+    def _upsert(self, result: ImportResult, item_code: str, item_name: str,
+                batch_id: str, row: dict) -> None:
+        if not frappe.db.exists("Item", item_code):
+            return                       # item didn't import (warned by ItemImporter)
+        existing_item = frappe.db.get_value("Batch", batch_id, "item")
+        if existing_item is not None:
+            # Batch ids are global in ERPNext. Same item → already created (idempotent);
+            # different item → a genuine cross-item id clash we must not hijack.
+            if existing_item != item_code:
+                result.add_warning(
+                    item_name,
+                    f"batch '{batch_id}' already exists for a different item "
+                    f"('{existing_item}'); skipped. Tally batch names are per-item but "
+                    "ERPNext batch ids are global - rename one to migrate both.")
+            else:
+                result.skipped += 1
+            return
+        try:
+            doc = frappe.get_doc({
+                "doctype": "Batch",
+                "batch_id": batch_id,
+                "item": item_code,
+                "manufacturing_date": TallyExtractor._parse_tally_date(row.get("mfg_date", "")) or None,
+                "expiry_date": self._parse_expiry(row.get("expiry", "")) or None,
+            })
+            doc.flags.ignore_mandatory = True
+            doc.insert(ignore_permissions=True)
+            frappe.db.commit()
+            result.add_created(doc.name)
+        except Exception as exc:
+            frappe.db.rollback()
+            result.add_error(f"{item_name} (batch {batch_id})", exc)
+
+    @staticmethod
+    def _parse_expiry(raw: str) -> str:
+        """Tally batch ``EXPIRYPERIOD`` text ("31-Jul-26") → ISO "2026-07-31".
+
+        Returns "" for a blank or unparseable value so the batch still posts with no
+        expiry rather than failing."""
+        s = (raw or "").strip()
+        if not s:
+            return ""
+        for fmt in ("%d-%b-%y", "%d-%b-%Y", "%d-%m-%Y", "%Y%m%d"):
+            try:
+                return datetime.strptime(s, fmt).date().isoformat()
+            except ValueError:
+                continue
+        return ""

--- a/tally_migrator/erpnext/importers/items.py
+++ b/tally_migrator/erpnext/importers/items.py
@@ -135,6 +135,14 @@ class ItemImporter(BaseImporter):
         vm = self._valuation_method(record)
         if vm:
             doc["valuation_method"] = vm
+        # Batch / expiry tracking. ERPNext models expiry per batch, so has_expiry_date
+        # is only valid alongside has_batch_no - gate it so a perishable-but-not-batch
+        # Tally item never produces an invalid Item. Tally batches are pre-existing, so
+        # we do NOT auto-create new ones; the Batch importer recreates the Tally batches.
+        if self._yes(record.get("IsBatchWiseOn")):
+            doc["has_batch_no"] = 1
+            if self._yes(record.get("IsPerishableOn")):
+                doc["has_expiry_date"] = 1
         doc.update(self._gst_fields(record))
         tpl = getattr(self, "_tax_templates", {}).get(record["_name"])
         if tpl:
@@ -228,6 +236,11 @@ class ItemImporter(BaseImporter):
         if "avg" in raw or "average" in raw or "moving" in raw:
             return "Moving Average"
         return None
+
+    @staticmethod
+    def _yes(val) -> bool:
+        """Tally boolean flag → bool. Tally writes 'Yes'/'No'; anything else is False."""
+        return (val or "").strip().lower() == "yes"
 
     @staticmethod
     def _is_stock_item(record: dict) -> int:

--- a/tally_migrator/erpnext/importers/openings.py
+++ b/tally_migrator/erpnext/importers/openings.py
@@ -927,10 +927,10 @@ class StockOpeningImporter:
         # an item legitimately carry opening stock in several godowns.
         by_key: dict[tuple, dict] = {}
         for it in items:
-            for wh, raw_qty, raw_rate, raw_value in self._placements(it, warehouse):
+            for wh, raw_qty, raw_rate, raw_value, batch in self._placements(it, warehouse):
                 self._add_opening_row(
                     by_key, it["_name"], wh, raw_qty, raw_rate, raw_value,
-                    it.get("StandardCost"), result)
+                    it.get("StandardCost"), result, batch=batch)
         rows = list(by_key.values())
         if not rows:
             return result  # no opening stock to post
@@ -956,36 +956,43 @@ class StockOpeningImporter:
 
     def _placements(self, it: dict, default_wh: str) -> list[tuple]:
         """Where this item's opening stock lands → list of
-        ``(warehouse, raw_qty, raw_rate, raw_value)`` buckets fed to
+        ``(warehouse, raw_qty, raw_rate, raw_value, batch)`` buckets fed to
         :meth:`_add_opening_row`.
 
         - No godown-wise detail (``GodownOpenings`` empty, e.g. a live client or an
           older export) → one bucket at the default warehouse using the item-level
           OpeningBalance/Rate/Value, i.e. exactly the legacy behaviour.
-        - Godown-wise detail present → one bucket per resolved warehouse. Several
-          godowns that map to the same warehouse (e.g. both fall back to the default
-          because they weren't migrated) are summed, so nothing is lost and the rows
-          stay unique. A warehouse fed by a single godown keeps that godown's raw
-          rate (preserving the unit-suffixed rate and the value/rate cross-check);
-          a summed bucket derives its rate from value÷qty.
+        - Godown-wise detail present → one bucket per (resolved warehouse, batch).
+          Several godowns that map to the same warehouse *and* batch (e.g. both fall
+          back to the default because they weren't migrated) are summed, so nothing
+          is lost and the rows stay unique. A bucket fed by a single godown keeps
+          that godown's raw rate (preserving the unit-suffixed rate and the
+          value/rate cross-check); a summed bucket derives its rate from value÷qty.
+          ``batch`` is "" for non-batch items, so they behave exactly as before.
         """
         godowns = it.get("GodownOpenings") or []
         if not godowns:
             return [(default_wh, it.get("OpeningBalance"),
-                     it.get("OpeningRate"), it.get("OpeningValue"))]
-        buckets: dict[str, list] = {}
+                     it.get("OpeningRate"), it.get("OpeningValue"), "")]
+        # Tally stamps EVERY item's opening allocation with a batch name - an implicit
+        # "Primary Batch" even for non-batch items - so the batch is only meaningful
+        # when the item is actually batch-tracked. Otherwise batch_no would be set on a
+        # has_batch_no=0 item and the reconciliation would be rejected.
+        is_batch = (it.get("IsBatchWiseOn") or "").strip().lower() == "yes"
+        buckets: dict[tuple, list] = {}
         for g in godowns:
             wh = self._warehouse_for_godown(g.get("godown", ""), default_wh)
-            buckets.setdefault(wh, []).append(g)
+            batch = (g.get("batch") or "").strip() if is_batch else ""
+            buckets.setdefault((wh, batch), []).append(g)
         placements: list[tuple] = []
-        for wh, gs in buckets.items():
+        for (wh, batch), gs in buckets.items():
             if len(gs) == 1:
                 g = gs[0]
-                placements.append((wh, g.get("qty"), g.get("rate"), g.get("value")))
+                placements.append((wh, g.get("qty"), g.get("rate"), g.get("value"), batch))
             else:
                 qsum = sum(TallyExtractor._parse_quantity(g.get("qty")) for g in gs)
                 vsum = sum(abs(BaseImporter._to_float(g.get("value"))) for g in gs)
-                placements.append((wh, str(qsum), "", str(vsum)))
+                placements.append((wh, str(qsum), "", str(vsum), batch))
         return placements
 
     def _warehouse_for_godown(self, godown: str, default_wh: str) -> str:
@@ -1001,13 +1008,16 @@ class StockOpeningImporter:
         return default_wh
 
     def _add_opening_row(self, by_key: dict, name: str, warehouse: str, raw_qty,
-                         raw_rate, raw_value, raw_std_cost, result: ImportResult) -> None:
+                         raw_rate, raw_value, raw_std_cost, result: ImportResult,
+                         batch: str = "") -> None:
         """Build and dedupe one opening-stock row for ``name`` at ``warehouse``.
 
         Carries the full per-row treatment (negative/unreadable-quantity drops, the
         rate cascade, the value/rate cross-check, the zero-rate allowance, and the
         item+warehouse de-duplication), so both the legacy single-warehouse path and
-        the per-godown path share identical behaviour."""
+        the per-godown path share identical behaviour. ``batch`` (when set) tags the
+        row with its Batch and widens the de-dup key, so a batch-tracked item can hold
+        opening stock in several batches at the same warehouse."""
         qty = TallyExtractor._parse_quantity(raw_qty)
         if qty < 0:
             # Tally can carry a negative opening quantity (e.g. oversold stock);
@@ -1057,7 +1067,7 @@ class StockOpeningImporter:
                     "the opening rate; verify this item's opening stock in Tally.")
 
         code = safe_item_code(name)
-        key = (code, warehouse)
+        key = (code, warehouse, batch)
         prev = by_key.get(key)
         if prev is not None:
             if abs(prev["qty"] - qty) > 1e-9:
@@ -1076,6 +1086,11 @@ class StockOpeningImporter:
             "qty": qty,
             "valuation_rate": rate,
         }
+        if batch:
+            # Batch-tracked item: tag the opening row with its Batch so the
+            # reconciliation posts the quantity into that batch (the Batch master is
+            # created first by BatchImporter).
+            row["batch_no"] = batch
         if rate == 0:
             # ERPNext rejects a positive opening qty at a zero rate
             # ("Valuation Rate required for Item …") unless the row explicitly

--- a/tally_migrator/erpnext/importers/orchestrator.py
+++ b/tally_migrator/erpnext/importers/orchestrator.py
@@ -31,6 +31,7 @@ from .warehouses import WarehouseImporter, StockGroupImporter
 from .units import UnitImporter
 from .prices import PriceImporter
 from .bom import BomImporter
+from .batch import BatchImporter
 from .accounts import AccountImporter, CostCentreImporter
 from .hsn import _restore_hsn_validation, _hsn_validation_suspended
 from .openings import (
@@ -123,6 +124,9 @@ class ERPNextImporter:
 
     def import_boms(self, items: list[dict]) -> ImportResult:
         return BomImporter(self.company, self.abbr).run(items)
+
+    def import_batches(self, items: list[dict]) -> ImportResult:
+        return BatchImporter(self.company, self.abbr).run(items)
 
     def import_warehouses(self, warehouses: list[dict]) -> ImportResult:
         return WarehouseImporter(self.company, self.abbr).run(warehouses)

--- a/tally_migrator/erpnext/importers/prices.py
+++ b/tally_migrator/erpnext/importers/prices.py
@@ -25,12 +25,35 @@ class PriceImporter:
         self.currency = frappe.get_cached_value(
             "Company", company, "default_currency") or "INR"
 
+    # Tally MRP has no native ERPNext field, so it is modelled as a selling Price
+    # List named "MRP" with one Item Price per item - mirroring how price levels map.
+    MRP_PRICE_LIST = "MRP"
+
     def run(self, items: list[dict]) -> ImportResult:
         result = ImportResult(self.doctype)
         for it in items:
             for lv in (it.get("PriceLevels") or []):
                 self._import_level(result, it.get("_name", ""), lv)
+            self._import_mrp(result, it.get("_name", ""), it.get("Mrp"))
         return result
+
+    def _import_mrp(self, result: ImportResult, item_name: str, raw_mrp) -> None:
+        """Tally MRP ("50000.00/Nos") → an Item Price on the 'MRP' selling list."""
+        rate, uom = self._parse_rate(raw_mrp or "")
+        if rate is None:
+            return                              # no MRP on this item
+        item_code = safe_item_code(item_name)
+        if not frappe.db.exists("Item", item_code):
+            return                              # item didn't import (warned by ItemImporter)
+        stock_uom = frappe.db.get_value("Item", item_code, "stock_uom")
+        if not self._uom_valid_for_item(item_code, uom, stock_uom):
+            uom = stock_uom
+        try:
+            price_list = self._ensure_price_list(self.MRP_PRICE_LIST)
+            self._ensure_item_price(result, item_code, price_list, uom, rate, None)
+        except Exception as exc:
+            result.add_error(f"{item_name} (MRP)", exc)
+            frappe.db.rollback()
 
     def _import_level(self, result: ImportResult, item_name: str, lv: dict) -> None:
         rate, uom = self._parse_rate(lv.get("rate", ""))

--- a/tally_migrator/migration/master_migrator.py
+++ b/tally_migrator/migration/master_migrator.py
@@ -281,9 +281,16 @@ class MasterMigrator:
             PipelineStep("Suppliers", 65, self.importer.import_suppliers, masters.suppliers),
             PipelineStep("Items", 80, self.importer.import_items, masters.items),
         ]
+        # Batch masters (Tally batch-wise opening detail) -> ERPNext Batch. After
+        # Items (the item must carry has_batch_no) and before Opening Stock (the
+        # reconciliation posts batch-wise rows against these). Gated on any item
+        # carrying a batch in its godown-wise opening detail.
+        if any((i.get("IsBatchWiseOn") or "").strip().lower() == "yes" for i in masters.items):
+            steps.append(PipelineStep("Batches", 81, self.importer.import_batches, masters.items))
         # Price levels (Retail/Wholesale) -> Price List + Item Price (+ discount
-        # Pricing Rule). After Items so item_code/UOM links resolve.
-        if any(i.get("PriceLevels") for i in masters.items):
+        # Pricing Rule); also Tally MRP -> an "MRP" Price List + Item Price. After
+        # Items so item_code/UOM links resolve.
+        if any(i.get("PriceLevels") or i.get("Mrp") for i in masters.items):
             steps.append(PipelineStep("Prices", 82, self.importer.import_prices, masters.items))
         # Bills of materials -> ERPNext BOM (submitted). After Items so the finished
         # item and every component exist.

--- a/tally_migrator/tally/extractors.py
+++ b/tally_migrator/tally/extractors.py
@@ -31,6 +31,12 @@ ITEM_FIELDS = [
     # Inventory valuation method (→ Item.valuation_method) and the flat item-level
     # GST flag (→ India-Compliance is_non_gst). Both have real ERPNext targets.
     "ValuationMethod", "GstApplicable",
+    # Batch/expiry flags (→ Item.has_batch_no / has_expiry_date). The flat tag names
+    # equal FIELD.upper() (ISBATCHWISEON / ISPERISHABLEON / HASMFGDATE), so no tag_map.
+    "IsBatchWiseOn", "IsPerishableOn", "HasMfgDate",
+    # Maximum Retail Price (→ an "MRP" selling Price List + Item Price). Nested under
+    # MRPDETAILS.LIST; the rate is unit-suffixed ("50000.00/Nos"), so it needs a path.
+    "Mrp",
 ]
 
 GODOWN_FIELDS     = ["Name", "Parent", "Address"]
@@ -111,6 +117,9 @@ ITEM_TAGS = {
     "ValuationMethod": ["VALUATIONMETHOD", "COSTINGMETHOD"],
     # Flat item-level "Applicable / Not Applicable" GST switch.
     "GstApplicable":   ["GSTAPPLICABLE"],
+    # MRP lives nested as a (state-wise, dated) revision list; take the latest rate.
+    # State-specific MRP is not modelled in ERPNext, so the "Any"/last rate is used.
+    "Mrp": ["MRPDETAILS.LIST/MRPRATEDETAILS.LIST/MRPRATE"],
 }
 
 GODOWN_TAGS = {
@@ -316,8 +325,9 @@ class TallyExtractor:
             it.setdefault("Boms", boms.get(it.get("_name", ""), []))
 
     def _attach_item_godown_openings(self, items: list[dict]) -> None:
-        """Set ``GodownOpenings`` (list of {godown, qty, rate, value}) on each item
-        dict. No-op when the source can't supply it (live client)."""
+        """Set ``GodownOpenings`` (list of {godown, qty, rate, value, batch, mfg_date,
+        expiry}) on each item dict. ``batch``/``mfg_date``/``expiry`` are populated only
+        for batch-tracked items. No-op when the source can't supply it (live client)."""
         if not hasattr(self.client, "item_godown_openings"):
             return
         godowns = self.client.item_godown_openings()

--- a/tally_migrator/tally/file_source.py
+++ b/tally_migrator/tally/file_source.py
@@ -393,16 +393,19 @@ class FileTallySource:
         return out
 
     def item_godown_openings(self) -> dict:
-        """``{stock item name: [{godown, qty, rate, value}, ...]}``.
+        """``{stock item name: [{godown, qty, rate, value, batch, mfg_date, expiry}, ...]}``.
 
         Tally stores an item's opening stock godown-wise (and batch-wise) under
         repeating ``BATCHALLOCATIONS.LIST`` rows, each carrying GODOWNNAME plus the
         allocation's own OPENINGBALANCE ("118 Ream") / OPENINGRATE ("265.50/Ream") /
-        OPENINGVALUE ("-31329.00"). The item-level OPENINGBALANCE is their sum, so
-        without this the whole opening collapses into one default warehouse. Raw
-        strings are returned; the importer parses qty/rate/value and maps the godown
-        to an ERPNext warehouse. Only rows that carry both a godown and an opening
-        balance are returned (an empty stub contributes nothing)."""
+        OPENINGVALUE ("-31329.00"), and - for a batch-tracked item - BATCHNAME, MFDON
+        (manufacturing date) and EXPIRYPERIOD (expiry). The item-level OPENINGBALANCE
+        is their sum, so without this the whole opening collapses into one default
+        warehouse. Raw strings are returned; the importer parses qty/rate/value, maps
+        the godown to an ERPNext warehouse, and (for batch items) posts per batch.
+        ``batch``/``mfg_date``/``expiry`` are "" for non-batch items. Only rows that
+        carry both a godown and an opening balance are returned (an empty stub
+        contributes nothing)."""
         out: dict = {}
         for elem in self._by_tag.get("STOCKITEM", ()):
             name = (elem.get("NAME") or elem.findtext("NAME") or "").strip()
@@ -415,7 +418,8 @@ class FileTallySource:
                 d = {}
                 for c in ba:
                     t = c.tag.split("}")[-1].upper()
-                    if t in ("GODOWNNAME", "OPENINGBALANCE", "OPENINGRATE", "OPENINGVALUE"):
+                    if t in ("GODOWNNAME", "OPENINGBALANCE", "OPENINGRATE",
+                             "OPENINGVALUE", "BATCHNAME", "MFDON", "EXPIRYPERIOD"):
                         d[t.lower()] = (c.text or "").strip()
                 if d.get("godownname") and d.get("openingbalance"):
                     rows.append({
@@ -423,6 +427,12 @@ class FileTallySource:
                         "qty": d.get("openingbalance", ""),
                         "rate": d.get("openingrate", ""),
                         "value": d.get("openingvalue", ""),
+                        # Batch-wise opening (only on batch-tracked items): the batch id,
+                        # its manufacturing date (MFDON, Tally YYYYMMDD) and expiry date
+                        # (EXPIRYPERIOD text, e.g. "31-Jul-26"). Blank for non-batch items.
+                        "batch": d.get("batchname", ""),
+                        "mfg_date": d.get("mfdon", ""),
+                        "expiry": d.get("expiryperiod", ""),
                     })
             if rows:
                 out[name] = rows

--- a/tally_migrator/tests/test_file_source.py
+++ b/tally_migrator/tests/test_file_source.py
@@ -229,6 +229,52 @@ class TestGodownOpenings(unittest.TestCase):
         self.assertEqual(nobatch["GodownOpenings"], [])
 
 
+# A batch-tracked, perishable item with MRP - mirrors a real "MRP Batch" export.
+BATCH_MRP_XML = """<ENVELOPE>
+  <BODY><IMPORTDATA><REQUESTDATA>
+    <TALLYMESSAGE>
+      <STOCKITEM NAME="Iphone 10"><PARENT>Primary</PARENT><BASEUNITS>Nos</BASEUNITS>
+        <ISBATCHWISEON>Yes</ISBATCHWISEON>
+        <ISPERISHABLEON>Yes</ISPERISHABLEON>
+        <HASMFGDATE>Yes</HASMFGDATE>
+        <OPENINGBALANCE>90 Nos</OPENINGBALANCE>
+        <MRPDETAILS.LIST>
+          <MRPRATEDETAILS.LIST><MRPRATE>50000.00/Nos</MRPRATE></MRPRATEDETAILS.LIST>
+        </MRPDETAILS.LIST>
+        <BATCHALLOCATIONS.LIST>
+          <MFDON>20260501</MFDON>
+          <GODOWNNAME>Main Location</GODOWNNAME>
+          <BATCHNAME>BATCH1</BATCHNAME>
+          <OPENINGBALANCE>90 Nos</OPENINGBALANCE>
+          <OPENINGRATE>50000.00/Nos</OPENINGRATE>
+          <OPENINGVALUE>-4500000.00</OPENINGVALUE>
+          <EXPIRYPERIOD JD="46142" INC="Y" P="31-Jul-26">31-Jul-26</EXPIRYPERIOD>
+        </BATCHALLOCATIONS.LIST></STOCKITEM>
+    </TALLYMESSAGE>
+  </REQUESTDATA></IMPORTDATA></BODY>
+</ENVELOPE>"""
+
+
+class TestBatchExpiryMrp(unittest.TestCase):
+    """Batch / expiry flags, batch-wise opening detail, and MRP are extracted."""
+
+    def setUp(self):
+        self.source = FileTallySource(BATCH_MRP_XML)
+
+    def test_batch_opening_carries_batch_mfg_expiry(self):
+        row = self.source.item_godown_openings()["Iphone 10"][0]
+        self.assertEqual(row["batch"], "BATCH1")
+        self.assertEqual(row["mfg_date"], "20260501")
+        self.assertEqual(row["expiry"], "31-Jul-26")
+
+    def test_item_flags_and_mrp_read(self):
+        item = self.source.get_collection(
+            "Stock Item", ITEM_FIELDS, ITEM_TAGS)[0]
+        self.assertEqual(item["IsBatchWiseOn"], "Yes")
+        self.assertEqual(item["IsPerishableOn"], "Yes")
+        self.assertEqual(item["Mrp"], "50000.00/Nos")
+
+
 # A real Tally Prime export nests the ledger's bank account under PAYMENTDETAILS.LIST
 # (ACCOUNTNUMBER / IFSCODE / BANKNAME), not the older flat <BANKDETAILS> tag. Before
 # the nested path was mapped, every such party's bank account silently dropped.

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -197,6 +197,109 @@ class TestERPNextImporter(unittest.TestCase):
         uom = frappe.db.get_value("Item", {"item_name": "_TMTest Item KG"}, "stock_uom")
         self.assertEqual(uom, "Kg")
 
+    # ── Batch / expiry / MRP (Tier 2) ───────────────────────────────────────────
+
+    @staticmethod
+    def _batch_item(name="_TMTest Batch Item"):
+        return {
+            "_name": name, "Parent": "All Item Groups", "BaseUnits": "Nos",
+            "HSNCode": "99041010",
+            "IsBatchWiseOn": "Yes", "IsPerishableOn": "Yes", "HasMfgDate": "Yes",
+            "Mrp": "50000.00/Nos",
+            "OpeningBalance": "90 Nos",
+            "GodownOpenings": [{
+                "godown": "Main Location", "qty": "90 Nos", "rate": "50000.00/Nos",
+                "value": "-4500000.00", "batch": "_TMTest BATCH1",
+                "mfg_date": "20260501", "expiry": "31-Jul-26",
+            }],
+        }
+
+    def test_batch_item_sets_has_batch_no_and_expiry(self):
+        item = self._batch_item()
+        result = self.importer.import_items([item])
+        self.assertEqual(result.failed, 0, msg=str(result.errors))
+        code = frappe.db.get_value("Item", {"item_name": item["_name"]}, "name")
+        flags = frappe.db.get_value(
+            "Item", code, ["has_batch_no", "has_expiry_date"], as_dict=True)
+        self.assertEqual(flags.has_batch_no, 1)
+        self.assertEqual(flags.has_expiry_date, 1)
+
+    def test_batch_master_created_with_dates(self):
+        item = self._batch_item()
+        self.importer.import_items([item])
+        self.addCleanup(
+            lambda: frappe.db.exists("Batch", "_TMTest BATCH1")
+            and frappe.delete_doc("Batch", "_TMTest BATCH1", force=1))
+        res = self.importer.import_batches([item])
+        self.assertEqual(res.failed, 0, msg=str(res.errors))
+        b = frappe.db.get_value(
+            "Batch", "_TMTest BATCH1",
+            ["item", "manufacturing_date", "expiry_date"], as_dict=True)
+        self.assertTrue(b)
+        self.assertEqual(str(b.manufacturing_date), "2026-05-01")
+        self.assertEqual(str(b.expiry_date), "2026-07-31")
+
+    def test_mrp_creates_item_price_on_mrp_list(self):
+        item = self._batch_item()
+        self.importer.import_items([item])
+        code = frappe.db.get_value("Item", {"item_name": item["_name"]}, "name")
+        self.addCleanup(
+            lambda: [frappe.delete_doc("Item Price", p, force=1)
+                     for p in frappe.get_all(
+                         "Item Price", filters={"item_code": code}, pluck="name")])
+        self.importer.import_prices([item])
+        rows = frappe.get_all(
+            "Item Price", filters={"item_code": code, "price_list": "MRP"},
+            fields=["price_list_rate", "uom"])
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].price_list_rate, 50000.0)
+
+    def test_opening_stock_row_carries_batch_no(self):
+        from tally_migrator.erpnext.importers import StockOpeningImporter
+        from tally_migrator.erpnext.importers.base import ImportResult
+        imp = StockOpeningImporter("_TMTest Co", "TC")
+        imp._warehouse_for_godown = lambda g, d: d   # avoid DB warehouse lookup
+        item = self._batch_item()
+        placements = imp._placements(item, "WH - TC")
+        self.assertEqual(placements[0][4], "_TMTest BATCH1")   # batch in the tuple
+        res, by_key = ImportResult("Stock Reconciliation"), {}
+        for wh, q, r, v, batch in placements:
+            imp._add_opening_row(by_key, "X", wh, q, r, v, None, res, batch=batch)
+        row = next(iter(by_key.values()))
+        self.assertEqual(row["batch_no"], "_TMTest BATCH1")
+        self.assertEqual(row["qty"], 90.0)
+
+    def test_parse_expiry_formats(self):
+        from tally_migrator.erpnext.importers.batch import BatchImporter
+        self.assertEqual(BatchImporter._parse_expiry("31-Jul-26"), "2026-07-31")
+        self.assertEqual(BatchImporter._parse_expiry(""), "")
+        self.assertEqual(BatchImporter._parse_expiry("garbage"), "")
+
+    def test_non_batch_item_ignores_implicit_primary_batch(self):
+        """Tally stamps EVERY item's opening with an implicit 'Primary Batch'. A
+        non-batch item (IsBatchWiseOn=No) must NOT get batch_no on its opening row,
+        or ERPNext rejects the row (has_batch_no=0)."""
+        from tally_migrator.erpnext.importers import StockOpeningImporter
+        from tally_migrator.erpnext.importers.base import ImportResult
+        imp = StockOpeningImporter("_TMTest Co", "TC")
+        imp._warehouse_for_godown = lambda g, d: d
+        item = {"_name": "PlainItem", "IsBatchWiseOn": "No", "GodownOpenings": [
+            {"godown": "Main Location", "qty": "10 Nos", "rate": "5.00/Nos",
+             "value": "-50.00", "batch": "Primary Batch"}]}
+        res, by_key = ImportResult("Stock Reconciliation"), {}
+        for wh, q, r, v, batch in imp._placements(item, "WH - TC"):
+            imp._add_opening_row(by_key, "PlainItem", wh, q, r, v, None, res, batch=batch)
+        row = next(iter(by_key.values()))
+        self.assertNotIn("batch_no", row)
+
+    def test_batch_importer_skips_non_batch_items(self):
+        """A non-batch item carrying an implicit 'Primary Batch' must not get a Batch."""
+        item = {"_name": "_TMTest Plain", "IsBatchWiseOn": "No", "GodownOpenings": [
+            {"godown": "Main Location", "qty": "10 Nos", "batch": "Primary Batch",
+             "mfg_date": "", "expiry": ""}]}
+        res = self.importer.import_batches([item])
+        self.assertEqual(res.created, 0)
+
     # ── Warehouse (requires a configured Company) ───────────────────────────────
 
     def test_warehouse_topo_sort_creates_parent_first(self):


### PR DESCRIPTION
## Summary
Tier 2 of the field-coverage audit — item-side features Tally carried but the migrator dropped.

- **Batch tracking** (`ISBATCHWISEON`) → Item `has_batch_no`.
- **Expiry** (`ISPERISHABLEON`) → `has_expiry_date` (gated on `has_batch_no`, since ERPNext models expiry per batch).
- **Batch masters** → new `BatchImporter`: each Tally batch (`BATCHNAME`) becomes a Batch with `manufacturing_date` (`MFDON`) and `expiry_date` (`EXPIRYPERIOD`). Global batch-id clashes across items skipped with a warning.
- **Batch-wise opening stock** → reconciliation posts per-batch rows (`batch_no`); de-dup key widened to `(item, warehouse, batch)`.
- **MRP** → modelled as an "MRP" selling Price List + Item Price (ERPNext has no native MRP field), mirroring the Retail/Wholesale mapping.

## Key correctness note
Tally stamps **every** item's opening with an implicit `Primary Batch` — even non-batch items. All batch handling is therefore gated on `ISBATCHWISEON=Yes`, or a non-batch item would get `batch_no` on a `has_batch_no=0` row and the reconciliation would be rejected.

## Validation
Validated end-to-end against real `MRP Batch.xml` and `TwoBatches.xml` exports — including a batch-but-not-perishable item (`Iphone 15`) and the implicit Primary-Batch case across 28 non-batch items. 61 importer tests pass (incl. new batch/expiry/MRP + regression tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)