### PR TITLE
Reconnect to a running migration instead of offering a colliding re-run

### DIFF
--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -208,7 +208,9 @@ masters-only file (just customers, items, and so on) shows a clean four-step flo
 
 You can leave at any point and come back. Your progress, and every fix you make
 along the way, is saved automatically. When you return, a banner offers to **resume
-your unfinished migration** or **start over**.
+your unfinished migration** or **start over**. If a migration was already running
+when you left (for example you reloaded the page mid-import), resuming reconnects to
+that run and tracks its progress to completion - it never starts a second one.
 
 ### Step 1 - Upload
 

--- a/tally_migrator/api.py
+++ b/tally_migrator/api.py
@@ -355,38 +355,66 @@ def _is_job_alive(job_id: str) -> bool:
         return True
 
 
-def _assert_no_active_run(company: str) -> None:
-    """Refuse to start a second migration while one is already running for the
-    same company. A stale run (crashed worker) is ignored so re-runs aren't locked
+def _active_run_log(company: str) -> dict | None:
+    """The live 'Running' migration log for a company, or None when none is active.
+
+    A stale run (crashed worker) is treated as not-active so re-runs aren't locked
     out. For an async run we ask RQ whether the worker is genuinely still alive; for
-    a sync run (no job id, request-bound) we fall back to an age cap. Best-effort UX
-    guard - the opening lock in the importer is what actually protects the books."""
+    a sync run (no job id, request-bound) we fall back to an age cap. Shared by the
+    start guard and the ``active_run`` endpoint so both judge "is a run live" the
+    same way."""
     if not company:
-        return
+        return None
     rows = frappe.get_all(
         "Tally Migration Log",
         filters={"company": company, "status": "Running"},
         fields=["name", "modified", "job_id"], order_by="modified desc", limit=1,
     )
     if not rows:
-        return
-    modified = rows[0].modified
+        return None
     job_id = rows[0].get("job_id")
     if job_id:
-        # Liveness, not age: an enqueued run blocks only while its RQ job is actually
+        # Liveness, not age: an enqueued run is live only while its RQ job is actually
         # queued or running. A crashed/finished/missing job leaves a 'Running' log
         # behind, but is_job_enqueued() returns False, so it never locks out a re-run -
-        # and a legitimately long (>2h) job keeps blocking, which the age cap couldn't.
+        # and a legitimately long (>2h) job stays live, which the age cap couldn't.
         if not _is_job_alive(job_id):
-            return
-    elif frappe.utils.time_diff_in_seconds(frappe.utils.now(), modified) >= _ACTIVE_RUN_STALE_SECONDS:
-        return
-    frappe.throw(
-        frappe._(
-            "A migration for '{0}' is already running (started {1}). Please wait "
-            "for it to finish, or open the migration log to check its status."
-        ).format(company, frappe.utils.pretty_date(modified))
-    )
+            return None
+    elif frappe.utils.time_diff_in_seconds(
+            frappe.utils.now(), rows[0].modified) >= _ACTIVE_RUN_STALE_SECONDS:
+        return None
+    return rows[0]
+
+
+def _assert_no_active_run(company: str) -> None:
+    """Refuse to start a second migration while one is already running for the same
+    company. Best-effort UX guard - the opening lock in the importer is what actually
+    protects the books. The wizard avoids hitting this by reconnecting to a live run
+    (see ``active_run``); this stays as the server-side backstop."""
+    row = _active_run_log(company)
+    if row:
+        frappe.throw(
+            frappe._(
+                "A migration for '{0}' is already running (started {1}). Please wait "
+                "for it to finish, or open the migration log to check its status."
+            ).format(company, frappe.utils.pretty_date(row.modified))
+        )
+
+
+@frappe.whitelist(methods=["GET", "POST"])
+def active_run(erpnext_company: str = "") -> dict:
+    """Return the live migration run for a company, so the wizard can reconnect to a
+    run already in progress (e.g. after a page reload) instead of offering to start a
+    second one. ``{}`` when nothing is running. Read-only."""
+    frappe.only_for(ALLOWED_ROLES)
+    row = _active_run_log(erpnext_company)
+    if not row:
+        return {}
+    return {
+        "log_name": row.name,
+        "status": row.get("status") or "Running",
+        "started": frappe.utils.pretty_date(row.modified),
+    }
 
 
 def _assert_file_access(file_doc) -> None:

--- a/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
+++ b/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
@@ -224,6 +224,8 @@ class TallyMigratorPage {
 					<h4>Migration</h4>
 					<p id="run-subtitle" class="text-muted"></p>
 
+					<div id="run-banner" class="tm-callout" style="display:none;"></div>
+
 					<div id="progress-section" class="tm-section" style="display:none;">
 						<div class="progress" style="margin-bottom:var(--margin-xs);">
 							<div id="progress-bar" class="progress-bar progress-bar-striped active" style="width:0%; min-width:2em;">0%</div>
@@ -636,6 +638,19 @@ class TallyMigratorPage {
 		$("#file-status").html(
 			`<span class="indicator green">${frappe.utils.escape_html(this.fileName || this.fileUrl)}</span>`
 		);
+		// If the user left off on the Migrate step, a job may still be running. Try to
+		// reconnect to it directly instead of re-scanning the file first - on a large
+		// file that scan is ~minute-long dead time before we'd even discover the run.
+		if (d.step === "section-run") {
+			this.reconnectOnResume(d);
+			return;
+		}
+		this._resumeNormally(d);
+	}
+
+	// Normal resume: re-scan the file, rebuild the wizard, and land the user at the
+	// step they left off on (gotoRun auto-attaches to a live run once it gets there).
+	_resumeNormally(d) {
 		this.loadPreview();        // refresh the counts for the file
 		this.proceedToConfigure(); // land on Configure, one click from where they were
 		if (this._restore.coa) { this.setCoa(this._restore.coa); this.updateCoaHint(); }
@@ -643,6 +658,43 @@ class TallyMigratorPage {
 		frappe.show_alert({
 			message: __("Resumed your in-progress migration - your fixes are saved."),
 			indicator: "green",
+		});
+	}
+
+	// Fast path for resuming on the Migrate step: ask the server if a run is live and,
+	// if so, jump straight to tracking it - skipping the heavy file re-scan, which the
+	// tracking view doesn't need (results come from the log). If no run is live, fall
+	// back to a normal resume.
+	reconnectOnResume(d) {
+		frappe.call({
+			method: "tally_migrator.api.active_run",
+			args: { erpnext_company: d.erpnext_company },
+			callback: (r) => {
+				const live = r && r.message;
+				if (!live || !live.log_name) {
+					this._resumeNormally(d);
+					return;
+				}
+				// Populate the company picker in the background so the Back button still
+				// lands on a usable Configure step. Drop 'step' from _restore so the
+				// company-load callback doesn't re-trigger the scan we're skipping.
+				this._restore = { company: d.erpnext_company };
+				this.loadERPNextCompanies();
+				if (d.coa_mode) { this.setCoa(d.coa_mode); this.updateCoaHint(); }
+				if (d.posting_date) this.setDate(d.posting_date);
+				$("#run-subtitle").html(
+					`Importing from <strong>${frappe.utils.escape_html(this.fileName || "your file")}</strong> ` +
+						`into <strong>${frappe.utils.escape_html(d.erpnext_company)}</strong>.`
+				);
+				this.show("section-run");
+				this.attachToActiveRun(live);
+				frappe.show_alert({
+					message: __("Reconnected to your running migration."),
+					indicator: "green",
+				});
+			},
+			// On error, don't strand the user on a blank step 5 - fall back to a full resume.
+			error: () => this._resumeNormally(d),
 		});
 	}
 
@@ -1957,24 +2009,48 @@ class TallyMigratorPage {
 				`into <strong>${frappe.utils.escape_html(erpnext)}</strong>.`
 		);
 		this.show("section-run");
+		// If a migration for this company is already running (e.g. the user reloaded
+		// or resumed mid-run), reconnect to it and track its progress instead of
+		// offering to start a second one - which would collide with the live job.
+		this.checkActiveRun(erpnext);
 	}
 
-	// ── Step 5: run ──────────────────────────────────────────────────────────────
+	// Ask the server whether a migration is already live for this company; if so,
+	// attach to it (track its progress) rather than showing the Run button.
+	checkActiveRun(company) {
+		if (!company) return;
+		frappe.call({
+			method: "tally_migrator.api.active_run",
+			args: { erpnext_company: company },
+			callback: (r) => {
+				const live = r && r.message;
+				if (live && live.log_name && this._currentStep === "section-run") {
+					this.attachToActiveRun(live);
+				}
+			},
+		});
+	}
 
-	runMigration() {
-		const erpnext = this.getCompany();
-		const overrides = this.uomOverrides || {};
-
-		$("#btn-run").prop("disabled", true);
-		$("#btn-back-3").prop("disabled", true);
+	// Switch step 5 into "tracking" mode for an already-running migration: no Run
+	// button, a calm banner, and the same progress stream + log poll a fresh run uses.
+	attachToActiveRun(live) {
+		$("#run-banner")
+			.html(
+				`A migration for this company is already running (started ${frappe.utils.escape_html(live.started || "a moment ago")}) - ` +
+					`tracking its progress below. You can leave this page; it also updates in the migration log.`
+			)
+			.show();
+		$("#run-actions").hide();
 		$("#error-section").hide();
 		$("#results-section").hide();
 		$("#progress-section").show();
+		this._setupProgressStream();
+		this.pollLog(live.log_name);
+	}
 
-		// One stable handler reference, registered once and removed by reference, so
-		// repeated runs don't stack duplicate listeners. Listens on our own
-		// "tally_migration_progress" event (not Frappe's "progress", which also pops
-		// the native dialog) so only the step-5 bar reflects the run.
+	// Register the realtime progress handler + heartbeat for a run we are tracking
+	// (a fresh run or a reconnected one). Idempotent - safe to call repeatedly.
+	_setupProgressStream() {
 		if (!this._onProgress) {
 			this._onProgress = (data) => {
 				if (data.title !== "Tally Masters Migration") return;
@@ -1986,11 +2062,6 @@ class TallyMigratorPage {
 		}
 		frappe.realtime.off("tally_migration_progress", this._onProgress);
 		frappe.realtime.on("tally_migration_progress", this._onProgress);
-
-		// Heartbeat: if no progress event arrives for a while (e.g. the realtime
-		// socket dropped), the striped bar would look frozen even though the run is
-		// still going. Show an "elapsed" reassurance so the user isn't left guessing;
-		// the authoritative result still arrives via the call's callback / log poll.
 		this._lastProgress = Date.now();
 		this._runStart = Date.now();
 		this.stopHeartbeat();
@@ -2002,6 +2073,42 @@ class TallyMigratorPage {
 				`result will appear here when the migration finishes.`
 			);
 		}, 5000);
+	}
+
+	// ── Step 5: run ──────────────────────────────────────────────────────────────
+
+	runMigration() {
+		const erpnext = this.getCompany();
+		const overrides = this.uomOverrides || {};
+
+		// Disable immediately so a fast double-click can't fire two starts.
+		$("#btn-run").prop("disabled", true);
+		$("#btn-back-3").prop("disabled", true);
+		$("#error-section").hide();
+		$("#results-section").hide();
+		$("#run-banner").hide();
+		$("#progress-section").show();
+		$("#progress-desc").text("Starting...");
+
+		// Re-check for a live run right before starting (covers two open tabs, a stale
+		// page, or a click that races the guard). If one is already going, attach to
+		// it instead of starting a second; the server guard remains the backstop.
+		frappe.call({
+			method: "tally_migrator.api.active_run",
+			args: { erpnext_company: erpnext },
+			callback: (r) => {
+				if (r && r.message && r.message.log_name) {
+					this.attachToActiveRun(r.message);
+					return;
+				}
+				this._startMigration(erpnext, overrides);
+			},
+			error: () => this._startMigration(erpnext, overrides),
+		});
+	}
+
+	_startMigration(erpnext, overrides) {
+		this._setupProgressStream();
 
 		frappe.call({
 			method: "tally_migrator.api.run_masters_migration_from_file",
@@ -2076,11 +2183,22 @@ class TallyMigratorPage {
 	// Track a backgrounded run by polling its log until it leaves 'Running',
 	// then render the same results table from the log's stored summary.
 	pollLog(logName) {
+		// Guard against duplicate poll loops for the same log. checkActiveRun (and the
+		// fast-path resume reconnect) can call this more than once if the user re-enters
+		// step 5 during a live run; without this we'd spawn parallel poll chains and
+		// render the result multiple times. Cleared on every terminal state below so
+		// "Keep checking" and a post-failure retry can re-arm.
+		if (this._trackingLog === logName) return;
+		this._trackingLog = logName;
 		const finishFromLog = (doc) => {
+			this._trackingLog = null;
 			frappe.realtime.off("tally_migration_progress", this._onProgress);
 			this.stopHeartbeat();
 			$("#progress-bar").removeClass("active progress-bar-striped").css("width", "100%").text("100%");
 			if (doc.status === "Failed") {
+				// A reconnected run hides #run-actions (see attachToActiveRun); re-show it
+				// so the user can actually retry, not just find a re-enabled-but-hidden button.
+				$("#run-actions").show();
 				$("#btn-run").prop("disabled", false);
 				$("#btn-back-3").prop("disabled", false);
 				$("#error-section")
@@ -2115,8 +2233,10 @@ class TallyMigratorPage {
 		const start = Date.now();
 
 		const stalled = () => {
+			this._trackingLog = null;
 			frappe.realtime.off("tally_migration_progress", this._onProgress);
 			this.stopHeartbeat();
+			$("#run-actions").show();
 			$("#btn-run").prop("disabled", false);
 			$("#btn-back-3").prop("disabled", false);
 			$("#progress-desc").html(


### PR DESCRIPTION
## Problem

If a migration was already running and the user reloaded the page (or switched away and resumed a draft), the wizard offered a fresh **Run Migration** button. Clicking it collided with the live job and surfaced as a red **"Migration failed"** with misleading "safe to run again" advice. The server's start guard threw, but the UX presented it as a failure rather than "it's already running."

## Fix

The wizard now detects a live run for the company and **tracks it** rather than offering to start a second one.

### Server (`api.py`)
- New `active_run` whitelisted endpoint backed by a shared `_active_run_log(company)` helper, so the start guard (`_assert_no_active_run`) and the wizard judge "is a run live" the same way: RQ job-liveness for async (background) runs, a 2h age cap for request-bound sync runs (so a crashed worker never locks the company out).

### Wizard (`tally_migrator.js`)
- `gotoRun` / `runMigration` re-check `active_run` and attach to a live run instead of starting one; Run/Back disable immediately to swallow a double-click.
- `attachToActiveRun` switches step 5 into a calm "tracking" mode using the same realtime progress stream + log poll a fresh run uses.
- **Resume on the Migrate step** reconnects directly and skips the heavy file re-scan (the tracking view reads results from the log). The company picker still loads in the background so the **Back** button lands on a usable Configure step. Falls back to a full resume when no run is live.
- Re-show `#run-actions` when a reconnected run **fails or stalls**, so the retry button isn't left hidden.
- Guard `pollLog` against duplicate poll loops if step 5 is re-entered mid-run.

### Docs
- Note the reconnect behaviour in the resume section of the user guide.

## Edge cases covered
- Reload mid-run, switch doctype and return to step 1, browser back, close tab and reopen - all reconnect rather than colliding.
- Reconnected run that fails/stalls keeps a working retry path.
- No live run on resume falls back cleanly to the normal re-scan resume.

## Testing
- `node --check` and `python -m py_compile` pass.
- `active_run` verified live earlier (returned the running log, `{}` after cleanup).