### PR TITLE
Map Tally compound "Regular - SEZ" type to SEZ GST category

### DIFF
--- a/tally_migrator/tally/mappings.py
+++ b/tally_migrator/tally/mappings.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 # ── Tally root groups that classify ledgers as customers / suppliers ──────────
 
 DEBTOR_ROOTS   = {"Sundry Debtors"}
@@ -203,7 +205,14 @@ GST_REGISTRATION_TYPE_MAP: dict[str, str] = {
 def gst_category_from_type(raw: str) -> str:
     """Map a Tally GST registration type to an ERPNext GST Category, or "" when
     the value is blank/unrecognised (caller then falls back to inference)."""
-    return GST_REGISTRATION_TYPE_MAP.get((raw or "").strip().lower(), "")
+    key = (raw or "").strip().lower()
+    # Tally records SEZ as a compound registration type ("Regular - SEZ"), not the
+    # bare "SEZ" the exact-match table holds and not the ISSEZPARTY flag (which
+    # TallyPrime leaves "No"). Match the SEZ token anywhere so the compound form
+    # maps to the SEZ category instead of falling through to "Registered Regular".
+    if re.search(r"\bsez\b", key):
+        return "SEZ"
+    return GST_REGISTRATION_TYPE_MAP.get(key, "")
 
 # ERPNext's standard root-type representative groups, used as a last-resort parent
 # in coa_mode="reuse" when a more specific default group can't be found.

--- a/tally_migrator/tests/test_mappings.py
+++ b/tally_migrator/tests/test_mappings.py
@@ -52,6 +52,15 @@ class TestGstCategoryFromType(unittest.TestCase):
         self.assertEqual(gst_category_from_type("Consumer"), "Unregistered")
         self.assertEqual(gst_category_from_type("SEZ"), "SEZ")
 
+    def test_compound_sez_type_maps_to_sez(self):
+        # Tally exports SEZ as the compound registration type "Regular - SEZ"
+        # (the bare "SEZ" the table holds never appears in a real export), so the
+        # SEZ token must be recognised inside the string, not only as an exact key.
+        self.assertEqual(gst_category_from_type("Regular - SEZ"), "SEZ")
+        self.assertEqual(gst_category_from_type("regular - sez"), "SEZ")
+        # The token match must not fire on substrings of unrelated words.
+        self.assertEqual(gst_category_from_type("Deemed Export"), "Deemed Export")
+
     def test_case_and_whitespace_insensitive(self):
         self.assertEqual(gst_category_from_type("  reGular "), "Registered Regular")
 


### PR DESCRIPTION
## Problem
Tally exports an SEZ party's registration type as the compound string `Regular - SEZ`, not the bare `SEZ` that `gst_category_from_type`'s exact-match table held — and **not** via the `ISSEZPARTY` flag (TallyPrime leaves that `No`, confirmed in the UI). The exact-match lookup missed the compound form, so SEZ parties fell through to GSTIN inference and were mislabeled **Registered Regular**, silently losing SEZ status.

## Fix
Recognise the `SEZ` token anywhere in the registration type using a word-boundary match (`\bsez\b`), so `Regular - SEZ` → `SEZ` while unrelated values like `Deemed Export` are unaffected. Exact-match table still handles all other types.

## Validation (against a real export, `GSTTDS.xml`)
| Check | Result |
|-------|--------|
| Unit: `gst_category_from_type("Regular - SEZ")` | `"SEZ"` ✅ |
| End-to-end: `PartyImporter._gst_category` on `TEST SEZ Customer` | `"SEZ"` ✅ |
| `TEST GST Customer` (regression) | `"Registered Regular"` unchanged ✅ |
| Full suite | 110 tests pass (incl. new `test_compound_sez_type_maps_to_sez`) ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)