### PR TITLE
Scale the duplicate-party scan to large files + clarify duplicate handling

### DIFF
--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -314,7 +314,7 @@ The issue types you may see (each is explained in full in the
 | PIN and state to verify | Warning | The PIN code looks like a different state |
 | Imports without the email | Warning | The email address is malformed |
 | Imports without HSN | Warning | An item has no HSN/SAC code |
-| Possible duplicate to review | Warning | Two parties look like the same real entity |
+| Possible duplicate to review | Warning | Two or more parties look like the same real entity |
 | Will merge into one | Warning | Two items / warehouses / units share a name and will merge |
 | Hierarchy loop simplified | Warning | A parent chain forms a loop |
 
@@ -722,8 +722,12 @@ Migrator handles a real-world wrinkle in Tally data.
   created, the party falls back to the standard default group, with a warning so the
   lost grouping is visible.
 - **Duplicate parties.** Two parties that look like the same real entity (by
-  normalised name, shared GSTIN, shared phone, or close name match) are flagged for
-  review. They still import; you decide whether to merge them.
+  normalised name, shared GSTIN, shared phone, or close name match) are **flagged for
+  review only**. The migration never merges or drops them - every distinctly named
+  party is imported as its own record exactly as it is in Tally. Merging, if you want
+  it, is something you do yourself in ERPNext afterwards. (On very large files the
+  close-name-match check is skipped for speed - exact matches by name, GSTIN, or phone
+  are still flagged at any size.)
 - **GST category.** Tally's explicit registration type wins when set (it is the only
   thing that distinguishes Composition or SEZ). Otherwise, a party outside India is
   "Overseas", and an Indian party's category is inferred from its GSTIN.
@@ -853,7 +857,7 @@ These appear on the Check step and in the log's data-quality section.
 | **PIN and state to verify** | Warning | The PIN code's region does not match the state | Check it; the PIN or the state may be a typo |
 | **Imports without the email** | Warning | The email is not a valid address; the party's contact would lose it | Fix or clear the email; the party imports with its other contact details either way |
 | **Imports without HSN** | Warning | An item has no HSN/SAC code | Add an HSN when ready; needed only for GST-compliant invoices |
-| **Possible duplicate to review** | Warning | Two parties look like the same real entity | Merge if it is the same party, or leave it |
+| **Possible duplicate to review** | Warning | Two or more parties look like the same real entity | Each imports as its own party - never merged or dropped; merge them yourself in ERPNext if they are the same |
 | **Will merge into one** | Warning | Two items, warehouses, or units share a name and will merge into one record on import | Rename in Tally first if that is not intended |
 | **Hierarchy loop simplified** | Warning | A record's parent chain forms a loop, so its hierarchy cannot be built faithfully | Fix the parent loop in Tally if the hierarchy matters |
 

--- a/tally_migrator/tests/test_validation.py
+++ b/tally_migrator/tests/test_validation.py
@@ -134,6 +134,33 @@ class TestDedup(unittest.TestCase):
         parties = [_party("Tata Steel"), _party("Infosys")]
         self.assertEqual(find_duplicate_groups(parties), [])
 
+    def test_exact_dupes_still_caught_when_fuzzy_skipped(self):
+        # fuzzy_max=0 forces the large-file path (no fuzzy pass). Identical names,
+        # GSTINs and phones must still be caught by the O(n) exact tier.
+        g = _valid_gstin()
+        parties = [
+            _party("Acme"), _party("Acme"),                       # same normalized name
+            _party("Beta", GSTRegistrationNumber=g),
+            _party("Beta Trading Co", GSTRegistrationNumber=g),   # same GSTIN
+            _party("Delta", LedgerMobile="9876543210"),
+            _party("Delta Corp", LedgerMobile="9876543210"),      # same phone
+            _party("Gamma"),                                       # unique
+        ]
+        groups = find_duplicate_groups(parties, fuzzy_max=0)
+        self.assertEqual(len(groups), 3)
+
+    def test_lookalike_skipped_when_above_cutoff(self):
+        # Names that only *look* alike (don't normalize equal) are grouped by the
+        # fuzzy pass for small sets, but skipped once above the cutoff.
+        parties = [_party("Reliance Industries"), _party("Reliance Ind.")]
+        self.assertEqual(len(find_duplicate_groups(parties)), 1)          # fuzzy on
+        self.assertEqual(find_duplicate_groups(parties, fuzzy_max=0), [])  # fuzzy off
+
+    def test_empty_normalized_names_do_not_clump(self):
+        # Names that normalize to "" (all suffixes/punctuation) must NOT all group.
+        parties = [_party("Ltd"), _party("& Co"), _party("Pvt Ltd")]
+        self.assertEqual(find_duplicate_groups(parties), [])
+
 
 # ── Master-level rules ────────────────────────────────────────────────────────
 

--- a/tally_migrator/validation/engine.py
+++ b/tally_migrator/validation/engine.py
@@ -223,12 +223,28 @@ def _phone_digits(rec: dict) -> str:
     return "".join(filter(str.isdigit, raw))[-10:]  # last 10 digits
 
 
-def find_duplicate_groups(parties: list[dict], threshold: float = 0.80) -> list[list[str]]:
+# Above this many parties the fuzzy (look-alike) pass is skipped - see
+# find_duplicate_groups. That pass compares every pair, so it grows quadratically
+# (~14 min at 13k parties) and on books that large its near-matches are mostly false
+# positives nobody can review anyway. Exact duplicates are always caught, at any size.
+_FUZZY_DEDUPE_MAX = 2000
+
+
+def find_duplicate_groups(parties: list[dict], threshold: float = 0.80,
+                          fuzzy_max: int = _FUZZY_DEDUPE_MAX) -> list[list[str]]:
     """Group party names that are likely the same real entity.
 
-    A pair groups when: identical normalized name, OR same non-empty GSTIN, OR
-    same 10-digit phone, OR fuzzy name ratio >= threshold. Returns groups of size
-    >= 2 (the singletons are not duplicates).
+    Two tiers, so it scales to large books:
+
+    - **Exact** (always, O(n)): identical normalized name, OR same non-empty GSTIN,
+      OR same 10-digit phone. Grouped by hashing each key into buckets (blanks
+      skipped, so empty-normalised names never clump together) - linear, runs at any
+      file size.
+    - **Look-alike** (only when party count <= ``fuzzy_max``): fuzzy name ratio >=
+      ``threshold``, an O(n^2) pairwise pass. Skipped on very large files, where it is
+      both far too slow and dominated by false positives.
+
+    Returns groups of size >= 2 (singletons are not duplicates).
     """
     n = len(parties)
     norm = [normalize_party_name(p["_name"]) for p in parties]
@@ -246,16 +262,28 @@ def find_duplicate_groups(parties: list[dict], threshold: float = 0.80) -> list[
     def union(a: int, b: int) -> None:
         parent[find(a)] = find(b)
 
-    for i in range(n):
-        for j in range(i + 1, n):
-            same = (
-                (norm[i] and norm[i] == norm[j])
-                or (gst[i] and gst[i] == gst[j])
-                or (phone[i] and phone[i] == phone[j])
-                or SequenceMatcher(None, norm[i], norm[j]).ratio() >= threshold
-            )
-            if same:
-                union(i, j)
+    # Exact tier: bucket indices by each key (skipping blanks) and union each bucket.
+    # O(n) per key - no pairwise comparison - so this is independent of file size.
+    for keys in (norm, gst, phone):
+        first: dict[str, int] = {}
+        for i, k in enumerate(keys):
+            if not k:
+                continue
+            if k in first:
+                union(i, first[k])
+            else:
+                first[k] = i
+
+    # Look-alike tier: quadratic, so only for small enough party sets. Already-grouped
+    # pairs are skipped, and empty normalised names are never fuzzy-matched.
+    if n <= fuzzy_max:
+        for i in range(n):
+            for j in range(i + 1, n):
+                if find(i) == find(j):
+                    continue
+                if (norm[i] and norm[j]
+                        and SequenceMatcher(None, norm[i], norm[j]).ratio() >= threshold):
+                    union(i, j)
 
     groups: dict[int, list[str]] = {}
     for i in range(n):
@@ -360,7 +388,8 @@ def _validate_duplicates(parties: list[dict], report: ValidationReport,
             report.add(ValidationIssue(
                 entity_of.get(dupe, "Customer"), dupe, WARNING, "DUPLICATE_PARTY",
                 f"Looks like a duplicate of '{primary}'.",
-                "Merge if it's the same party, or leave it as is."))
+                "Each imports as its own party - the migration never merges or "
+                "drops them. If they are the same, merge them yourself in ERPNext."))
 
 
 def _validate_name_collisions(masters, report: ValidationReport) -> None:


### PR DESCRIPTION
## Problem

The pre-flight duplicate-party check compared **every party with every other party** and ran a fuzzy name-similarity check on each pair - O(n²). On a real 13,000-party Tally export this took **~14 minutes** and effectively hung the Check step (the "Checking your file against ERPNext…" spinner never returned).

## Fix

Two tiers in `find_duplicate_groups` (`validation/engine.py`, still pure - no Frappe):

- **Exact (always, O(n))** - bucket parties by normalised name / GSTIN / phone via hashing and union each bucket. Blanks are skipped, so empty-normalised names (all-suffix/punctuation) no longer clump together - a latent quirk in the old fuzzy path. Catches genuine duplicates at any file size.
- **Look-alike (only when party count ≤ `_FUZZY_DEDUPE_MAX`, default 2000)** - the existing fuzzy pairwise pass, skipped on very large files where it is both far too slow and dominated by false positives.

### Measured
- 13,225-party scan: **~14 min → ~0.02s**, still finding the real exact duplicates (e.g. two ledgers sharing one phone number).

## Also: clarify what happens to duplicates

Made explicit - in the Check-step card and the user guide - that flagged duplicates are **never merged or dropped**; each imports as its own party, and merging (if wanted) is a manual step in ERPNext. Wording is count-agnostic (a group can be more than two). The guide also notes the look-alike check is skipped on very large files (exact matches still flagged at any size).

## Tests

Added three pure tests: exact dupes still caught when fuzzy is skipped, look-alikes skipped above the cutoff, and empty normalised names do not clump. Existing small-file behaviour unchanged.