### PR TITLE
perf: scale the importer duplicate check + per-phase timing & live progress

### DIFF
--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -443,8 +443,10 @@ The final step imports the records.
 
 Click **Run Migration**. A progress bar shows the stages (reading the file,
 extracting masters, importing each entity type, posting opening balances, saving the
-log). For a large file, the import keeps running in the background and you can leave
-the page; the result still appears here and in the log.
+log). It advances continuously within a stage and shows a live count (for example,
+"Importing suppliers 8,432 of 13,088"), so a large stage never looks stuck. For a
+large file, the import keeps running in the background and you can leave the page; the
+result still appears here and in the log.
 
 When it finishes, you see a results table with one row per record type and these
 columns:

--- a/tally_migrator/erpnext/importers/base.py
+++ b/tally_migrator/erpnext/importers/base.py
@@ -1,6 +1,7 @@
 """Result tracking and the BaseImporter template (shared by all importers)."""
 
 import contextlib
+import unicodedata
 from collections import Counter
 from dataclasses import dataclass, field
 
@@ -114,6 +115,11 @@ class BaseImporter:
     def __init__(self, company: str, abbr: str):
         self.company = company
         self.abbr = abbr
+        # Set by run() to a {key_value: name} map of records that already exist, so the
+        # per-record duplicate check is an in-memory lookup instead of a SQL query. None
+        # means "not prefetched" - _upsert then falls back to a live get_value. See
+        # _prefetch_existing / _upsert.
+        self._existing: dict | None = None
 
     @property
     def company_country(self) -> str:
@@ -125,6 +131,7 @@ class BaseImporter:
     def run(self, records: list[dict]) -> ImportResult:
         result = ImportResult(self.doctype)
         self.before_run(records, result)
+        self._existing = self._prefetch_existing()
         for record in self.iter_records(records):
             name, created = self._upsert(result, self.build_doc(record))
             # after_insert (e.g. address creation) must run ONLY for newly
@@ -146,6 +153,90 @@ class BaseImporter:
 
     def after_insert(self, name: str, record: dict, result: "ImportResult") -> None:
         pass
+
+    # ── Duplicate-check prefetch ───────────────────────────────────────────────
+    @staticmethod
+    def _dedupe_key(value) -> str:
+        """A *prefilter* key for the duplicate check - NOT the authority.
+
+        The dedup columns (supplier_name, customer_name, item_code, warehouse_name) are
+        ``utf8mb4_unicode_ci``: case-, accent- and (PAD SPACE) trailing-space-insensitive
+        - verified empirically to collapse even 'ABC'/'abc', 'café'/'cafe', 'ß'/'ss',
+        ligatures and full-width forms. We approximate that with NFKD accent-strip +
+        casefold + trailing-space strip, chosen to be at least as aggressive as the
+        collation so a *miss* here reliably means "no DB variant exists" (safe to insert
+        without a query). It is never trusted to *skip*: an exact match skips directly,
+        and any normalised-only match is confirmed against the DB (see _lookup_existing),
+        so an imperfect approximation can never drop a distinct record."""
+        s = unicodedata.normalize("NFKD", str(value if value is not None else ""))
+        s = "".join(c for c in s if not unicodedata.combining(c))
+        return s.casefold().rstrip(" ")
+
+    def _prefetch_existing(self) -> dict | None:
+        """Snapshot existing records once, so the per-record duplicate check in ``_upsert``
+        avoids a SQL round-trip per record.
+
+        Why this matters: ``key_field`` (e.g. ``supplier_name``) is usually not indexed,
+        so a per-record ``get_value`` is a full table scan - O(n) per record, O(n^2) over
+        the run, and the dominant cost on large books and on every re-run (all skips).
+
+        Returns ``{"exact": {raw_key: name}, "norm": {normalised_key, ...}}`` so
+        ``_lookup_existing`` can:
+          - skip instantly on an exact key match (an exact match is always equal under the
+            collation, so this never drops a distinct record), and
+          - tell, from the normalised set, whether a case/accent/space *variant* might
+            exist and therefore needs a DB confirmation.
+
+        Returns ``None`` (disabling the optimisation; ``_upsert`` then uses the live
+        lookup) when there is no ``key_field`` to key on.
+
+        Note on concurrency: this is a per-run snapshot, kept current as this run inserts.
+        It can only go stale if a *second* migration writes the same company at the same
+        time, which the single-active-run guard (``_assert_no_active_run`` / the wizard's
+        reconnect) already prevents - so the snapshot is safe in normal operation, and a
+        variant collision would in any case be caught by the DB confirmation."""
+        if not self.key_field:
+            return None
+        filters = {}
+        if self.scope_field:
+            filters[self.scope_field] = self.company
+        exact: dict = {}
+        norm: set = set()
+        for row in frappe.get_all(
+                self.doctype, filters=filters, fields=[self.key_field, "name"]):
+            kv = row.get(self.key_field)
+            exact[kv] = row.get("name")
+            norm.add(self._dedupe_key(kv))
+        return {"exact": exact, "norm": norm}
+
+    def _lookup_existing(self, key_value) -> str | None:
+        """Name of an already-existing record equal to ``key_value`` under the DB
+        collation, or ``None``. Over-skip-proof: a skip is returned only on an exact key
+        match (always collation-equal) or a DB-confirmed variant match; a brand-new key
+        (no exact and no normalised hit) returns ``None`` without a query. So the common
+        exact and brand-new cases never hit the DB, and only a genuine case/accent/space
+        variant collision triggers one authoritative ``get_value``."""
+        if self._existing is None:
+            filters = {self.key_field: key_value}
+            if self.scope_field:
+                filters[self.scope_field] = self.company
+            return frappe.db.get_value(self.doctype, filters, "name")
+        if key_value in self._existing["exact"]:
+            return self._existing["exact"][key_value]
+        if self._dedupe_key(key_value) in self._existing["norm"]:
+            filters = {self.key_field: key_value}
+            if self.scope_field:
+                filters[self.scope_field] = self.company
+            return frappe.db.get_value(self.doctype, filters, "name")
+        return None
+
+    def _remember_inserted(self, key_value, name: str) -> None:
+        """Add a just-inserted record to the in-run snapshot so a later record with the
+        same (or variant) key in this same run is skipped - mirroring the old behaviour
+        where the just-committed row was found by the live lookup."""
+        if self._existing is not None:
+            self._existing["exact"][key_value] = name
+            self._existing["norm"].add(self._dedupe_key(key_value))
 
     # ── Shared upsert ─────────────────────────────────────────────────────────
     def _upsert(self, result: ImportResult, data: dict) -> tuple[str | None, bool]:
@@ -172,17 +263,18 @@ class BaseImporter:
         deliberate non-goal here.
         """
         key_value = data.get(self.key_field, "")
-        filters = {self.key_field: key_value}
-        if self.scope_field:
-            filters[self.scope_field] = self.company
         try:
-            existing = frappe.db.get_value(self.doctype, filters, "name")
+            # Already exists (under the DB collation)? Skip. _lookup_existing is
+            # over-skip-proof: it only ever reports a match it is certain of (exact key,
+            # or a DB-confirmed variant), so this can never drop a genuinely new record.
+            existing = self._lookup_existing(key_value)
             if existing:
                 result.skipped += 1
                 return existing, False
             doc = frappe.get_doc(data)
             doc.insert(ignore_permissions=True)
             frappe.db.commit()
+            self._remember_inserted(key_value, doc.name)
             result.add_created(doc.name)
             return doc.name, True
         except Exception as exc:
@@ -196,6 +288,7 @@ class BaseImporter:
                     doc = frappe.get_doc(retry_data)
                     doc.insert(ignore_permissions=True)
                     frappe.db.commit()
+                    self._remember_inserted(retry_data.get(self.key_field, key_value), doc.name)
                     result.add_created(doc.name)
                     if warning:
                         result.add_warning(retry_data.get(self.key_field, key_value), warning)

--- a/tally_migrator/erpnext/importers/base.py
+++ b/tally_migrator/erpnext/importers/base.py
@@ -128,17 +128,25 @@ class BaseImporter:
         return frappe.get_cached_value("Company", self.company, "country") or "India"
 
     # ── Template method ─────────────────────────────────────────────────────
-    def run(self, records: list[dict]) -> ImportResult:
+    def run(self, records: list[dict], on_progress=None) -> ImportResult:
         result = ImportResult(self.doctype)
         self.before_run(records, result)
         self._existing = self._prefetch_existing()
-        for record in self.iter_records(records):
+        # ``on_progress(done, total)`` lets the caller draw a live progress bar that
+        # moves *within* this phase (not just between phases). Called once per record
+        # - skips included - so the bar advances even on an all-skip re-run. ``total``
+        # is the input count; ``iter_records`` only filters, never multiplies, so
+        # ``done`` never exceeds it. Optional: tests and direct callers pass nothing.
+        total = len(records)
+        for done, record in enumerate(self.iter_records(records), 1):
             name, created = self._upsert(result, self.build_doc(record))
             # after_insert (e.g. address creation) must run ONLY for newly
             # created records - otherwise a re-run duplicates side effects for
             # records that were skipped because they already exist.
             if name and created:
                 self.after_insert(name, record, result)
+            if on_progress:
+                on_progress(done, total)
         return result
 
     # ── Overridable hooks ────────────────────────────────────────────────────

--- a/tally_migrator/erpnext/importers/openings.py
+++ b/tally_migrator/erpnext/importers/openings.py
@@ -419,22 +419,36 @@ class PartyOpeningImporter:
 
     # ── Orchestration ─────────────────────────────────────────────────────────
     def run(self, bills: list, customers: list[dict],
-            suppliers: list[dict]) -> ImportResult:
+            suppliers: list[dict], on_progress=None) -> ImportResult:
         result = ImportResult("Opening Invoice")
         by_party: dict[str, list] = {}
         for b in bills or []:
             by_party.setdefault(b.party, []).append(b)
         seen = self._existing_markers()
-        self._process(customers, "Customer", by_party, seen, result)
-        self._process(suppliers, "Supplier", by_party, seen, result)
+        # Live progress across both party lists: this is the heavy phase (one
+        # submitted invoice per bill), so the bar must move within it. ``tick`` fires
+        # once per party - posted or skipped - so ``done`` reaches ``total``.
+        total = len(customers or []) + len(suppliers or [])
+        progress = {"done": 0}
+
+        def tick():
+            progress["done"] += 1
+            if on_progress:
+                on_progress(progress["done"], total)
+
+        self._process(customers, "Customer", by_party, seen, result, tick)
+        self._process(suppliers, "Supplier", by_party, seen, result, tick)
         return result
 
     def _process(self, parties: list[dict], party_type: str,
-                 by_party: dict, seen: set, result: ImportResult) -> None:
+                 by_party: dict, seen: set, result: ImportResult,
+                 tick=None) -> None:
         if not parties:
             return
         key_field = self._PARTY_KEY_FIELD[party_type]
         for record in parties:
+            if tick:
+                tick()
             tally_name = record["_name"]
             ledger_amt, ledger_drcr = TallyExtractor._parse_opening(
                 record.get("OpeningBalance", ""))

--- a/tally_migrator/erpnext/importers/orchestrator.py
+++ b/tally_migrator/erpnext/importers/orchestrator.py
@@ -56,6 +56,10 @@ class ERPNextImporter:
         self.abbr = frappe.get_value("Company", erpnext_company, "abbr") or ""
         self._uom_overrides = uom_overrides or {}
         self._coa_mode = coa_mode
+        # Per-phase progress callback ``(done, total)``, set by the migrator before
+        # each step so the wizard bar moves *within* a phase. None = no reporting
+        # (the default for tests and standalone use).
+        self.on_progress = None
 
     def import_accounts(self, accounts: list) -> ImportResult:
         return AccountImporter(self.company, self.abbr, mode=self._coa_mode).run(accounts)
@@ -97,7 +101,7 @@ class ERPNextImporter:
                 return result
             return PartyOpeningImporter(
                 self.company, self.abbr, self._opening_date(posting_date)).run(
-                    bills, customers, suppliers)
+                    bills, customers, suppliers, on_progress=self.on_progress)
 
     def import_opening_stock(self, items: list, posting_date: str = "") -> ImportResult:
         with _company_opening_lock(self.company) as got:
@@ -129,13 +133,16 @@ class ERPNextImporter:
         return BatchImporter(self.company, self.abbr).run(items)
 
     def import_warehouses(self, warehouses: list[dict]) -> ImportResult:
-        return WarehouseImporter(self.company, self.abbr).run(warehouses)
+        return WarehouseImporter(self.company, self.abbr).run(
+            warehouses, on_progress=self.on_progress)
 
     def import_customers(self, customers: list[dict]) -> ImportResult:
-        return CustomerImporter(self.company, self.abbr).run(customers)
+        return CustomerImporter(self.company, self.abbr).run(
+            customers, on_progress=self.on_progress)
 
     def import_suppliers(self, suppliers: list[dict]) -> ImportResult:
-        return SupplierImporter(self.company, self.abbr).run(suppliers)
+        return SupplierImporter(self.company, self.abbr).run(
+            suppliers, on_progress=self.on_progress)
 
     def import_items(self, items: list[dict]) -> ImportResult:
         # Heal a prior hard-killed run before reading the setting, then suspend
@@ -143,7 +150,8 @@ class ERPNextImporter:
         _restore_hsn_validation()
         with _hsn_validation_suspended():
             return ItemImporter(
-                self.company, self.abbr, uom_overrides=self._uom_overrides).run(items)
+                self.company, self.abbr, uom_overrides=self._uom_overrides).run(
+                    items, on_progress=self.on_progress)
 
     def _opening_date(self, posting_date: str = "") -> str:
         """Posting date for opening entries.

--- a/tally_migrator/migration/master_migrator.py
+++ b/tally_migrator/migration/master_migrator.py
@@ -255,10 +255,20 @@ class MasterMigrator:
                 f"| bills: {len(bills)} | extract {self._timings['Extract']}s")
 
             results: dict[str, ImportResult] = {}
-            for step in self._pipeline(masters, coa, bills):
+            steps = self._pipeline(masters, coa, bills)
+            for i, step in enumerate(steps):
                 self._progress(step.percent, f"Importing {len(step.records)} {step.label.lower()}...")
+                # The bar fills from this step's percent up to (but not reaching) the
+                # next step's percent, so a long phase keeps moving instead of sitting
+                # frozen. The finalize milestone (95) caps the last step's band.
+                band_end = steps[i + 1].percent if i + 1 < len(steps) else 95
+                self.importer.on_progress = self._step_progress_cb(
+                    step.label, step.percent, band_end)
                 _t = _time.monotonic()
-                results[step.label] = step.importer(step.records)
+                try:
+                    results[step.label] = step.importer(step.records)
+                finally:
+                    self.importer.on_progress = None
                 self._timings[step.label] = round(_time.monotonic() - _t, 2)
                 frappe.logger().info(
                     f"[Tally Migrator] Phase '{step.label}': {len(step.records)} records "
@@ -368,6 +378,43 @@ class MasterMigrator:
         results["Accounts"] = acc
 
     # ── Progress ────────────────────────────────────────────────────────────────
+
+    # Emit an intra-phase progress update at most every this many records (or
+    # whenever the whole-number percent ticks up). Bounds the realtime/Redis writes
+    # to roughly a hundred over a full run - cheap enough to never dent throughput -
+    # while still moving the counter often enough to read as continuous.
+    _PROGRESS_EVERY = 250
+
+    def _step_progress_cb(self, label: str, start: int, end: int):
+        """Build an ``on_progress(done, total)`` callback for one phase.
+
+        Maps the phase's record progress onto the bar band ``[start, end)`` and emits
+        a throttled update carrying a live "x of N" count. Whole side-channel: wrapped
+        so a progress hiccup can never interrupt the import, and monotonic so the bar
+        only ever moves forward."""
+        state = {"pct": start, "done": 0}
+
+        def cb(done: int, total: int) -> None:
+            try:
+                if not total:
+                    return
+                # Clamp into the band; the end is reserved for the next phase's start.
+                pct = start + (end - start) * done // total
+                if pct >= end:
+                    pct = end - 1
+                advanced = pct > state["pct"]
+                stepped = done - state["done"] >= self._PROGRESS_EVERY
+                if not advanced and not stepped:
+                    return
+                state["pct"] = max(pct, state["pct"])
+                state["done"] = done
+                self._progress(
+                    state["pct"],
+                    f"Importing {label.lower()} {done:,} of {total:,}...")
+            except Exception:
+                pass
+
+        return cb
 
     def _progress(self, pct: int, description: str = "") -> None:
         # A custom realtime event (not frappe.publish_progress) so only the wizard's

--- a/tally_migrator/migration/master_migrator.py
+++ b/tally_migrator/migration/master_migrator.py
@@ -222,6 +222,10 @@ class MasterMigrator:
         self.applied_edits: list[dict] = []   # audit trail of effective pre-flight edits
         self.posting_date = getattr(config, "posting_date", "") or ""
         self.log = log
+        # Wall-time (seconds) per phase, for the performance baseline / before-after
+        # comparison. Folded into the log's extracted_counts under "_phase_seconds" at
+        # finalize and logged. Pure measurement - no effect on what gets imported.
+        self._timings: dict[str, float] = {}
 
     # ── Public ────────────────────────────────────────────────────────────────
 
@@ -230,11 +234,13 @@ class MasterMigrator:
         # create one now so an interrupted run is still recorded.
         self.log = self.log or self._create_log()
         try:
+            import time as _time
             self._progress(0)
             if not self.client.ping():
                 frappe.throw("Could not read the uploaded file. Please re-upload a valid Tally Masters XML export.")
 
             self._progress(10)
+            _t = _time.monotonic()
             masters = self.extractor.extract_all()
             apply_record_overrides(masters, self.record_overrides, self.applied_edits)
             self._record_uom_edits()
@@ -243,14 +249,20 @@ class MasterMigrator:
             # source can't supply child lists, so party openings then degrade to a
             # single lump opening invoice per party (no bill breakdown).
             bills = self.extractor.extract_bill_allocations()
+            self._timings["Extract"] = round(_time.monotonic() - _t, 2)
             frappe.logger().info(
                 f"[Tally Migrator] Extracted: {masters.summary} | COA: {coa.summary} "
-                f"| bills: {len(bills)}")
+                f"| bills: {len(bills)} | extract {self._timings['Extract']}s")
 
             results: dict[str, ImportResult] = {}
             for step in self._pipeline(masters, coa, bills):
                 self._progress(step.percent, f"Importing {len(step.records)} {step.label.lower()}...")
+                _t = _time.monotonic()
                 results[step.label] = step.importer(step.records)
+                self._timings[step.label] = round(_time.monotonic() - _t, 2)
+                frappe.logger().info(
+                    f"[Tally Migrator] Phase '{step.label}': {len(step.records)} records "
+                    f"in {self._timings[step.label]}s")
             self._record_excluded(results, coa)
             summary = MigrationSummary(results)
 
@@ -258,6 +270,7 @@ class MasterMigrator:
             self._finalize_log(masters, coa, summary)
 
             self._progress(100)
+            frappe.logger().info(f"[Tally Migrator] Phase timings (s): {self._timings}")
             return summary
         except Exception as exc:
             self._fail_log(exc)
@@ -435,7 +448,8 @@ class MasterMigrator:
         try:
             self.log.reload()
             self.log.status = "Completed with Errors" if summary.has_errors else "Completed"
-            self.log.extracted_counts = frappe.as_json({**masters.summary, **coa.summary})
+            self.log.extracted_counts = frappe.as_json(
+                {**masters.summary, **coa.summary, "_phase_seconds": self._timings})
             self.log.import_summary = frappe.as_json(summary.as_dict())
             self.log.applied_edits = frappe.as_json(self.applied_edits)
             manifest = summary.created_records()


### PR DESCRIPTION
First of a four-PR stack that makes the masters migration fast and memory-safe on large books. Review/merge **bottom-up**; this is the base.

### The problem
The per-record duplicate check (`BaseImporter._upsert`) did one `frappe.db.get_value(doctype, {key_field: value})` per record. The dedup columns (`supplier_name`, `customer_name`, `item_code`, …) are **not indexed**, so each lookup is a full table scan: O(n) per record, **O(n²) over a run**. On the real 13k-supplier book that's ~113s of pure dedup on the first run - and it's the *dominant* cost on every re-run, where every record is a skip.

### The fix
Snapshot existing records once per importer (`_prefetch_existing`) into `{exact: {key: name}, norm: {normalised_key}}`, consulted in-memory and kept current as the run inserts (`_remember_inserted`). ~113s → ~0.1s on suppliers; fixes the first run *and* every re-run.

**It is over-skip-proof by construction** (the property that matters - a wrong skip would silently drop a real record):
- an **exact** key hit skips directly (always collation-equal, so never a false skip);
- a **normalised-only** hit (case/accent/PAD-SPACE variant) is *confirmed against the DB* before skipping;
- a brand-new key returns without a query and inserts.

So the in-memory snapshot can never drop a distinct record; the DB get_value remains the authority for the only ambiguous case. The normalisation (NFKD strip + casefold + rstrip) is deliberately *at least* as aggressive as the `utf8mb4_unicode_ci` collation, so a miss reliably means "no DB variant exists."

### Also here
- **Per-phase wall-time instrumentation** folded into the migration log (`_phase_seconds`) - the baseline that made the rest of this stack measurable rather than guessed.
- **Continuously-moving progress bar**: progress now advances *within* a phase (per-record callback, throttled), not just between phases, and is reconnect-safe.

No change to what gets imported.