### PR TITLE
Document the exact Tally export recipe (wizard step 1 + README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,24 @@ You need:
   tax rates, GST unit codes, GST registration type). It is optional: without it the
   core records still import, and anything GST-specific is skipped with a note in the
   log so nothing disappears silently.
-- Your data exported from Tally as **"Export Masters (XML)"**.
+- Your data exported from Tally as a **Masters XML** file (see below).
+
+### Exporting your data from Tally
+
+In Tally, go to **Gateway of Tally → Export → Masters → Configure**, set the
+following, then choose **Export**:
+
+| Setting | Value |
+|---|---|
+| Type of master | **All Masters** |
+| Include dependent masters | **Yes** |
+| Export closing balance as opening balance | **Yes** |
+| File Format | **XML (Data Interchange)** |
+
+"Export closing balance as opening balance" is what turns last year's closing
+figures into this year's opening balances in ERPNext, so don't skip it. Tally
+writes a `Master.xml` file (to the folder shown in the export screen) - that's the
+file you upload in step 1.
 
 ---
 

--- a/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
+++ b/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
@@ -69,11 +69,17 @@ class TallyMigratorPage {
 					<div class="tm-section" style="margin-top:var(--margin-lg);">
 						<strong>First, export a file from Tally</strong>
 						<ol style="margin:var(--margin-sm) 0 0 0; padding-left:20px; font-size:var(--text-md); line-height:1.7;">
-							<li>Open your company in <strong>Tally Prime</strong>.</li>
-							<li>Go to <strong>Gateway of Tally → Import/Export → Export</strong>.</li>
-							<li>Choose <strong>Masters</strong> as the type.</li>
-							<li>Set <strong>Format</strong> to <strong>XML</strong>, and <strong>Show All Masters</strong> to <strong>Yes</strong>.</li>
-							<li>Export, and note where the <code>.xml</code> file is saved.</li>
+							<li>Open your company in Tally Prime.</li>
+							<li>Go to <strong>Gateway of Tally → Export → Masters</strong>, then open Configure.</li>
+							<li>Set these options:
+								<ul style="margin:var(--margin-xs) 0 0 0; padding-left:18px; list-style:disc;">
+									<li>Type of master: <strong>All Masters</strong></li>
+									<li>Include dependent masters: <strong>Yes</strong></li>
+									<li>Export closing balance as opening balance: <strong>Yes</strong> (this becomes your opening balances in ERPNext)</li>
+									<li>File Format: <strong>XML (Data Interchange)</strong></li>
+								</ul>
+							</li>
+							<li>Choose Export, and note where the <code>Master.xml</code> file is saved.</li>
 						</ol>
 					</div>
 


### PR DESCRIPTION
Step 1's export instructions were missing the two settings that matter most: "Include dependent masters = Yes" and, critically, "Export closing balance as opening balance = Yes" (without it, no opening balances come across).

- Updates the path to Gateway of Tally → Export → Masters → Configure and lists the exact options, in both the wizard's step 1 and the README.
- Trims the heavy bolding in step 1: bold only the navigation path and the values to choose; setting names, prose, and the file name stay plain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)