### PR TITLE
Show pre-flight UOM resolutions in the migration log audit trail

### DIFF
--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -540,9 +540,18 @@ Check step), kept for the record, grouped by type with the affected records.
 
 ### Applied edits
 
-If you fixed any values on the Check step, this lists each one: which field on which
-record changed, and its old and new values. The uploaded file itself was never
-modified, so this is the authoritative record of what you changed.
+If you changed anything on the Check step, this lists each change so you have an
+authoritative record of what you adjusted. It covers two kinds of edit:
+
+- **Field fixes** - which field on which record changed, with its old and new values
+  (for example a customer's PIN code or GSTIN).
+- **Unit resolutions** - each Tally unit you resolved, shown as either "Mapped to
+  existing unit" (for example Carton to Box) or "Created as new unit", with the Tally
+  name and the resulting ERPNext unit.
+
+The uploaded file itself is never modified, so this table is the authoritative record
+of what you changed before import. (Automatic unit normalisations the app does on its
+own, such as "Kgs" to "Kg", are not listed here because they are not your edits.)
 
 ### Accounts mapping
 

--- a/tally_migrator/migration/master_migrator.py
+++ b/tally_migrator/migration/master_migrator.py
@@ -6,7 +6,7 @@ import frappe
 from tally_migrator.tally.config import TallyConfig
 from tally_migrator.tally.extractors import TallyExtractor, ExtractedMasters
 from tally_migrator.erpnext.importers import ERPNextImporter, ImportResult
-from tally_migrator.migration.overrides import apply_record_overrides
+from tally_migrator.migration.overrides import apply_record_overrides, uom_edits
 
 
 def _collapse_identical(rows: list[dict], sample: int = 5) -> list[dict]:
@@ -237,6 +237,7 @@ class MasterMigrator:
             self._progress(10)
             masters = self.extractor.extract_all()
             apply_record_overrides(masters, self.record_overrides, self.applied_edits)
+            self._record_uom_edits()
             coa = self.extractor.extract_coa()
             # Bill-wise party opening detail (BILLALLOCATIONS) - empty when the
             # source can't supply child lists, so party openings then degrade to a
@@ -368,6 +369,19 @@ class MasterMigrator:
             },
             user=frappe.session.user,
         )
+
+    def _record_uom_edits(self) -> None:
+        """Fold the pre-flight UOM resolutions into the applied-edits audit trail.
+
+        Resolving a unit on the Check screen is a real pre-flight decision, like a
+        per-record field fix, but UOM choices travel on their own channel
+        (``uom_overrides`` / ``created_uoms``) and so were absent from the audit
+        table. We append them here (after the field edits) so the log shows every
+        change the user made. On a re-run ``created_uoms`` isn't replayed, but by then
+        those units exist, so they read as "Mapped to existing unit" - accurate for
+        that run. See :func:`uom_edits` for the row shape and exclusions.
+        """
+        self.applied_edits.extend(uom_edits(self.uom_overrides, self.created_uoms))
 
     # ── Migration log lifecycle ──────────────────────────────────────────────────
 

--- a/tally_migrator/migration/overrides.py
+++ b/tally_migrator/migration/overrides.py
@@ -59,3 +59,32 @@ def apply_record_overrides(masters, overrides: dict | None, changelog: list | No
                     })
                 record[field] = value
     return masters
+
+
+def uom_edits(uom_overrides: dict | None,
+              created_uoms: list | None = None) -> list[dict]:
+    """Audit-trail rows for the pre-flight UOM resolutions, in the same shape as the
+    field-edit changelog so they can be folded into the same "Applied edits" table.
+
+    A unit resolved on the Check screen is either *mapped to an existing* ERPNext UOM
+    (e.g. Carton -> Box) or *created as a new* unit; ``created_uoms`` (the units the
+    user chose to create) decides which label a row gets. ``old`` is the Tally unit
+    and ``new`` the resulting ERPNext unit, so a create-with-rename (e.g. Pkt ->
+    Packet) reads correctly too.
+
+    Pure: automatic ``UOM_MAP`` normalisations never reach ``uom_overrides`` (only
+    user-resolved units do), so they are naturally excluded - this lists user
+    decisions only, exactly like the record overrides above.
+    """
+    created = set(created_uoms or [])
+    return [
+        {
+            "entity_type": "Unit",
+            "record_name": tally_uom,
+            "field": ("Created as new unit" if erpnext_uom in created
+                      else "Mapped to existing unit"),
+            "old": tally_uom,
+            "new": erpnext_uom,
+        }
+        for tally_uom, erpnext_uom in (uom_overrides or {}).items()
+    ]

--- a/tally_migrator/tally_migration/doctype/tally_migration_log/tally_migration_log.js
+++ b/tally_migrator/tally_migration/doctype/tally_migration_log/tally_migration_log.js
@@ -796,9 +796,11 @@ function render_created(frm) {
 }
 
 // ── Applied-edits audit trail ───────────────────────────────────────────────
-// Renders the exact pre-flight (step 3) edits that were applied to the data
-// before import: which field on which record changed, old → new. The source
-// XML is never modified, so this is the authoritative record of what changed.
+// Renders the exact pre-flight (step 3) changes that were applied to the data
+// before import: per-record field fixes (which field on which record changed,
+// old → new) and unit-of-measure resolutions (each Tally unit mapped to an
+// existing UOM or created as a new one). The source XML is never modified, so
+// this is the authoritative record of what changed.
 
 function render_edits(frm) {
 	const field = frm.get_field("edits_view");
@@ -846,7 +848,7 @@ function render_edits(frm) {
 	wrapper.html(section(`
 		<div style="${CARD}">
 			<div class="text-muted small" style="margin-bottom:6px;">
-				<strong>${edits.length}</strong> field edit(s) were applied on the pre-flight
+				<strong>${edits.length}</strong> change(s) were applied on the pre-flight
 				screen before this run. The uploaded file was not modified.
 			</div>
 			${collapsible(edits.length, `Show all ${edits.length} edit(s)`, table)}

--- a/tally_migrator/tests/test_overrides.py
+++ b/tally_migrator/tests/test_overrides.py
@@ -4,7 +4,7 @@
 import unittest
 
 from tally_migrator.tally.extractors import ExtractedMasters
-from tally_migrator.migration.overrides import apply_record_overrides
+from tally_migrator.migration.overrides import apply_record_overrides, uom_edits
 from tally_migrator.validation.engine import (
     validate_masters, group_report, records_by_key, erpnext_states, EDITABLE_FIELDS,
 )
@@ -101,6 +101,30 @@ class TestEditableReport(unittest.TestCase):
 
     def test_duplicate_party_is_not_editable(self):
         self.assertNotIn("DUPLICATE_PARTY", EDITABLE_FIELDS)
+
+
+class TestUomEdits(unittest.TestCase):
+    def test_map_to_existing_is_labelled(self):
+        rows = uom_edits({"Carton": "Box"}, created_uoms=[])
+        self.assertEqual(rows, [{
+            "entity_type": "Unit", "record_name": "Carton",
+            "field": "Mapped to existing unit", "old": "Carton", "new": "Box",
+        }])
+
+    def test_create_as_new_is_labelled_and_shows_rename(self):
+        rows = uom_edits({"Pkt": "Packet"}, created_uoms=["Packet"])
+        self.assertEqual(rows[0]["field"], "Created as new unit")
+        self.assertEqual((rows[0]["old"], rows[0]["new"]), ("Pkt", "Packet"))
+
+    def test_empty_overrides_yield_no_rows(self):
+        self.assertEqual(uom_edits({}, []), [])
+        self.assertEqual(uom_edits(None, None), [])
+
+    def test_rerun_without_created_list_reads_as_mapped(self):
+        # On a re-run created_uoms isn't replayed; the unit exists by then, so the
+        # "mapped to existing" label is the accurate one for that run.
+        rows = uom_edits({"Pkt": "Packet"}, created_uoms=[])
+        self.assertEqual(rows[0]["field"], "Mapped to existing unit")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

On the Check step, two kinds of edits can be made before import:

- **Per-record field fixes** (PIN, GSTIN, state, HSN) - recorded in the log's **Applied edits** table.
- **Unit-of-measure resolutions** (map a Tally unit to an existing ERPNext UOM, or create it as a new unit) - applied at import but **never shown** in that table.

UOM resolutions travel on a separate channel (`uom_overrides` / `created_uoms`), so a user's unit decisions were invisible in the migration log. Reported after a real run where `Carton → Box` was chosen on step 3: only the PIN edit appeared in "Edits Applied Before Import".

## Fix

Fold UOM resolutions into the same `applied_edits` audit trail:

- **`overrides.uom_edits()`** - pure helper that builds an audit row per resolved unit, labelled **"Mapped to existing unit"** (e.g. Carton → Box) or **"Created as new unit"** (e.g. Pkt → Packet), with the Tally unit and the resulting ERPNext unit. Automatic `UOM_MAP` normalisations (e.g. Kgs → Kg) never reach `uom_overrides`, so they stay excluded - the table lists user decisions only.
- **`MasterMigrator._record_uom_edits()`** - appends those rows after the field edits.
- **Log form** - reword the heading from "field edit(s)" to "change(s)" and note both edit kinds; the section already appears whenever `applied_edits` is non-empty, so a UOM-only run now surfaces it too.

## Edge cases

- map-to-existing, create-as-new (shows rename like Pkt → Packet)
- automatic UOM_MAP normalisations excluded
- UOM-only runs (no field edits) now show the section
- ordering: field edits first, then unit decisions
- re-run: `created_uoms` isn't replayed, but the units exist by then, so "Mapped to existing unit" is the accurate label for that run

## Tests / verification

- 4 new pure tests (`TestUomEdits`) covering map, create-with-rename, empty, and re-run.
- End-to-end run confirmed the audit table now shows both the field edit and the `Carton → Box` unit mapping.

## Docs

Updated the "Applied edits" section of the user guide to document both edit kinds and the UOM_MAP exclusion.