### PR TITLE
Reconnect-safe progress bar and step-5 UI polish

### DIFF
--- a/tally_migrator/api.py
+++ b/tally_migrator/api.py
@@ -417,6 +417,33 @@ def active_run(erpnext_company: str = "") -> dict:
     }
 
 
+@frappe.whitelist(methods=["GET", "POST"])
+def run_progress(log_name: str = "") -> dict:
+    """Status + latest progress percent/description for a migration run.
+
+    The progress bar is driven over realtime, but realtime is best-effort: a page
+    that reloads mid-run misses the events already sent and would otherwise sit at
+    0%. This lets the wizard poll the persisted progress (written by
+    MasterMigrator._progress) so a reconnected bar advances reliably. ``import_summary``
+    is returned too so the existing poll can render results from a single call once
+    the run finishes. ``{}`` when the log is unknown. Read-only."""
+    frappe.only_for(ALLOWED_ROLES)
+    if not log_name:
+        return {}
+    row = frappe.db.get_value(
+        "Tally Migration Log", log_name, ["status", "import_summary"], as_dict=True
+    )
+    if not row:
+        return {}
+    cached = frappe.cache().get_value(f"tally_migration_progress:{log_name}") or {}
+    return {
+        "status": row.status,
+        "import_summary": row.import_summary,
+        "percent": cached.get("percent"),
+        "description": cached.get("description"),
+    }
+
+
 def _assert_file_access(file_doc) -> None:
     """Refuse to read a File the current user has no claim to.
 

--- a/tally_migrator/migration/master_migrator.py
+++ b/tally_migrator/migration/master_migrator.py
@@ -360,15 +360,31 @@ class MasterMigrator:
         # A custom realtime event (not frappe.publish_progress) so only the wizard's
         # own step-5 bar updates - publish_progress also triggers Frappe's native
         # progress dialog, which double-rendered on top of our bar.
+        desc = description or self.STEPS.get(pct, "")
         frappe.publish_realtime(
             "tally_migration_progress",
             {
                 "title": "Tally Masters Migration",
                 "percent": pct,
-                "description": description or self.STEPS.get(pct, ""),
+                "description": desc,
             },
             user=frappe.session.user,
         )
+        # Persist the latest progress so a reloaded/reconnected page can recover it by
+        # polling (see api.run_progress). Realtime is best-effort - a page that reloads
+        # mid-run misses past events - so the poll is the reliable source of truth and
+        # this is what stops the reconnected bar from sitting at 0%.
+        # Best-effort: progress reporting is cosmetic and runs inside the migration's
+        # critical path, so a cache/Redis hiccup must never abort an otherwise-good run.
+        if self.log:
+            try:
+                frappe.cache().set_value(
+                    f"tally_migration_progress:{self.log.name}",
+                    {"percent": pct, "description": desc},
+                    expires_in_sec=6 * 60 * 60,
+                )
+            except Exception:
+                pass
 
     def _record_uom_edits(self) -> None:
         """Fold the pre-flight UOM resolutions into the applied-edits audit trail.

--- a/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
+++ b/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
@@ -224,7 +224,7 @@ class TallyMigratorPage {
 					<h4>Migration</h4>
 					<p id="run-subtitle" class="text-muted"></p>
 
-					<div id="run-banner" class="tm-callout" style="display:none;"></div>
+					<div id="run-banner" class="tm-callout tm-section" style="display:none;"></div>
 
 					<div id="progress-section" class="tm-section" style="display:none;">
 						<div class="progress" style="margin-bottom:var(--margin-xs);">
@@ -2153,6 +2153,7 @@ class TallyMigratorPage {
 			error: (err) => {
 				frappe.realtime.off("tally_migration_progress", this._onProgress);
 				this.stopHeartbeat();
+				$("#progress-section").hide();   // the run failed; don't leave a stuck 0% bar above the error
 				$("#btn-run").prop("disabled", false);
 				$("#btn-back-3").prop("disabled", false);
 				const detail =
@@ -2196,6 +2197,7 @@ class TallyMigratorPage {
 			this.stopHeartbeat();
 			$("#progress-bar").removeClass("active progress-bar-striped").css("width", "100%").text("100%");
 			if (doc.status === "Failed") {
+				$("#progress-section").hide();   // the run failed; don't leave a stuck bar above the error
 				// A reconnected run hides #run-actions (see attachToActiveRun); re-show it
 				// so the user can actually retry, not just find a re-enabled-but-hidden button.
 				$("#run-actions").show();
@@ -2254,18 +2256,31 @@ class TallyMigratorPage {
 		const poll = () => {
 			if (Date.now() - start > POLL_CAP_MS) { stalled(); return; }
 			frappe.call({
-				method: "frappe.client.get_value",
-				args: { doctype: "Tally Migration Log", filters: { name: logName }, fieldname: ["status", "import_summary"] },
+				method: "tally_migrator.api.run_progress",
+				args: { log_name: logName },
 				callback: (r) => {
 					const doc = r.message;
 					if (!doc) { setTimeout(poll, 3000); return; }
-					if (doc.status === "Running" || !doc.status) { setTimeout(poll, 3000); return; }
+					if (doc.status === "Running" || !doc.status) {
+						// Drive the bar from the persisted progress so a reconnected page
+						// advances even when it missed the realtime events (which is what
+						// otherwise left it stuck at 0%). Realtime stays the fast-path.
+						if (typeof doc.percent === "number") {
+							this._lastProgress = Date.now();
+							$("#progress-bar").css("width", doc.percent + "%").text(doc.percent + "%");
+							if (doc.description) $("#progress-desc").text(doc.description);
+						}
+						setTimeout(poll, 3000);
+						return;
+					}
 					finishFromLog(doc);
 				},
 				error: () => setTimeout(poll, 5000),
 			});
 		};
-		setTimeout(poll, 3000);
+		// Poll immediately so a reconnected bar paints the real percent within a tick,
+		// not after the first 3s interval.
+		poll();
 	}
 
 	renderResults(summary) {


### PR DESCRIPTION
## Problem

After the reconnect feature (#39), reloading mid-migration correctly reattaches to the running job, but the progress bar **sat at 0%**. Progress was driven over realtime only, and a reloaded page misses the events already sent - so the bar never advanced until completion. Two smaller step-5 issues surfaced alongside it.

## Fix

### Reconnect-safe progress
Realtime is best-effort and can never be reconnect-safe on its own. Progress is now **persisted and polled**, with realtime kept as the fast-path:

- `master_migrator._progress` also caches the latest `{percent, description}` in Redis, keyed by log name (6h TTL). It's **best-effort** - wrapped so a cache/Redis hiccup can never abort an otherwise-good migration (it runs inside the migration's critical path).
- New `run_progress(log_name)` endpoint returns `status` + `import_summary` + cached `percent`/`description` (role-gated like `active_run`).
- `pollLog` now polls `run_progress` and drives the bar from it, painting **immediately** on attach instead of after the first 3s interval.

Bonus: progress is published with the starter's `user` scope, so before this a *different* manager reconnecting got no realtime at all. The poll drives the bar regardless of who started the run.

### Step-5 UI polish
- The "already running" reconnect banner now uses the standard `tm-section` spacing (it shares the pattern with the other callouts), so the progress bar no longer butts directly against it.
- The progress bar is hidden on the two genuine failure paths, so a stuck `0%` bar no longer sits above the **Migration failed** message. `stalled()` deliberately keeps it - it reuses that area for its "keep checking" message.

## Performance / scalability
`_progress` is called at coarse boundaries (~12 times per run), **not per record** - it does not scale with file size. The poll's DB cost is identical to the `frappe.client.get_value` it replaces, plus a trivial Redis read. Per-log keys with a TTL, so nothing accumulates.

## Edge cases checked
- `percent === 0` paints (typeof check, not truthiness).
- Cross-process: worker writes / web reads via shared Redis (pickled dict).
- Cache miss (run started before this code): `null` percent, bar still finishes from `import_summary`.
- Status flips to Completed between cache write and poll: `finishFromLog` renders and forces 100%.
- Retry after failure: new log name = new key, no stale collision.
- Redis down: migration unaffected; progress just stops updating.
- Re-entry into step 5 mid-run: `_trackingLog` guard keeps a single poll loop.

## Testing
- `node --check` and `python -m py_compile` pass.
- `run_progress` verified against a live running log (returned correct `status`).