### PR TITLE
Fix batch opening stock, broaden revert coverage, align wizard footers

### DIFF
--- a/tally_migrator/api.py
+++ b/tally_migrator/api.py
@@ -222,7 +222,8 @@ def clear_draft():
 @frappe.whitelist(methods=["POST"])
 def run_masters_migration_from_file(file_url: str, erpnext_company: str = "", uom_overrides: str = "",
                                     validation_report: str = "", record_overrides: str = "",
-                                    coa_mode: str = "reuse", posting_date: str = ""):
+                                    coa_mode: str = "reuse", posting_date: str = "",
+                                    created_uoms: str = ""):
     """Run the masters migration from an uploaded Tally masters XML export.
 
     ``file_url``        - URL of the File uploaded via the standard Frappe uploader.
@@ -239,6 +240,7 @@ def run_masters_migration_from_file(file_url: str, erpnext_company: str = "", uo
     _assert_no_active_run(erpnext_company)
     uom: dict = json.loads(uom_overrides) if uom_overrides else {}
     records: dict = json.loads(record_overrides) if record_overrides else {}
+    created: list = json.loads(created_uoms) if created_uoms else []
 
     file_doc, source = _source_from_file(file_url)
     config = _build_masters_config(
@@ -253,8 +255,9 @@ def run_masters_migration_from_file(file_url: str, erpnext_company: str = "", uo
     if source.approx_record_count() > RUN_ASYNC_THRESHOLD:
         return _enqueue_masters_run(
             config, file_url, erpnext_company, uom_overrides or "",
-            validation_report or "", record_overrides or "", coa_mode, posting_date or "")
-    return _run_and_summarize(config, source, uom, records)
+            validation_report or "", record_overrides or "", coa_mode, posting_date or "",
+            created_uoms or "")
+    return _run_and_summarize(config, source, uom, records, created)
 
 
 @frappe.whitelist(methods=["POST"])
@@ -524,12 +527,14 @@ def _build_masters_config(file_url, file_name, erpnext_company, source,
 
 
 def _run_and_summarize(config: TallyConfig, source, uom_overrides: dict | None = None,
-                       record_overrides: dict | None = None) -> dict:
+                       record_overrides: dict | None = None,
+                       created_uoms: list | None = None) -> dict:
     """Run a masters migration and return its summary dict plus the log name."""
     migrator = MasterMigrator(
         config, source=source,
         uom_overrides=uom_overrides or {},
         record_overrides=record_overrides or {},
+        created_uoms=created_uoms or [],
     )
     result = migrator.run().as_dict()
     result["log_name"] = migrator.log.name if migrator.log else None
@@ -537,7 +542,8 @@ def _run_and_summarize(config: TallyConfig, source, uom_overrides: dict | None =
 
 
 def _enqueue_masters_run(config: TallyConfig, file_url, erpnext_company, uom_overrides,
-                         validation_report, record_overrides, coa_mode, posting_date) -> dict:
+                         validation_report, record_overrides, coa_mode, posting_date,
+                         created_uoms="") -> dict:
     """Create the log now, hand the run to a background worker, return the log name.
 
     The log is created (and committed) in the request so the page has something to
@@ -564,18 +570,20 @@ def _enqueue_masters_run(config: TallyConfig, file_url, erpnext_company, uom_ove
         record_overrides=record_overrides,
         coa_mode=coa_mode,
         posting_date=posting_date,
+        created_uoms=created_uoms,
         log_name=log.name,
     )
     return {"enqueued": True, "log_name": log.name, "company": erpnext_company}
 
 
 def _run_masters_job(file_url, erpnext_company, uom_overrides, validation_report,
-                     record_overrides, coa_mode, posting_date, log_name):
+                     record_overrides, coa_mode, posting_date, log_name, created_uoms=""):
     """Background entry point: re-parse the file and run the migration into an
     already-created log. Errors are recorded on the log by ``MasterMigrator`` and
     re-raised so the failure is also visible in the job/error log."""
     uom = json.loads(uom_overrides) if uom_overrides else {}
     records = json.loads(record_overrides) if record_overrides else {}
+    created = json.loads(created_uoms) if created_uoms else []
     file_doc, source = _source_from_file(file_url)
     config = _build_masters_config(
         file_url, file_doc.file_name, erpnext_company, source,
@@ -583,6 +591,7 @@ def _run_masters_job(file_url, erpnext_company, uom_overrides, validation_report
     log = frappe.get_doc("Tally Migration Log", log_name)
     MasterMigrator(
         config, source=source, uom_overrides=uom, record_overrides=records, log=log,
+        created_uoms=created,
     ).run()
 
 

--- a/tally_migrator/erpnext/importers/accounts.py
+++ b/tally_migrator/erpnext/importers/accounts.py
@@ -165,7 +165,7 @@ class AccountImporter:
 
     def _save_company_bank_account(self, node, account_name: str,
                                    result: ImportResult) -> None:
-        bank = _ensure_bank(node.bank_name)
+        bank = _ensure_bank(node.bank_name, result)
         if not bank:
             result.add_warning(
                 node.name, "bank account not created: no bank name on the ledger")

--- a/tally_migrator/erpnext/importers/banks.py
+++ b/tally_migrator/erpnext/importers/banks.py
@@ -28,12 +28,18 @@ from .base import ImportResult
 
 # ── Bank Account helpers (shared by party + company bank accounts) ─────────────
 
-def _ensure_bank(bank_name: str) -> str:
+def _ensure_bank(bank_name: str, result: "ImportResult | None" = None) -> str:
     """Return an existing/created Bank master name, or "" when no name is given.
 
     ERPNext's Bank Account requires a linked Bank; Tally only gives us its name,
     so we create the Bank master on demand. Best-effort: a failure returns "" and
-    the caller skips bank-account creation with a warning rather than aborting."""
+    the caller skips bank-account creation with a warning rather than aborting.
+
+    A Bank we actually create is recorded on ``result`` so revert removes it too
+    (the linked Bank Accounts are deleted first - company ones in the same manifest
+    bucket, party ones when the party goes - and the Bank delete is unforced, so one
+    still referenced elsewhere is safely kept). An already-existing Bank is never
+    recorded, so a pre-existing Bank is left untouched."""
     name = (bank_name or "").strip()
     if not name:
         return ""
@@ -42,6 +48,8 @@ def _ensure_bank(bank_name: str) -> str:
     try:
         frappe.get_doc({"doctype": "Bank", "bank_name": name}).insert(ignore_permissions=True)
         frappe.db.commit()
+        if result is not None:
+            result.add_created(name, "Bank")
         return name
     except Exception:
         frappe.db.rollback()

--- a/tally_migrator/erpnext/importers/items.py
+++ b/tally_migrator/erpnext/importers/items.py
@@ -289,7 +289,10 @@ class ItemImporter(BaseImporter):
 
         A failure here means items in that group will fall back to the default
         group, so it's recorded as a warning (visible loss of grouping) rather
-        than failing silently."""
+        than failing silently. A group we create is recorded on the manifest so
+        revert removes it too - the items that reference it are deleted first (same
+        bucket, reversed order) and the delete is unforced, so a group still used by
+        an item outside this run is kept."""
         for group in groups:
             if group and not frappe.db.exists("Item Group", group):
                 try:
@@ -298,6 +301,7 @@ class ItemImporter(BaseImporter):
                     ig.parent_item_group = DEFAULT_ITEM_GROUP
                     ig.insert(ignore_permissions=True)
                     frappe.db.commit()
+                    result.add_created(ig.name, "Item Group")
                 except Exception as exc:
                     frappe.log_error("Tally Migrator", f"Item Group creation failed: {group}: {exc}")
                     result.add_warning(group, f"item group not created: {exc}")

--- a/tally_migrator/erpnext/importers/openings.py
+++ b/tally_migrator/erpnext/importers/openings.py
@@ -935,6 +935,14 @@ class StockOpeningImporter:
         if not rows:
             return result  # no opening stock to post
 
+        # Batch-tracked rows post through a Serial and Batch Bundle, which ERPNext
+        # refuses to build unless Stock Settings > "Activate Serial and Batch No for
+        # Item" is on (it is off by default). It is a hard prerequisite for batch
+        # stock in ERPNext v15+, so enable it once when this import actually carries
+        # batch rows, and record it on the log so the change is visible.
+        if any(r.get("use_serial_batch_fields") for r in rows):
+            self._ensure_serial_batch_enabled(result)
+
         try:
             doc = frappe.get_doc({
                 "doctype": "Stock Reconciliation",
@@ -1090,7 +1098,17 @@ class StockOpeningImporter:
             # Batch-tracked item: tag the opening row with its Batch so the
             # reconciliation posts the quantity into that batch (the Batch master is
             # created first by BatchImporter).
+            #
+            # ERPNext v15+ models batch/serial stock through a Serial and Batch
+            # Bundle, not the legacy batch_no field. Stock Reconciliation.validate
+            # (set_current_serial_and_batch_bundle) throws "Please add Serial and
+            # Batch Bundle for Item ..." for any batch row unless use_serial_batch_fields
+            # is set. Setting it keeps the plain batch_no path: on_submit's
+            # make_bundle_using_old_serial_batch_fields then builds the Bundle from
+            # batch_no automatically. Without the flag the whole aggregate
+            # reconciliation fails to submit and no opening stock posts at all.
             row["batch_no"] = batch
+            row["use_serial_batch_fields"] = 1
         if rate == 0:
             # ERPNext rejects a positive opening qty at a zero rate
             # ("Valuation Rate required for Item …") unless the row explicitly
@@ -1106,6 +1124,22 @@ class StockOpeningImporter:
                 "opening stock has no book value. Set a valuation rate in ERPNext "
                 "if it should carry value.")
         by_key[key] = row
+
+    @staticmethod
+    def _ensure_serial_batch_enabled(result: ImportResult) -> None:
+        """Turn on Stock Settings > 'Activate Serial and Batch No for Item' if off.
+
+        Idempotent and global (Stock Settings is a Single). Required for ERPNext to
+        create the Serial and Batch Bundle that batch-tracked opening stock posts
+        through; we set it only when this import actually has batch rows."""
+        if frappe.db.get_single_value("Stock Settings", "enable_serial_and_batch_no_for_item"):
+            return
+        frappe.db.set_single_value("Stock Settings", "enable_serial_and_batch_no_for_item", 1)
+        result.add_warning(
+            "Opening Stock",
+            "enabled Stock Settings > 'Activate Serial and Batch No for Item' - it "
+            "was off, and ERPNext requires it to post batch-tracked opening stock. "
+            "Leave it on for batch/serial items to keep working.")
 
     def _existing_opening_stock(self) -> bool:
         """True when a non-cancelled Opening Stock reconciliation exists for the company."""

--- a/tally_migrator/erpnext/importers/party.py
+++ b/tally_migrator/erpnext/importers/party.py
@@ -54,10 +54,10 @@ class PartyImporter(BaseImporter):
 
         Best-effort and non-fatal: a group that can't be created just means those
         parties fall back to ``default_group`` (recorded as a warning so the lost
-        grouping is visible), never a failed party. Mirrors
-        ``ItemImporter._ensure_item_groups``: created groups are NOT added to the
-        run's manifest, exactly like Item Groups, so they are not company-scoped
-        and a revert leaves shared masters untouched."""
+        grouping is visible), never a failed party. A group we actually create is
+        recorded on the manifest so revert removes it too - the parties that
+        reference it are deleted first (same bucket, reversed order), and the delete
+        is unforced, so a group still used by a party outside this run is kept."""
         if not self.group_doctype:
             return
         for name in names:
@@ -74,6 +74,7 @@ class PartyImporter(BaseImporter):
                 doc.is_group = 0
                 doc.insert(ignore_permissions=True)
                 frappe.db.commit()
+                result.add_created(doc.name, self.group_doctype)
             except Exception as exc:
                 frappe.db.rollback()
                 frappe.log_error(
@@ -424,7 +425,7 @@ class PartyImporter(BaseImporter):
         acc_no = (data.get("BankAccountNo") or "").strip()
         if not acc_no:
             return
-        bank = _ensure_bank(data.get("BankName") or "")
+        bank = _ensure_bank(data.get("BankName") or "", result)
         if not bank:
             result.add_warning(
                 link_name, "bank account not created: no bank name on the ledger")

--- a/tally_migrator/erpnext/importers/prices.py
+++ b/tally_migrator/erpnext/importers/prices.py
@@ -4,6 +4,7 @@ price-list-scoped Pricing Rule for any per-level discount)."""
 import frappe
 
 from tally_migrator.naming import safe_item_code
+from tally_migrator.tally.mappings import UOM_MAP
 from .base import BaseImporter, ImportResult
 
 
@@ -168,8 +169,12 @@ class PriceImporter:
         if not raw:
             return None, ""
         rate_part, _, uom = raw.partition("/")
+        # Normalise the price-level unit the same way the item's stock UOM was resolved
+        # (e.g. "Pcs" -> "Nos"), so a price quoted in the item's own Tally unit matches
+        # it instead of being treated as a foreign unit and falling back with a warning.
+        uom = UOM_MAP.get(uom.strip(), uom.strip())
         try:
-            return float(rate_part.replace(",", "").strip()), uom.strip()
+            return float(rate_part.replace(",", "").strip()), uom
         except ValueError:
             return None, ""
 

--- a/tally_migrator/erpnext/importers/units.py
+++ b/tally_migrator/erpnext/importers/units.py
@@ -212,6 +212,11 @@ class UnitImporter:
             cat.insert(ignore_permissions=True)
             frappe.db.commit()
             if result is not None:
+                # Track it so revert removes the category too. Its UOM Conversion
+                # Factors are purged as a side effect when the run's UOMs are deleted,
+                # and the category delete is unforced - so it goes only once nothing
+                # references it, and is otherwise safely kept.
+                result.add_created(cat.name, "UOM Category")
                 result.add_warning(
                     "UOM Category",
                     "auto-created a 'Tally Imported' UOM Category to hold compound-unit "

--- a/tally_migrator/erpnext/uom_resolver.py
+++ b/tally_migrator/erpnext/uom_resolver.py
@@ -6,9 +6,25 @@ so the whitelisted endpoint stays thin (mirrors validation/engine.py).
 """
 from __future__ import annotations
 
+import re
 from typing import Iterable
 
 from tally_migrator.tally.mappings import UOM_MAP
+
+# Tally gives a service item the placeholder base unit "Not Applicable" (often
+# prefixed with a stray control char, e.g. "\x04 Not Applicable"). It is not a
+# real UOM - the service Item just keeps ERPNext's mandatory default (Nos) - so
+# it must never surface as a unit to create. Strip control chars before matching.
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f]")
+
+
+def _clean_uom(raw: str) -> str:
+    return _CONTROL_CHARS.sub("", raw or "").strip()
+
+
+def _is_real_uom(raw: str) -> bool:
+    cleaned = _clean_uom(raw)
+    return bool(cleaned) and cleaned.lower() != "not applicable"
 
 
 class UomResolver:
@@ -36,4 +52,4 @@ class UomResolver:
 
     @staticmethod
     def _unique(values: Iterable[str]) -> list[str]:
-        return sorted({(v or "").strip() for v in values if (v or "").strip()})
+        return sorted({_clean_uom(v) for v in values if _is_real_uom(v)})

--- a/tally_migrator/migration/master_migrator.py
+++ b/tally_migrator/migration/master_migrator.py
@@ -187,7 +187,8 @@ class MasterMigrator:
     }
 
     def __init__(self, config: TallyConfig, source, uom_overrides: dict | None = None,
-                 record_overrides: dict | None = None, log=None):
+                 record_overrides: dict | None = None, log=None,
+                 created_uoms: list | None = None):
         """``source`` is any object exposing ``ping()`` + ``get_collection``.
 
         In practice this is a :class:`FileTallySource` wrapping an uploaded
@@ -211,6 +212,11 @@ class MasterMigrator:
             coa_mode=getattr(config, "coa_mode", "reuse"),
         )
         self.record_overrides = record_overrides or {}
+        # UOMs the pre-flight "create as new" step (create_uoms) inserted BEFORE this
+        # run. The unit importer then skips them as already-existing and never records
+        # them, so they would survive a revert. We fold them into the manifest at
+        # finalize so revert undoes them too. See _track_wizard_uoms.
+        self.created_uoms = created_uoms or []
         self.applied_edits: list[dict] = []   # audit trail of effective pre-flight edits
         self.posting_date = getattr(config, "posting_date", "") or ""
         self.log = log
@@ -400,7 +406,9 @@ class MasterMigrator:
             self.log.extracted_counts = frappe.as_json({**masters.summary, **coa.summary})
             self.log.import_summary = frappe.as_json(summary.as_dict())
             self.log.applied_edits = frappe.as_json(self.applied_edits)
-            self.log.created_records = frappe.as_json(summary.created_records())
+            manifest = summary.created_records()
+            self._track_wizard_uoms(manifest)
+            self.log.created_records = frappe.as_json(manifest)
             self.log.reconciliation_report = frappe.as_json(self._reconciliation(masters, coa))
             self.log.set("errors", [])
             if summary.has_errors or summary.has_warnings:
@@ -411,6 +419,24 @@ class MasterMigrator:
             frappe.db.commit()
         except Exception as exc:
             frappe.log_error(f"Migration log finalize failed: {exc}", "Tally Migrator")
+
+    def _track_wizard_uoms(self, manifest: dict) -> None:
+        """Fold the pre-flight "create as new" UOMs into the manifest's Units entry so
+        revert undoes them.
+
+        These are inserted by the create_uoms endpoint BEFORE the run, so the unit
+        importer skips them as already-existing and never records them - leaving them
+        orphaned by revert. Only names the wizard reported creating are added, never
+        a pre-existing UOM (create_uoms returns those under "existing", not here), and
+        only if the UOM still exists. Revert deletes them unforced, so one still
+        referenced by a non-migration item is safely kept rather than force-removed."""
+        if not self.created_uoms:
+            return
+        units = manifest.setdefault("Units", [])
+        already = {(d.get("doctype"), d.get("name")) for d in units}
+        for name in self.created_uoms:
+            if ("UOM", name) not in already and frappe.db.exists("UOM", name):
+                units.append({"doctype": "UOM", "name": name})
 
     def _reconciliation(self, masters: ExtractedMasters, coa) -> dict:
         """Read-only post-import reconciliation summary (Tally figures vs ERPNext).

--- a/tally_migrator/migration/rollback.py
+++ b/tally_migrator/migration/rollback.py
@@ -161,6 +161,11 @@ _SIDE_EFFECTS = {
             # India Compliance's GST Settings child rows the UQC step writes; absent
             # on a site without india_compliance, so the purge is table-guarded.
             ("GST UOM Map", "uom")),
+    # The auto-created "Tally Imported" UOM Category is blocked by the UOM Conversion
+    # Factors that name it. Purge those when the category is deleted so it goes
+    # regardless of whether every owning UOM was removed first (order-independent) -
+    # they are this run's own conversions (all in this category), so this is safe.
+    "UOM Category": (("UOM Conversion Factor", "category"),),
 }
 
 
@@ -216,6 +221,15 @@ def _purge_party_links(party_type: str, party: str) -> list[dict]:
     contacts, bank accounts), not silent plumbing, so the audit must show them.
     """
     purged: list[dict] = []
+    # The party doc holds its own primary links (customer_primary_address /
+    # _contact, or the supplier_* equivalents - all core ERPNext fields). These
+    # point AT the Address/Contact, so delete_doc on that record is refused
+    # ("Cannot delete ... linked with <Party>") and the party is kept. The party is
+    # about to be deleted, so clear the links first; a direct db.set_value (plain
+    # UPDATE, no doc reload) is enough and the field set differs only by prefix.
+    prefix = party_type.lower()
+    for field in (f"{prefix}_primary_address", f"{prefix}_primary_contact"):
+        frappe.db.set_value(party_type, party, field, None)
     for linked_dt in ("Contact", "Address"):
         names = frappe.get_all(
             "Dynamic Link",
@@ -278,6 +292,21 @@ def _delete_one(row: dict, protected: set) -> str | None:
             doc.cancel()
             for ledger in _LEDGER_DOCTYPES:
                 frappe.db.delete(ledger, {"voucher_no": name})
+            # The opening Stock Reconciliation auto-creates a Serial and Batch Bundle
+            # per batch-tracked row (we set use_serial_batch_fields on those rows).
+            # Cancelling the reconciliation only delinks the Bundle and flags it
+            # is_cancelled - the submitted Bundle doc lingers with voucher_no still
+            # pointing here, and ERPNext's link check would then block the unforced
+            # delete of the reconciliation, leaving it kept. Cancel already removed
+            # its stock effect (the Stock Ledger Entries were purged just above), and
+            # is_cancelled lets the Bundle's on_trash guard pass, so force-delete each
+            # Bundle (cascading its child entries) before the voucher is removed.
+            if frappe.db.table_exists("Serial and Batch Bundle"):
+                for bundle in frappe.get_all(
+                        "Serial and Batch Bundle",
+                        filters={"voucher_no": name}, pluck="name"):
+                    frappe.delete_doc("Serial and Batch Bundle", bundle,
+                                      force=True, ignore_permissions=True)
         # Clear ERPNext's derived side-effect rows for this master (Repost Item
         # Valuation, UOM Conversion Factor, GST UOM Map) before the delete, so they
         # don't block it. Scoped to this master's name, inside the savepoint, so a

--- a/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
+++ b/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
@@ -138,9 +138,10 @@ class TallyMigratorPage {
 						<div id="configure-counts" style="margin-top:10px;"></div>
 					</div>
 
-					<button id="btn-back-2" class="btn btn-default btn-sm">${TallyMigratorPage.navIcon("left")} Back</button>
-					&nbsp;
-					<button id="btn-next-2" class="btn btn-primary btn-sm">Continue ${TallyMigratorPage.navIcon("right")}</button>
+					<div style="margin-top:24px; display:flex; justify-content:space-between; align-items:center;">
+						<button id="btn-back-2" class="btn btn-default btn-sm">${TallyMigratorPage.navIcon("left")} Back</button>
+						<button id="btn-next-2" class="btn btn-primary btn-sm">Continue ${TallyMigratorPage.navIcon("right")}</button>
+					</div>
 				</div>
 
 				<!-- STEP 3: Pre-flight check -->
@@ -189,12 +190,14 @@ class TallyMigratorPage {
 					</div>
 
 
-					<div style="margin-top:24px;">
-						<button id="btn-back-check" class="btn btn-default btn-sm">${TallyMigratorPage.navIcon("left")} Back</button>
-						&nbsp;
+					<div style="margin-top:24px; display:flex; justify-content:space-between; align-items:center;">
+						<div>
+							<button id="btn-back-check" class="btn btn-default btn-sm">${TallyMigratorPage.navIcon("left")} Back</button>
+							&nbsp;
+							<button id="btn-startover-check" class="btn btn-default btn-sm"
+								style="color:var(--text-muted, #8d99a6);">Start over</button>
+						</div>
 						<button id="btn-next-check" class="btn btn-primary btn-sm">Continue ${TallyMigratorPage.navIcon("right")}</button>
-						<button id="btn-startover-check" class="btn btn-default btn-sm pull-right"
-							style="color:var(--text-muted, #8d99a6);">Start over</button>
 					</div>
 				</div>
 
@@ -211,9 +214,8 @@ class TallyMigratorPage {
 					<div id="review-all" style="margin-bottom:16px;"></div>
 					<div id="review-parties"></div>
 
-					<div style="margin-top:24px;">
+					<div style="margin-top:24px; display:flex; justify-content:space-between; align-items:center;">
 						<button id="btn-back-review" class="btn btn-default btn-sm">${TallyMigratorPage.navIcon("left")} Back</button>
-						&nbsp;
 						<button id="btn-next-review" class="btn btn-primary btn-sm">Continue ${TallyMigratorPage.navIcon("right")}</button>
 					</div>
 				</div>
@@ -235,9 +237,10 @@ class TallyMigratorPage {
 					<div id="error-section" style="display:none; background:var(--red-100, #fff0f0); border:1px solid var(--red-200, #fcd7d7); border-radius:8px; padding:12px 14px;"></div>
 
 					<div id="run-actions">
-						<button id="btn-back-3" class="btn btn-default btn-sm">${TallyMigratorPage.navIcon("left")} Back</button>
-						&nbsp;
-						<button id="btn-run" class="btn btn-primary btn-sm">Run Migration</button>
+						<div style="display:flex; justify-content:space-between; align-items:center;">
+							<button id="btn-back-3" class="btn btn-default btn-sm">${TallyMigratorPage.navIcon("left")} Back</button>
+							<button id="btn-run" class="btn btn-primary btn-sm">Run Migration</button>
+						</div>
 					</div>
 				</div>
 
@@ -1455,6 +1458,10 @@ class TallyMigratorPage {
 			callback: (r) => {
 				frappe.dom.unfreeze();
 				const res = r.message || {};
+				// Remember the units we actually created here so the run can record
+				// them in its revert manifest - they're inserted before the run, so the
+				// importer skips them and would otherwise orphan them on revert.
+				this.createdUoms = (this.createdUoms || []).concat(res.created || []);
 				const failed = res.failed || {};
 				if (Object.keys(failed).length) {
 					const lines = Object.entries(failed)
@@ -1869,6 +1876,7 @@ class TallyMigratorPage {
 				record_overrides: JSON.stringify(this.recordOverrides || {}),
 				coa_mode: $("#coa-mode").val() || "reuse",
 				posting_date: $("#opening-date").val() || "",
+				created_uoms: JSON.stringify(this.createdUoms || []),
 			},
 			callback: (r) => {
 				const summary = r.message;

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -268,6 +268,35 @@ class TestERPNextImporter(unittest.TestCase):
         row = next(iter(by_key.values()))
         self.assertEqual(row["batch_no"], "_TMTest BATCH1")
         self.assertEqual(row["qty"], 90.0)
+        # ERPNext v15+ throws "Please add Serial and Batch Bundle" on a batch row
+        # unless use_serial_batch_fields is set; with it, on_submit builds the bundle
+        # from batch_no. Without this the whole opening-stock reconciliation fails.
+        self.assertEqual(row["use_serial_batch_fields"], 1)
+
+    def test_ensure_serial_batch_enabled_flips_setting_when_off(self):
+        from unittest import mock
+        from tally_migrator.erpnext.importers import StockOpeningImporter
+        from tally_migrator.erpnext.importers.base import ImportResult
+        from tally_migrator.erpnext.importers import openings
+        res = ImportResult("Stock Reconciliation")
+        with mock.patch.object(openings.frappe.db, "get_single_value", return_value=0), \
+             mock.patch.object(openings.frappe.db, "set_single_value") as set_single:
+            StockOpeningImporter._ensure_serial_batch_enabled(res)
+        set_single.assert_called_once_with(
+            "Stock Settings", "enable_serial_and_batch_no_for_item", 1)
+        self.assertTrue(res.warnings)   # the flip is recorded on the log
+
+    def test_ensure_serial_batch_enabled_noop_when_already_on(self):
+        from unittest import mock
+        from tally_migrator.erpnext.importers import StockOpeningImporter
+        from tally_migrator.erpnext.importers.base import ImportResult
+        from tally_migrator.erpnext.importers import openings
+        res = ImportResult("Stock Reconciliation")
+        with mock.patch.object(openings.frappe.db, "get_single_value", return_value=1), \
+             mock.patch.object(openings.frappe.db, "set_single_value") as set_single:
+            StockOpeningImporter._ensure_serial_batch_enabled(res)
+        set_single.assert_not_called()
+        self.assertFalse(res.warnings)
 
     def test_parse_expiry_formats(self):
         from tally_migrator.erpnext.importers.batch import BatchImporter
@@ -291,6 +320,8 @@ class TestERPNextImporter(unittest.TestCase):
             imp._add_opening_row(by_key, "PlainItem", wh, q, r, v, None, res, batch=batch)
         row = next(iter(by_key.values()))
         self.assertNotIn("batch_no", row)
+        # No batch_no -> the bundle flag must stay off too (a plain qty/warehouse row).
+        self.assertNotIn("use_serial_batch_fields", row)
 
     def test_batch_importer_skips_non_batch_items(self):
         """A non-batch item carrying an implicit 'Primary Batch' must not get a Batch."""
@@ -483,6 +514,64 @@ class TestERPNextImporter(unittest.TestCase):
         with mock.patch("frappe.db.exists", return_value=False):
             doc = imp.build_doc({"_name": "Acme", "Parent": "Trade Debtors - Domestic"})
         self.assertEqual(doc["customer_group"], DEFAULT_CUSTOMER_GROUP)
+
+    # ── Auto-created reference masters are tracked so revert removes them ────────
+    def test_party_group_creation_is_tracked_for_revert(self):
+        from unittest import mock
+        from tally_migrator.erpnext.importers import CustomerImporter
+        from tally_migrator.erpnext.importers.base import ImportResult
+        imp = CustomerImporter("_TMTest Co", "TC")
+        res = ImportResult("Customer")
+        fake = mock.MagicMock(); fake.name = "Trade Debtors"
+        with mock.patch("frappe.db.exists", return_value=False), \
+             mock.patch("frappe.new_doc", return_value=fake), \
+             mock.patch("frappe.db.commit"):
+            imp._ensure_party_groups({"Trade Debtors"}, res)
+        self.assertIn({"name": "Trade Debtors", "doctype": "Customer Group"}, res.created_docs)
+
+    def test_item_group_creation_is_tracked_for_revert(self):
+        from unittest import mock
+        from tally_migrator.erpnext.importers import ItemImporter
+        from tally_migrator.erpnext.importers.base import ImportResult
+        imp = ItemImporter("_TMTest Co", "TC")
+        res = ImportResult("Item")
+        fake = mock.MagicMock(); fake.name = "Stationery"
+        with mock.patch("frappe.db.exists", return_value=False), \
+             mock.patch("frappe.new_doc", return_value=fake), \
+             mock.patch("frappe.db.commit"):
+            imp._ensure_item_groups({"Stationery"}, res)
+        self.assertIn({"name": "Stationery", "doctype": "Item Group"}, res.created_docs)
+
+    def test_bank_creation_is_tracked_for_revert(self):
+        from unittest import mock
+        from tally_migrator.erpnext.importers import banks
+        from tally_migrator.erpnext.importers.base import ImportResult
+        res = ImportResult("Account")
+        with mock.patch.object(banks.frappe.db, "exists", return_value=False), \
+             mock.patch.object(banks.frappe, "get_doc"), \
+             mock.patch.object(banks.frappe.db, "commit"):
+            out = banks._ensure_bank("HDFC Bank", res)
+        self.assertEqual(out, "HDFC Bank")
+        self.assertIn({"name": "HDFC Bank", "doctype": "Bank"}, res.created_docs)
+        # An already-existing Bank must NOT be recorded (leave pre-existing data alone).
+        res2 = ImportResult("Account")
+        with mock.patch.object(banks.frappe.db, "exists", return_value=True):
+            banks._ensure_bank("HDFC Bank", res2)
+        self.assertEqual(res2.created_docs, [])
+
+    def test_uom_category_creation_is_tracked_for_revert(self):
+        from unittest import mock
+        from tally_migrator.erpnext.importers import units
+        from tally_migrator.erpnext.importers.units import UnitImporter
+        from tally_migrator.erpnext.importers.base import ImportResult
+        res = ImportResult("UOM")
+        fake = mock.MagicMock(); fake.name = "Tally Imported"
+        with mock.patch.object(units.frappe.db, "has_column", return_value=True), \
+             mock.patch.object(units.frappe, "get_all", return_value=[]), \
+             mock.patch.object(units.frappe, "get_doc", return_value=fake), \
+             mock.patch.object(units.frappe.db, "commit"):
+            UnitImporter._uom_category(res)
+        self.assertIn({"name": "Tally Imported", "doctype": "UOM Category"}, res.created_docs)
 
     # ── Re-run idempotency guards (no DB - guard stubbed) ───────────────────────
 

--- a/tally_migrator/tests/test_prices.py
+++ b/tally_migrator/tests/test_prices.py
@@ -44,6 +44,9 @@ class TestParsers(unittest.TestCase):
         self.assertEqual(PriceImporter._parse_rate("360.00"), (360.0, ""))
         self.assertEqual(PriceImporter._parse_rate(""), (None, ""))
         self.assertEqual(PriceImporter._parse_rate("x/Ream"), (None, ""))
+        # The price-level unit is normalised through UOM_MAP (like the item's stock
+        # UOM), so "Pcs" resolves to "Nos" and matches the item instead of warning.
+        self.assertEqual(PriceImporter._parse_rate("50.00/Pcs"), (50.0, "Nos"))
 
     def test_parse_qty_and_date(self):
         self.assertEqual(PriceImporter._parse_qty(" 100 Ream"), 100.0)

--- a/tally_migrator/tests/test_rollback.py
+++ b/tally_migrator/tests/test_rollback.py
@@ -13,6 +13,15 @@ import frappe
 from tally_migrator.migration import rollback
 
 
+class TestSideEffects(unittest.TestCase):
+    def test_uom_category_purges_its_conversion_factors(self):
+        # The auto-created "Tally Imported" UOM Category is blocked by UOM Conversion
+        # Factors naming it; deleting the category must purge those first so it goes
+        # regardless of UOM deletion order.
+        self.assertIn(("UOM Conversion Factor", "category"),
+                      rollback._SIDE_EFFECTS["UOM Category"])
+
+
 class TestDeletionOrder(unittest.TestCase):
     """_deletion_order flattens the manifest into reverse-creation order."""
 
@@ -99,6 +108,7 @@ class TestDeleteOneSafety(unittest.TestCase):
             # no side-effect tables, no party links to purge.
             mock.patch.object(rollback.frappe.db, "table_exists", return_value=False),
             mock.patch.object(rollback.frappe.db, "delete", lambda *a, **k: None),
+            mock.patch.object(rollback.frappe.db, "set_value", lambda *a, **k: None),
             mock.patch.object(rollback.frappe, "get_all", return_value=[]),
             mock.patch.object(rollback.frappe, "get_doc",
                               return_value=mock.Mock(docstatus=0)),
@@ -126,6 +136,42 @@ class TestDeleteOneSafety(unittest.TestCase):
         reason = rollback._delete_one({"doctype": "Item", "name": "Widget"}, set())
         self.assertIn("SI-9", reason)                          # kept + reported, not deleted
 
+    def test_recon_bundle_force_deleted_before_voucher(self):
+        # The opening Stock Reconciliation auto-creates a Serial and Batch Bundle per
+        # batch row. Cancelling the recon only delinks + flags it; the submitted
+        # Bundle would block the recon's unforced delete. _delete_one must force-delete
+        # the Bundle (found by voucher_no) BEFORE deleting the reconciliation.
+        deleted = []
+
+        def fake_delete_doc(doctype, name, **kw):
+            deleted.append((doctype, name, kw.get("force")))
+
+        patches = [
+            mock.patch.object(rollback.frappe.db, "exists", return_value=True),
+            mock.patch.object(rollback.frappe.db, "savepoint", lambda *a, **k: None),
+            mock.patch.object(rollback.frappe.db, "rollback", lambda *a, **k: None),
+            mock.patch.object(rollback.frappe.db, "delete", lambda *a, **k: None),
+            mock.patch.object(rollback.frappe.db, "table_exists", return_value=True),
+            mock.patch.object(rollback.frappe, "get_all",
+                              side_effect=lambda dt, **k: ["SBB-1"]
+                              if dt == "Serial and Batch Bundle" else []),
+            mock.patch.object(rollback.frappe, "get_doc",
+                              return_value=mock.Mock(docstatus=1)),
+            mock.patch.object(rollback.frappe, "delete_doc", side_effect=fake_delete_doc),
+            mock.patch.object(rollback.frappe, "local", mock.Mock(message_log=[])),
+        ]
+        for p in patches:
+            p.start()
+        self.addCleanup(lambda: [p.stop() for p in patches])
+        reason = rollback._delete_one(
+            {"doctype": "Stock Reconciliation", "name": "SR-1"}, set())
+        self.assertIsNone(reason)
+        # Bundle force-deleted, and ordered before the reconciliation itself.
+        self.assertEqual(deleted[0], ("Serial and Batch Bundle", "SBB-1", True))
+        self.assertIn(("Stock Reconciliation", "SR-1", None), deleted)
+        self.assertLess(deleted.index(("Serial and Batch Bundle", "SBB-1", True)),
+                        deleted.index(("Stock Reconciliation", "SR-1", None)))
+
 
 class TestPurgePartyLinks(unittest.TestCase):
     """_purge_party_links must never strip a record shared with another party, and
@@ -138,7 +184,7 @@ class TestPurgePartyLinks(unittest.TestCase):
         ``link_rows_by_parent`` -> every link row on a given parent (to detect sharing);
         ``bank_accounts`` -> names returned for the Bank Account query.
         """
-        deleted, dl_deletes = [], []
+        deleted, dl_deletes, cleared = [], [], []
 
         def fake_get_all(doctype, filters=None, pluck=None, fields=None):
             if doctype == "Dynamic Link" and "link_name" in (filters or {}):
@@ -156,6 +202,8 @@ class TestPurgePartyLinks(unittest.TestCase):
             mock.patch.object(rollback.frappe, "get_all", side_effect=fake_get_all),
             mock.patch.object(rollback.frappe.db, "exists", return_value=True),
             mock.patch.object(rollback.frappe.db, "delete", side_effect=fake_db_delete),
+            mock.patch.object(rollback.frappe.db, "set_value",
+                              side_effect=lambda dt, nm, f, v: cleared.append((dt, nm, f, v))),
             mock.patch.object(rollback.frappe, "delete_doc",
                               side_effect=lambda dt, nm, **k: deleted.append((dt, nm))),
         ]
@@ -163,6 +211,7 @@ class TestPurgePartyLinks(unittest.TestCase):
             p.start()
         self.addCleanup(lambda: [p.stop() for p in patches])
         purged = rollback._purge_party_links("Customer", "ACME")
+        self._cleared = cleared
         return purged, deleted, dl_deletes
 
     def test_unshared_records_deleted_and_reported(self):
@@ -197,6 +246,22 @@ class TestPurgePartyLinks(unittest.TestCase):
         self.assertEqual(len(dl_deletes), 1)
         self.assertEqual(dl_deletes[0][1]["link_name"], "ACME")
         self.assertEqual(purged, [])  # nothing actually deleted -> nothing to report
+
+    def test_primary_links_cleared_before_deleting_records(self):
+        # The party's own customer_primary_address/_contact point at the Address/
+        # Contact, so deleting those is refused until the links are cleared. They
+        # must be nulled (one set_value per primary field) so the records - and then
+        # the party - can be removed.
+        self._run(
+            dynamic_links={"Address": ["ADDR-1"], "Contact": ["CON-1"]},
+            link_rows_by_parent={
+                "ADDR-1": [{"link_doctype": "Customer", "link_name": "ACME"}],
+                "CON-1": [{"link_doctype": "Customer", "link_name": "ACME"}],
+            },
+            bank_accounts=[],
+        )
+        self.assertIn(("Customer", "ACME", "customer_primary_address", None), self._cleared)
+        self.assertIn(("Customer", "ACME", "customer_primary_contact", None), self._cleared)
 
 
 class TestRevertGuards(unittest.TestCase):

--- a/tally_migrator/tests/test_summary.py
+++ b/tally_migrator/tests/test_summary.py
@@ -1,8 +1,10 @@
 """Unit tests for MigrationSummary (no DB required)."""
 import unittest
+from unittest import mock
 
 from tally_migrator.erpnext.importers import ImportResult
-from tally_migrator.migration.master_migrator import MigrationSummary
+from tally_migrator.migration import master_migrator
+from tally_migrator.migration.master_migrator import MasterMigrator, MigrationSummary
 
 
 def _result(doctype, created=0, skipped=0, errors=(), created_names=(), warnings=()):
@@ -126,6 +128,42 @@ class TestMigrationSummary(unittest.TestCase):
     def test_error_records_empty_when_clean(self):
         s = _summary(_result("Warehouse", created=1), _result("Customer", created=2), _result("Supplier"), _result("Item"))
         self.assertEqual(s.error_records(), [])
+
+
+class TestTrackWizardUoms(unittest.TestCase):
+    """The pre-flight 'create as new' UOMs are inserted before the run, so the unit
+    importer skips them and never records them. _track_wizard_uoms folds them into the
+    manifest so revert undoes them - but only the ones that actually exist, and never
+    a duplicate of one the importer already recorded."""
+
+    def _migrator(self, created_uoms):
+        m = object.__new__(MasterMigrator)   # bypass __init__ (needs a live source)
+        m.created_uoms = created_uoms
+        return m
+
+    def test_existing_wizard_uoms_added_without_duplicates(self):
+        m = self._migrator(["Dozen", "Ream", "Ghost"])
+        manifest = {"Units": [{"doctype": "UOM", "name": "Pcs"},
+                              {"doctype": "UOM", "name": "Dozen"}]}  # Dozen already tracked
+        # Ghost was reported created but no longer exists -> must be skipped.
+        with mock.patch.object(master_migrator.frappe.db, "exists",
+                               side_effect=lambda dt, n: n in {"Dozen", "Ream"}):
+            m._track_wizard_uoms(manifest)
+        names = [d["name"] for d in manifest["Units"]]
+        self.assertEqual(names, ["Pcs", "Dozen", "Ream"])  # Ream added; no dup Dozen; no Ghost
+
+    def test_creates_units_label_when_absent(self):
+        m = self._migrator(["Ream"])
+        manifest = {}   # run created no Unit masters of its own
+        with mock.patch.object(master_migrator.frappe.db, "exists", return_value=True):
+            m._track_wizard_uoms(manifest)
+        self.assertEqual(manifest["Units"], [{"doctype": "UOM", "name": "Ream"}])
+
+    def test_no_wizard_uoms_leaves_manifest_untouched(self):
+        m = self._migrator([])
+        manifest = {"Items": [{"doctype": "Item", "name": "X"}]}
+        m._track_wizard_uoms(manifest)
+        self.assertEqual(manifest, {"Items": [{"doctype": "Item", "name": "X"}]})
 
 
 if __name__ == "__main__":

--- a/tally_migrator/tests/test_uom_resolver.py
+++ b/tally_migrator/tests/test_uom_resolver.py
@@ -34,6 +34,16 @@ class TestUomResolver(unittest.TestCase):
         r = UomResolver([" Nos ", "Kg", "", "Nos"])
         self.assertEqual(r.existing_sorted, ["Kg", "Nos"])  # trimmed, deduped, sorted
 
+    def test_not_applicable_placeholder_is_dropped(self):
+        # A Tally service item carries the base unit "Not Applicable", often with a
+        # stray control char (e.g. "\x04 Not Applicable"). It is not a real UOM - the
+        # service Item keeps ERPNext's mandatory default - so it must not surface as
+        # a unit to resolve/create, while real units around it still do.
+        r = UomResolver(["Nos"])
+        names = [i["tally_uom"] for i in
+                 r.issues_for(["Ream", "\x04 Not Applicable", "Not Applicable", "Dozen"])]
+        self.assertEqual(names, ["Dozen", "Ream"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
End-to-end fixes validated on a fresh ERPNext v16 site importing `GSTTDS.xml`.

### Batch opening stock (v15+)
- Set `use_serial_batch_fields` on batch Stock Reconciliation rows → ERPNext builds the Serial and Batch Bundle from `batch_no` (validate otherwise throws "Please add Serial and Batch Bundle").
- Auto-enable Stock Settings **Activate Serial and Batch No for Item** (off by default) when an import has batch rows — required to create the bundle. Logged as a warning.

### Revert coverage
- Clear a party's `*_primary_address`/`*_primary_contact` before deleting its Address/Contact, so parties no longer stay "Cannot delete … linked with".
- Force-delete the auto-created Serial and Batch Bundle (by `voucher_no`) before deleting a cancelled opening Stock Reconciliation.
- Track masters the run creates so revert removes them: step-3 "create as new" UOMs (`MasterMigrator._track_wizard_uoms`), **Bank** masters, **Customer/Supplier Groups**, lazy **Item Groups**, and the **"Tally Imported" UOM Category** (with a `_SIDE_EFFECTS` purge of its conversion factors so it deletes order-independently). All deletes stay **unforced** — a master still referenced outside this run is kept, never force-removed.

### UOM / prices
- Drop Tally's `Not Applicable` service placeholder (control-char stripped) from the UOM resolution step.
- Normalise the price-level unit through `UOM_MAP` (`Pcs` → `Nos`) so it matches the item instead of warning + falling back.

### Wizard UI
- Consistent footers: primary action (Continue/Run) flush-right, Back/Start over flush-left; step 1 keeps its single button left.

## Testing
- `bench run-tests --app tally_migrator` → **425 passing** (added regression tests for each fix).
- Manually validated on a reinstalled site: batch opening stock posts (recon submitted, 3 bundles, 29 SLEs), UOM step shows only real units, footers aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)