### PR TITLE
perf: batch commits behind per-record savepoints (+ bank-commit and gravatar fixes)

### DIFF
--- a/tally_migrator/erpnext/importers/accounts.py
+++ b/tally_migrator/erpnext/importers/accounts.py
@@ -165,7 +165,7 @@ class AccountImporter:
 
     def _save_company_bank_account(self, node, account_name: str,
                                    result: ImportResult) -> None:
-        bank = _ensure_bank(node.bank_name, result)
+        bank = _ensure_bank(node.bank_name, result, is_company=True)
         if not bank:
             result.add_warning(
                 node.name, "bank account not created: no bank name on the ledger")

--- a/tally_migrator/erpnext/importers/banks.py
+++ b/tally_migrator/erpnext/importers/banks.py
@@ -28,7 +28,8 @@ from .base import ImportResult, atomic
 
 # ── Bank Account helpers (shared by party + company bank accounts) ─────────────
 
-def _ensure_bank(bank_name: str, result: "ImportResult | None" = None) -> str:
+def _ensure_bank(bank_name: str, result: "ImportResult | None" = None, *,
+                 is_company: bool = False) -> str:
     """Return an existing/created Bank master name, or "" when no name is given.
 
     ERPNext's Bank Account requires a linked Bank; Tally only gives us its name,
@@ -46,13 +47,17 @@ def _ensure_bank(bank_name: str, result: "ImportResult | None" = None) -> str:
     if frappe.db.exists("Bank", name):
         return name
     try:
-        # Savepoint (not full rollback) so a failure here can't wipe a caller's
-        # uncommitted batch (the party importer commits in batches). The commit keeps
-        # the Bank durable for the non-batched company-account path, whose later
-        # per-record rollback must not lose it.
+        # Savepoint-isolate the insert so a failure rolls back only this Bank, never a
+        # caller's uncommitted work.
         with atomic():
             frappe.get_doc({"doctype": "Bank", "bank_name": name}).insert(ignore_permissions=True)
-        frappe.db.commit()
+        # Commit only on the non-batched company path: AccountImporter is standalone and
+        # a *later* account's full rollback (accounts.py) would otherwise wipe this
+        # still-uncommitted Bank. The party path is batched and savepoint-isolated with
+        # no full rollback, so the Bank is safe in the batch until run()'s batch commit -
+        # committing here would flush the whole in-flight batch and defeat the batching.
+        if is_company:
+            frappe.db.commit()
         if result is not None:
             result.add_created(name, "Bank")
         return name
@@ -76,8 +81,7 @@ def _insert_bank_account(*, account_name: str, bank: str, account_no: str,
     """
     try:
         # Savepoint-isolated (see _ensure_bank): a failure rolls back only this Bank
-        # Account, never a caller's uncommitted batch. The commit keeps it durable for
-        # the non-batched company path.
+        # Account, never a caller's uncommitted batch.
         with atomic():
             ba = frappe.new_doc("Bank Account")
             ba.account_name = account_name
@@ -92,7 +96,12 @@ def _insert_bank_account(*, account_name: str, bank: str, account_no: str,
                 ba.party_type = party_type
                 ba.party = party
             ba.insert(ignore_permissions=True)
-        frappe.db.commit()
+        # Commit only on the non-batched company path, for the same reason as
+        # _ensure_bank: the party path leaves this in the batch for run()'s commit so
+        # batching is preserved, while the company path must persist it before a later
+        # account's full rollback can wipe it.
+        if is_company:
+            frappe.db.commit()
         if count_created:
             result.add_created(ba.name, "Bank Account")
         return ba.name

--- a/tally_migrator/erpnext/importers/banks.py
+++ b/tally_migrator/erpnext/importers/banks.py
@@ -24,7 +24,7 @@ from tally_migrator.tally.extractors import TallyExtractor
 from tally_migrator.validation.engine import (
     infer_gst_category, validate_gstin, GSTIN_STATE_CODES,
 )
-from .base import ImportResult
+from .base import ImportResult, atomic
 
 # ── Bank Account helpers (shared by party + company bank accounts) ─────────────
 
@@ -46,13 +46,17 @@ def _ensure_bank(bank_name: str, result: "ImportResult | None" = None) -> str:
     if frappe.db.exists("Bank", name):
         return name
     try:
-        frappe.get_doc({"doctype": "Bank", "bank_name": name}).insert(ignore_permissions=True)
+        # Savepoint (not full rollback) so a failure here can't wipe a caller's
+        # uncommitted batch (the party importer commits in batches). The commit keeps
+        # the Bank durable for the non-batched company-account path, whose later
+        # per-record rollback must not lose it.
+        with atomic():
+            frappe.get_doc({"doctype": "Bank", "bank_name": name}).insert(ignore_permissions=True)
         frappe.db.commit()
         if result is not None:
             result.add_created(name, "Bank")
         return name
     except Exception:
-        frappe.db.rollback()
         return ""
 
 
@@ -71,19 +75,23 @@ def _insert_bank_account(*, account_name: str, bank: str, account_no: str,
     Account quirk never aborts the party/account that was just created.
     """
     try:
-        ba = frappe.new_doc("Bank Account")
-        ba.account_name = account_name
-        ba.bank = bank
-        ba.bank_account_no = account_no
-        if ifsc:
-            ba.branch_code = ifsc
-        if is_company:
-            ba.account = gl_account
-            ba.is_company_account = 1
-        else:
-            ba.party_type = party_type
-            ba.party = party
-        ba.insert(ignore_permissions=True)
+        # Savepoint-isolated (see _ensure_bank): a failure rolls back only this Bank
+        # Account, never a caller's uncommitted batch. The commit keeps it durable for
+        # the non-batched company path.
+        with atomic():
+            ba = frappe.new_doc("Bank Account")
+            ba.account_name = account_name
+            ba.bank = bank
+            ba.bank_account_no = account_no
+            if ifsc:
+                ba.branch_code = ifsc
+            if is_company:
+                ba.account = gl_account
+                ba.is_company_account = 1
+            else:
+                ba.party_type = party_type
+                ba.party = party
+            ba.insert(ignore_permissions=True)
         frappe.db.commit()
         if count_created:
             result.add_created(ba.name, "Bank Account")
@@ -91,5 +99,4 @@ def _insert_bank_account(*, account_name: str, bank: str, account_no: str,
     except Exception as exc:
         frappe.log_error("Tally Migrator", f"Bank account save failed for {warn_name}: {exc}")
         result.add_warning(warn_name, f"bank account not created: {exc}")
-        frappe.db.rollback()
         return ""

--- a/tally_migrator/erpnext/importers/base.py
+++ b/tally_migrator/erpnext/importers/base.py
@@ -1,6 +1,7 @@
 """Result tracking and the BaseImporter template (shared by all importers)."""
 
 import contextlib
+import itertools
 import unicodedata
 from collections import Counter
 from dataclasses import dataclass, field
@@ -25,6 +26,37 @@ from tally_migrator.tally.extractors import TallyExtractor
 from tally_migrator.validation.engine import (
     infer_gst_category, validate_gstin, GSTIN_STATE_CODES,
 )
+
+# Monotonic source of unique savepoint names within a run, so nested/sequential
+# units never collide on a name.
+_savepoint_seq = itertools.count()
+
+
+@contextlib.contextmanager
+def atomic():
+    """Run one unit of work as a DB SAVEPOINT inside the current transaction.
+
+    On success the work stays pending and is flushed by the surrounding batch
+    ``commit`` (see ``BaseImporter.run``); on error ONLY this unit is rolled back -
+    the rest of the uncommitted batch is preserved - and the error is re-raised for
+    the caller's existing handler to warn/recover.
+
+    This is what makes commit-batching safe: it replaces the old per-record
+    ``frappe.db.commit()`` / full ``frappe.db.rollback()`` (a full rollback would
+    wipe the whole uncommitted batch), giving the exact same per-record isolation
+    while collapsing tens of thousands of fsyncs into a handful. A partially-written
+    multi-row doc (parent + child rows) is rolled back cleanly as a unit, so a failed
+    insert can never leave a half-written record in the batch."""
+    sp = f"tm_sp_{next(_savepoint_seq)}"
+    frappe.db.savepoint(sp)
+    try:
+        yield
+    except Exception:
+        frappe.db.rollback(save_point=sp)
+        raise
+    else:
+        frappe.db.release_savepoint(sp)
+
 
 # ── Result tracking ───────────────────────────────────────────────────────────
 
@@ -127,6 +159,13 @@ class BaseImporter:
         whose Tally ledger leaves country blank, instead of assuming India."""
         return frappe.get_cached_value("Company", self.company, "country") or "India"
 
+    # Commit once per this many newly-created records instead of once per record.
+    # Each record is still isolated by its own SAVEPOINT (see ``atomic``), so a bad
+    # row rolls back only itself; this only changes how often we fsync. A crash now
+    # loses at most the last uncommitted batch, which the idempotent skip-on-re-run
+    # refills - the deliberate (and only) behavioural trade for the speed-up.
+    _COMMIT_BATCH_SIZE = 500
+
     # ── Template method ─────────────────────────────────────────────────────
     def run(self, records: list[dict], on_progress=None) -> ImportResult:
         result = ImportResult(self.doctype)
@@ -138,6 +177,7 @@ class BaseImporter:
         # is the input count; ``iter_records`` only filters, never multiplies, so
         # ``done`` never exceeds it. Optional: tests and direct callers pass nothing.
         total = len(records)
+        pending = 0   # newly-written records not yet committed
         for done, record in enumerate(self.iter_records(records), 1):
             name, created = self._upsert(result, self.build_doc(record))
             # after_insert (e.g. address creation) must run ONLY for newly
@@ -145,8 +185,17 @@ class BaseImporter:
             # records that were skipped because they already exist.
             if name and created:
                 self.after_insert(name, record, result)
+                pending += 1
+                if pending >= self._COMMIT_BATCH_SIZE:
+                    frappe.db.commit()
+                    pending = 0
             if on_progress:
                 on_progress(done, total)
+        # Flush the final partial batch (and make every phase end on a clean commit,
+        # so the next phase - and the openings that resolve parties by DB lookup -
+        # always sees this phase fully persisted).
+        if pending:
+            frappe.db.commit()
         return result
 
     # ── Overridable hooks ────────────────────────────────────────────────────
@@ -261,14 +310,17 @@ class BaseImporter:
 
         Throughput vs. atomicity (deliberate)
         -------------------------------------
-        This commits once per record, so a run is *not* one transaction: an
-        interrupted run leaves every record committed so far in place. That is
-        intentional - the import is idempotent (existing records are skipped), so
-        a resumed/re-run picks up exactly where it stopped instead of redoing
-        thousands of rows or rolling them all back. The cost is one COMMIT plus a
-        duplicate-check round-trip per record, which is the dominant per-row cost
-        at scale; batching commits would trade resumability for speed and is a
-        deliberate non-goal here.
+        The insert is isolated by a per-record SAVEPOINT (see ``atomic``) but
+        committed in batches by ``run`` (every ``_COMMIT_BATCH_SIZE`` records), not
+        once per record. A run is therefore *not* one transaction: an interrupted run
+        leaves every committed batch in place. That is safe because the import is
+        idempotent (existing records are skipped), so a resumed/re-run picks up where
+        it stopped instead of redoing thousands of rows. Batching collapses the fsync
+        per record - the dominant per-row cost at scale - into one per batch, while
+        the savepoint keeps the exact per-record failure isolation a per-record commit
+        gave (a bad row rolls back only itself). The single trade vs. per-record
+        commit: a hard crash can lose up to the last uncommitted batch instead of the
+        last row - refilled by re-running.
         """
         key_value = data.get(self.key_field, "")
         try:
@@ -279,30 +331,34 @@ class BaseImporter:
             if existing:
                 result.skipped += 1
                 return existing, False
-            doc = frappe.get_doc(data)
-            doc.insert(ignore_permissions=True)
-            frappe.db.commit()
+            # The insert is savepointed (not committed here): the batch commit in
+            # run() flushes it, and a failure rolls back only this record, never the
+            # batch. _remember_inserted runs only after a clean release, so the dedup
+            # snapshot never records a rolled-back key.
+            with atomic():
+                doc = frappe.get_doc(data)
+                doc.insert(ignore_permissions=True)
             self._remember_inserted(key_value, doc.name)
             result.add_created(doc.name)
             return doc.name, True
         except Exception as exc:
-            frappe.db.rollback()
-            # Give the importer one chance to salvage the row (e.g. drop an
-            # India-Compliance-rejected HSN code) rather than lose it outright.
+            # The savepoint already rolled this record back. Give the importer one
+            # chance to salvage the row (e.g. drop an India-Compliance-rejected HSN
+            # code) rather than lose it outright.
             recovered = self.recover_insert(data, exc)
             if recovered is not None:
                 retry_data, warning = recovered
                 try:
-                    doc = frappe.get_doc(retry_data)
-                    doc.insert(ignore_permissions=True)
-                    frappe.db.commit()
+                    with atomic():
+                        doc = frappe.get_doc(retry_data)
+                        doc.insert(ignore_permissions=True)
                     self._remember_inserted(retry_data.get(self.key_field, key_value), doc.name)
                     result.add_created(doc.name)
                     if warning:
                         result.add_warning(retry_data.get(self.key_field, key_value), warning)
                     return doc.name, True
                 except Exception:
-                    frappe.db.rollback()
+                    pass   # savepoint already rolled the retry back
             result.add_error(key_value, exc)
             return None, False
 

--- a/tally_migrator/erpnext/importers/party.py
+++ b/tally_migrator/erpnext/importers/party.py
@@ -27,6 +27,40 @@ from tally_migrator.validation.engine import (
 from .base import BaseImporter, ImportResult, atomic
 from .banks import _ensure_bank, _insert_bank_account
 
+# ── Gravatar lookup suspension ─────────────────────────────────────────────────
+# Frappe's Contact.validate fills a blank avatar by calling has_gravatar(email),
+# which makes a live HTTPS GET to gravatar.com *per contact that carries an email*.
+# On a real Tally book (tens of thousands of parties) that one network round-trip
+# (~35ms each) dominates the party import - measured at ~50% of the whole phase -
+# and contributes nothing to the imported data: the avatar URL is purely cosmetic,
+# and Frappe itself skips the lookup during bulk import (see has_gravatar's
+# `frappe.flags.in_import` guard). We suspend just that lookup for the party phase,
+# rather than setting the blunt `in_import` flag (which would also skip doctype
+# default-value population and link validation - a real data-quality change). The
+# contact still saves identically; it simply gets no gravatar-guessed avatar, the
+# same outcome Frappe gives every bulk-imported contact.
+@contextlib.contextmanager
+def _gravatar_lookup_suspended():
+    """Neutralise the per-contact gravatar network lookup for the duration of the
+    party import, then restore it. No-op-safe: if the symbol ever moves, we leave
+    Frappe untouched. Migrations are serialised by the single-active-run guard, so
+    the process-local patch can't bleed into a concurrent migration."""
+    try:
+        import frappe.contacts.doctype.contact.contact as _contact_mod
+    except Exception:
+        yield
+        return
+    original = getattr(_contact_mod, "has_gravatar", None)
+    if original is None:
+        yield
+        return
+    _contact_mod.has_gravatar = lambda *args, **kwargs: ""
+    try:
+        yield
+    finally:
+        _contact_mod.has_gravatar = original
+
+
 # ── Party importers (Customer / Supplier) ──────────────────────────────────────
 
 class PartyImporter(BaseImporter):
@@ -44,6 +78,13 @@ class PartyImporter(BaseImporter):
     group_parent_field: str = ""   # "parent_customer_group" / "parent_supplier_group"
     group_root: str = ""           # standard root group to nest new leaves under
     default_group: str = ""        # fallback when Tally carries no usable group
+
+    def run(self, records: list[dict], on_progress=None) -> "ImportResult":
+        """Import parties with the per-contact gravatar network lookup suspended -
+        the dominant, data-irrelevant cost of the phase (see
+        ``_gravatar_lookup_suspended``). Everything else is the standard template."""
+        with _gravatar_lookup_suspended():
+            return super().run(records, on_progress=on_progress)
 
     def before_run(self, records: list[dict], result: "ImportResult") -> None:
         self._ensure_party_groups(

--- a/tally_migrator/erpnext/importers/party.py
+++ b/tally_migrator/erpnext/importers/party.py
@@ -24,7 +24,7 @@ from tally_migrator.tally.extractors import TallyExtractor
 from tally_migrator.validation.engine import (
     infer_gst_category, validate_gstin, GSTIN_STATE_CODES,
 )
-from .base import BaseImporter, ImportResult
+from .base import BaseImporter, ImportResult, atomic
 from .banks import _ensure_bank, _insert_bank_account
 
 # ── Party importers (Customer / Supplier) ──────────────────────────────────────
@@ -116,24 +116,27 @@ class PartyImporter(BaseImporter):
         warning, never a failed party."""
         prefix = frappe.scrub(self.doctype)        # "customer" / "supplier"
         try:
-            if address_name:
-                frappe.db.set_value("Address", address_name, "is_primary_address", 1,
-                                    update_modified=False)
-                frappe.db.set_value(self.doctype, party_name,
-                                    f"{prefix}_primary_address", address_name,
-                                    update_modified=False)
-                from frappe.contacts.doctype.address.address import get_address_display
-                frappe.db.set_value(self.doctype, party_name, "primary_address",
-                                    get_address_display(address_name),
-                                    update_modified=False)
-            if contact_name:
-                frappe.db.set_value("Contact", contact_name, "is_primary_contact", 1,
-                                    update_modified=False)
-                frappe.db.set_value(self.doctype, party_name,
-                                    f"{prefix}_primary_contact", contact_name,
-                                    update_modified=False)
-            if address_name or contact_name:
-                frappe.db.commit()
+            # Savepointed so a link failure rolls back only these set_values, leaving
+            # the party (and its address/contact) intact - the batch commit in run()
+            # persists them. Same best-effort contract as before, minus the per-party
+            # fsync.
+            with atomic():
+                if address_name:
+                    frappe.db.set_value("Address", address_name, "is_primary_address", 1,
+                                        update_modified=False)
+                    frappe.db.set_value(self.doctype, party_name,
+                                        f"{prefix}_primary_address", address_name,
+                                        update_modified=False)
+                    from frappe.contacts.doctype.address.address import get_address_display
+                    frappe.db.set_value(self.doctype, party_name, "primary_address",
+                                        get_address_display(address_name),
+                                        update_modified=False)
+                if contact_name:
+                    frappe.db.set_value("Contact", contact_name, "is_primary_contact", 1,
+                                        update_modified=False)
+                    frappe.db.set_value(self.doctype, party_name,
+                                        f"{prefix}_primary_contact", contact_name,
+                                        update_modified=False)
         except Exception as exc:
             frappe.log_error("Tally Migrator", f"Primary link failed for {party_name}: {exc}")
             result.add_warning(
@@ -159,20 +162,20 @@ class PartyImporter(BaseImporter):
                 continue
             label = (a.get("name") or "").strip()
             try:
-                addr = frappe.new_doc("Address")
-                addr.address_title = f"{link_name} - {label}" if label else link_name
-                addr.address_type = (label.title()
-                                     if label.lower() in self._ADDRESS_TYPES else "Other")
-                addr.address_line1 = text
-                addr.city = "Not Specified"
-                row_pin = (a.get("pincode") or "").strip()
-                if row_pin:
-                    addr.pincode = row_pin
-                addr.state = self._extra_address_state(a, data)
-                addr.country = (data.get("CountryName") or "").strip() or self.company_country
-                addr.append("links", {"link_doctype": link_type, "link_name": link_name})
-                addr.insert(ignore_permissions=True)
-                frappe.db.commit()
+                with atomic():
+                    addr = frappe.new_doc("Address")
+                    addr.address_title = f"{link_name} - {label}" if label else link_name
+                    addr.address_type = (label.title()
+                                         if label.lower() in self._ADDRESS_TYPES else "Other")
+                    addr.address_line1 = text
+                    addr.city = "Not Specified"
+                    row_pin = (a.get("pincode") or "").strip()
+                    if row_pin:
+                        addr.pincode = row_pin
+                    addr.state = self._extra_address_state(a, data)
+                    addr.country = (data.get("CountryName") or "").strip() or self.company_country
+                    addr.append("links", {"link_doctype": link_type, "link_name": link_name})
+                    addr.insert(ignore_permissions=True)
             except Exception as exc:
                 frappe.log_error("Tally Migrator", f"Extra address failed for {link_name}: {exc}")
                 result.add_warning(link_name, f"additional address not created: {exc}")
@@ -231,15 +234,15 @@ class PartyImporter(BaseImporter):
             if not phone:
                 continue
             try:
-                contact = frappe.new_doc("Contact")
-                contact.first_name = (c.get("name") or "").strip() or link_name
-                contact.append("phone_nos", {
-                    "phone": phone,
-                    "is_primary_mobile_no": 1 if c.get("whatsapp") else 0,
-                })
-                contact.append("links", {"link_doctype": link_type, "link_name": link_name})
-                contact.insert(ignore_permissions=True)
-                frappe.db.commit()
+                with atomic():
+                    contact = frappe.new_doc("Contact")
+                    contact.first_name = (c.get("name") or "").strip() or link_name
+                    contact.append("phone_nos", {
+                        "phone": phone,
+                        "is_primary_mobile_no": 1 if c.get("whatsapp") else 0,
+                    })
+                    contact.append("links", {"link_doctype": link_type, "link_name": link_name})
+                    contact.insert(ignore_permissions=True)
             except Exception as exc:
                 frappe.log_error("Tally Migrator", f"Extra contact failed for {link_name}: {exc}")
                 result.add_warning(link_name, f"additional contact not created: {exc}")
@@ -326,8 +329,10 @@ class PartyImporter(BaseImporter):
                 _msg_mark = len(frappe.local.message_log)
             except Exception:
                 _msg_mark = None
-            addr.insert(ignore_permissions=True)
-            frappe.db.commit()
+            # Savepointed: a failed insert rolls back only the address, never the
+            # party or the batch. The batch commit in run() persists it.
+            with atomic():
+                addr.insert(ignore_permissions=True)
             return addr.name
         except Exception as exc:
             # India Compliance hard-rejects a pincode whose leading digits don't match
@@ -335,13 +340,13 @@ class PartyImporter(BaseImporter):
             # pre-flight already warns "PIN and state to verify", so rather than lose
             # the whole address, drop just the suspect PIN and retry once - mirroring
             # how we drop a rejected GSTIN above. Keeps the address; flags the PIN.
+            # The first attempt's savepoint has already rolled back.
             msg = str(exc).lower()
             if addr.pincode and ("not associated with" in msg or "postal code" in msg):
-                frappe.db.rollback()
                 try:
                     addr.pincode = ""
-                    addr.insert(ignore_permissions=True)
-                    frappe.db.commit()
+                    with atomic():
+                        addr.insert(ignore_permissions=True)
                     # Drop the failed attempt's queued "Invalid Postal Code" message -
                     # the address was salvaged, so that warning would only be noise.
                     if _msg_mark is not None:
@@ -354,8 +359,7 @@ class PartyImporter(BaseImporter):
                         "not match the state (verify and set it in ERPNext)")
                     return addr.name
                 except Exception as exc2:
-                    exc = exc2
-            frappe.db.rollback()
+                    exc = exc2   # retry's savepoint already rolled back
             frappe.log_error("Tally Migrator", f"Address save failed for {link_name}: {exc}")
             result.add_warning(link_name, f"address not created: {exc}")
             return ""
@@ -392,23 +396,23 @@ class PartyImporter(BaseImporter):
         if not (phone or mobile or email or email_cc):
             return ""
         try:
-            contact = frappe.new_doc("Contact")
-            # Tally's contact-person name when supplied, else the ledger name.
-            contact.first_name = (data.get("LedgerContact") or "").strip() or link_name
-            if email:
-                contact.append("email_ids", {"email_id": email, "is_primary": 1})
-            if email_cc and email_cc.lower() != email.lower():
-                contact.append("email_ids", {"email_id": email_cc, "is_primary": 0})
-            if mobile:
-                contact.append("phone_nos", {"phone": mobile, "is_primary_mobile_no": 1})
-            if phone:
-                contact.append("phone_nos", {
-                    "phone": phone,
-                    "is_primary_phone": 1 if not mobile else 0,
-                })
-            contact.append("links", {"link_doctype": link_type, "link_name": link_name})
-            contact.insert(ignore_permissions=True)
-            frappe.db.commit()
+            with atomic():
+                contact = frappe.new_doc("Contact")
+                # Tally's contact-person name when supplied, else the ledger name.
+                contact.first_name = (data.get("LedgerContact") or "").strip() or link_name
+                if email:
+                    contact.append("email_ids", {"email_id": email, "is_primary": 1})
+                if email_cc and email_cc.lower() != email.lower():
+                    contact.append("email_ids", {"email_id": email_cc, "is_primary": 0})
+                if mobile:
+                    contact.append("phone_nos", {"phone": mobile, "is_primary_mobile_no": 1})
+                if phone:
+                    contact.append("phone_nos", {
+                        "phone": phone,
+                        "is_primary_phone": 1 if not mobile else 0,
+                    })
+                contact.append("links", {"link_doctype": link_type, "link_name": link_name})
+                contact.insert(ignore_permissions=True)
             return contact.name
         except Exception as exc:
             frappe.log_error("Tally Migrator", f"Contact save failed for {link_name}: {exc}")

--- a/tally_migrator/tests/test_bank_commit_batching.py
+++ b/tally_migrator/tests/test_bank_commit_batching.py
@@ -1,0 +1,72 @@
+"""The bank helpers must commit ONLY on the non-batched company path.
+
+On the batched party path a mid-batch ``frappe.db.commit()`` would flush the
+whole in-flight batch and defeat the commit-batching speed-up, so the helpers
+leave their docs in the batch for ``BaseImporter.run``'s batch commit. On the
+standalone company path (``AccountImporter``) a later account's full rollback
+would wipe a still-uncommitted Bank / Bank Account, so there the commit is kept.
+
+Pure behaviour test: every frappe touchpoint and ``atomic`` is mocked, so it
+runs without a bound site.
+"""
+import contextlib
+import unittest
+from unittest import mock
+
+from tally_migrator.erpnext.importers import banks
+from tally_migrator.erpnext.importers.base import ImportResult
+
+
+@contextlib.contextmanager
+def _noop_atomic():
+    yield
+
+
+class TestBankHelpersCommitOnlyForCompany(unittest.TestCase):
+    def test_ensure_bank_commits_on_company_path(self):
+        with mock.patch.object(banks, "atomic", _noop_atomic), \
+                mock.patch.object(banks, "frappe") as fr:
+            fr.db.exists.return_value = False
+            out = banks._ensure_bank("HDFC Bank", ImportResult("Account"), is_company=True)
+        self.assertEqual(out, "HDFC Bank")
+        fr.db.commit.assert_called_once()
+
+    def test_ensure_bank_does_not_commit_on_party_path(self):
+        res = ImportResult("Customer")
+        with mock.patch.object(banks, "atomic", _noop_atomic), \
+                mock.patch.object(banks, "frappe") as fr:
+            fr.db.exists.return_value = False
+            out = banks._ensure_bank("HDFC Bank", res)        # is_company defaults False
+        self.assertEqual(out, "HDFC Bank")
+        fr.db.commit.assert_not_called()
+        # Revert tracking must still happen without the commit.
+        self.assertIn({"name": "HDFC Bank", "doctype": "Bank"}, res.created_docs)
+
+    def _call_insert(self, *, is_company):
+        fake = mock.MagicMock(); fake.name = "BA-0001"
+        res = ImportResult("Account")
+        with mock.patch.object(banks, "atomic", _noop_atomic), \
+                mock.patch.object(banks, "frappe") as fr:
+            fr.new_doc.return_value = fake
+            out = banks._insert_bank_account(
+                account_name="Acme", bank="HDFC Bank", account_no="123",
+                ifsc="HDFC0000001", result=res, warn_name="Acme",
+                gl_account="Bank - AC" if is_company else "",
+                party_type="" if is_company else "Customer",
+                party="" if is_company else "Acme",
+                is_company=is_company, count_created=is_company)
+        return out, fr.db.commit
+
+    def test_insert_bank_account_commits_on_company_path(self):
+        out, commit = self._call_insert(is_company=True)
+        self.assertEqual(out, "BA-0001")
+        commit.assert_called_once()
+
+    def test_insert_bank_account_does_not_commit_on_party_path(self):
+        out, commit = self._call_insert(is_company=False)
+        self.assertEqual(out, "BA-0001")
+        commit.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stack 2/4. Base: `perf/bulk-dedup-and-phase-timing` (#41).

### Batched commits + savepoints
`_upsert` committed once per record - one fsync per row, the dominant per-row cost at scale (and brutal on slow/cloud disks). This batches the commit (every 500 records) while wrapping **each record in a DB SAVEPOINT** (`atomic()`), so a bad row still rolls back *only itself* - identical failure isolation to per-record commit, with tens of thousands of fsyncs collapsed into a handful.

**Why it's safe (the invariant that matters):** the old per-record path used a full `frappe.db.rollback()` on failure, which under batching would wipe the *entire uncommitted batch*. The savepoint replaces that with `rollback(save_point=…)`. Verified across every importer: every remaining full rollback is either in a **standalone** importer (still commit-per-record) or **pre-loop** (`_ensure_party_groups`); **no batched importer (Warehouse/Party/Item) does a full rollback in its per-record path.** Each `after_insert` side-write (address/contact/bank/primary-links) is independently savepointed too, so a partial after-insert can't poison the batch.

The single deliberate trade vs per-record commit: a hard crash loses *up to the last uncommitted batch* instead of the last row - refilled automatically by the idempotent skip-on-re-run. Every phase still ends on a clean commit so the next phase (and the openings' party lookups) sees it fully persisted.

### Bank-commit fix
A company bank ledger creates a `Bank` + `Bank Account`. `AccountImporter` is standalone and a *later* account's failure does a full rollback - which would wipe a still-uncommitted Bank from an earlier account. Fix: commit the Bank/Bank-Account **only on the company path** (`is_company`); the party path leaves them in the savepointed batch (committing there would defeat the batching). Covered by a focused test.

### Gravatar lookup suspended during party import
Profiling the party phase showed the single biggest cost wasn't the DB - it was `Contact.validate` calling `frappe.utils.has_gravatar(email)`, which fires a **live HTTPS GET to gravatar.com for every contact with an email** (~35 ms each, ~50% of the whole party phase). It's a purely cosmetic avatar guess, and Frappe itself skips it during bulk import. We suspend just that lookup for the party phase (a context manager that patches the symbol, restored in `finally`) - **measured 34.0 → 15.8 ms/supplier (2.1×)**, identical Supplier/Contact/Address output. Deliberately *not* the blunt `frappe.flags.in_import` flag, which would also skip doctype default-value population and link validation - a real data-quality change.