### PR TITLE
feat: accept zipped XML and Google Drive links for large exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ figures into this year's opening balances in ERPNext, so don't skip it. Tally
 writes a `Master.xml` file (to the folder shown in the export screen) - that's the
 file you upload in step 1.
 
+**Large export?** A Masters XML compresses ~90%, so if your file is too big to
+upload (the browser upload is capped, commonly around 25 MB), you have two
+options in step 1:
+
+- **Zip it first** and upload the `.zip` - the app unpacks the XML automatically.
+- **Import from a Google Drive link** - share the file in Drive as "Anyone with
+  the link", then in the upload dialog choose **Link** and paste the link; the app
+  downloads it server-side. A zipped XML on Drive works too.
+
 ---
 
 ## Installation
@@ -106,8 +115,9 @@ Manager) to anyone who should be allowed to run a migration.
 Open the **Tally Migrator** page from the ERPNext desk (search "Tally Migrator" in
 the awesomebar). The wizard walks you through a few guided steps:
 
-1. **Upload** - drop in your Tally export file. The app reads it and tells you what
-   it found.
+1. **Upload** - drop in your Tally export file (`.xml`, or a `.zip` of it). For a
+   file too large to upload, use the dialog's **Link** option to paste a public
+   Google Drive link instead. The app reads it and tells you what it found.
 
    ![Step 1 - Upload](docs/images/wizard-1-upload.png)
 2. **Configure** - pick the ERPNext company the data should go into, choose how to

--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -214,11 +214,26 @@ that run and tracks its progress to completion - it never starts a second one.
 
 ### Step 1 - Upload
 
-Click **Choose Tally XML file** and pick the `Master.xml` you exported. The app
-reads it and shows you what it found, as a row of count chips: Customers,
+Click **Choose Tally XML or .zip file** and pick the `Master.xml` you exported. The
+app reads it and shows you what it found, as a row of count chips: Customers,
 Suppliers, Items, Warehouses, and (when present) Accounts and Cost Centres.
 
 > _Screenshot placeholder: step 1 after a successful upload, showing the count chips._
+
+**Importing a large file.** The browser upload is capped (commonly around 25 MB),
+but a Masters XML compresses by roughly 90%, so a big export has two easy routes:
+
+- **Upload a zip.** Zip the `Master.xml` and choose the `.zip` - the app unpacks it
+  automatically and reads the XML inside. The zip must contain exactly one `.xml`
+  file. (The uncompressed XML is still held to the same size limit, so a zip cannot
+  be used to slip an over-limit file past the cap.)
+- **Import from a Google Drive link.** In the upload dialog, choose the **Link**
+  option and paste the share link to your file. In Drive, the file must be shared as
+  **Anyone with the link** - otherwise Google returns a sign-in page instead of the
+  file and the import is refused with a clear message. The app downloads the file on
+  the server, so nothing has to pass through your browser. A zipped XML on Drive
+  works the same way. Only Google Drive links are accepted; any other link is
+  rejected.
 
 This preview is your first and best check that you exported the right thing. Read
 the counts carefully.

--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -225,8 +225,9 @@ but a Masters XML compresses by roughly 90%, so a big export has two easy routes
 
 - **Upload a zip.** Zip the `Master.xml` and choose the `.zip` - the app unpacks it
   automatically and reads the XML inside. The zip must contain exactly one `.xml`
-  file. (The uncompressed XML is still held to the same size limit, so a zip cannot
-  be used to slip an over-limit file past the cap.)
+  file and must not be password-protected. (The uncompressed XML is still held to
+  the same size limit, so a zip cannot be used to slip an over-limit file past the
+  cap.)
 - **Import from a Google Drive link.** In the upload dialog, choose the **Link**
   option and paste the share link to your file. In Drive, the file must be shared as
   **Anyone with the link** - otherwise Google returns a sign-in page instead of the

--- a/tally_migrator/api.py
+++ b/tally_migrator/api.py
@@ -1,11 +1,13 @@
 import json
+import re
 import threading
 from collections import OrderedDict
+from urllib.parse import urlparse
 
 import frappe
 
 from tally_migrator.tally.config import TallyConfig
-from tally_migrator.tally.file_source import FileTallySource, decode_tally_bytes
+from tally_migrator.tally.file_source import FileTallySource, decode_tally_bytes, unzip_if_zip
 from tally_migrator.tally.extractors import TallyExtractor, ITEM_FIELDS, ITEM_TAGS
 from tally_migrator.erpnext.uom_resolver import UomResolver
 from tally_migrator.validation.engine import (
@@ -497,7 +499,11 @@ def _source_from_file(file_url):
         if source is not None:
             _SOURCE_CACHE.move_to_end(cache_key)     # mark most-recently used
             return file_doc, source
-        source = FileTallySource(_decode(_raw_file_bytes(file_doc)))
+        # A zipped XML is accepted transparently: unzip (with the uncompressed
+        # size held to the same cap) before decoding, so the parser only ever
+        # sees plain XML bytes regardless of how the file was uploaded.
+        raw = unzip_if_zip(_raw_file_bytes(file_doc), _max_upload_bytes())
+        source = FileTallySource(_decode(raw))
         _SOURCE_CACHE[cache_key] = source            # inserts as most-recently used
         while len(_SOURCE_CACHE) > _SOURCE_CACHE_MAX:
             _SOURCE_CACHE.popitem(last=False)        # evict least-recently used
@@ -512,7 +518,15 @@ def _raw_file_bytes(file_doc) -> bytes:
     mark on a genuine UTF-16 Tally export, so our own encoding detection in
     ``decode_tally_bytes`` never runs and the parser dies at byte 0. Reading binary
     keeps the real bytes - and the BOM - intact.
+
+    A "Link" upload (Frappe's FileUploader web-link tab) stores the URL as the
+    File's ``file_url`` and downloads nothing, so ``get_content()`` has no local
+    bytes to read. We support exactly one remote source - a public Google Drive
+    link - and fetch it here, so a too-large export shared via Drive flows through
+    the identical pipeline (a zipped XML on Drive is unpacked downstream as usual).
     """
+    if getattr(file_doc, "is_remote_file", False):
+        return _download_drive_file(_parse_drive_id(file_doc.file_url))
     content = file_doc.get_content()
     raw = bytes(content) if isinstance(content, (bytes, bytearray)) else None
     if raw is not None:
@@ -550,10 +564,118 @@ def _raw_file_bytes(file_doc) -> bytes:
         return encoded
 
 
+# A Google Drive file id as it appears in the common share-link shapes:
+#   https://drive.google.com/file/d/<ID>/view?usp=sharing
+#   https://drive.google.com/open?id=<ID>
+#   https://drive.google.com/uc?export=download&id=<ID>
+#   https://docs.google.com/spreadsheets/d/<ID>/edit
+# The id alphabet is URL-safe base64 ([A-Za-z0-9_-]); we match the longest run.
+_DRIVE_ID_PATTERNS = (
+    re.compile(r"/file/d/([A-Za-z0-9_-]{10,})"),
+    re.compile(r"/d/([A-Za-z0-9_-]{10,})"),
+    re.compile(r"[?&]id=([A-Za-z0-9_-]{10,})"),
+)
+_BARE_DRIVE_ID = re.compile(r"^[A-Za-z0-9_-]{10,}$")
+
+
+def _parse_drive_id(url: str) -> str:
+    """Extract the Drive file id from a share link (or accept a bare id).
+
+    Rejects anything that is not a Google Drive / Docs link so this endpoint can
+    only ever reach Google - it is not a general URL fetcher."""
+    url = (url or "").strip()
+    if not url:
+        frappe.throw(frappe._("Paste a Google Drive link first."))
+    if _BARE_DRIVE_ID.match(url):
+        return url
+    if not re.match(r"^https?://", url, re.IGNORECASE):
+        frappe.throw(frappe._("That doesn't look like a link. Paste the full Google Drive share URL."))
+    host = (urlparse(url).hostname or "").lower()
+    if not (host == "google.com" or host.endswith(".google.com")):
+        frappe.throw(frappe._(
+            "Only Google Drive links are supported here. Share your file on "
+            "Google Drive as 'Anyone with the link' and paste that link."
+        ))
+    for pat in _DRIVE_ID_PATTERNS:
+        m = pat.search(url)
+        if m:
+            return m.group(1)
+    frappe.throw(frappe._(
+        "Could not find a file id in that Google Drive link. Open the file in "
+        "Drive, choose Share, copy the link, and paste it here."
+    ))
+
+
+def _download_drive_file(file_id: str) -> bytes:
+    """Stream a public Drive file's bytes, capped at the upload size limit.
+
+    Uses the ``drive.usercontent.google.com`` download endpoint with
+    ``confirm=t`` so Drive's large-file "can't scan for viruses" interstitial is
+    skipped and the real bytes are returned. If Drive serves an HTML page
+    instead (the file isn't shared publicly, or the link is wrong) we detect that
+    and raise an actionable error rather than importing a web page as XML.
+    """
+    import requests
+
+    max_bytes = _max_upload_bytes()
+    try:
+        resp = requests.get(
+            "https://drive.usercontent.google.com/download",
+            params={"id": file_id, "export": "download", "confirm": "t"},
+            stream=True,
+            timeout=(10, 180),
+        )
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        frappe.throw(frappe._(
+            "Could not reach Google Drive to download the file ({0}). Check the "
+            "link and your network, then try again."
+        ).format(type(e).__name__))
+
+    chunks, total = [], 0
+    try:
+        for chunk in resp.iter_content(chunk_size=262144):
+            if not chunk:
+                continue
+            total += len(chunk)
+            if total > max_bytes:
+                frappe.throw(frappe._(
+                    "The Drive file is larger than the {0} MB limit for a single "
+                    "import. Export your Tally masters in smaller batches, or ask "
+                    "your administrator to raise tally_migrator_max_upload_mb."
+                ).format(max_bytes // (1024 * 1024)))
+            chunks.append(chunk)
+    finally:
+        resp.close()
+
+    raw = b"".join(chunks)
+    if not raw:
+        frappe.throw(frappe._("Google Drive returned an empty file. Check the link and sharing settings."))
+    # Drive serves the sharing-blocked / not-found case as an HTML page.
+    head = raw[:512].lstrip().lower()
+    if head.startswith(b"<!doctype html") or head.startswith(b"<html"):
+        frappe.throw(frappe._(
+            "Google Drive returned a web page instead of your file. Make sure the "
+            "file is shared as 'Anyone with the link' and the link points to a "
+            "single file (not a folder)."
+        ))
+    return raw
+
+
+def _max_upload_bytes() -> int:
+    """The single-import size ceiling in bytes (site-config overridable).
+
+    Applied to a raw upload, to a Drive download, and - as the zip-bomb guard -
+    to the *uncompressed* size of a zipped XML, so every ingestion path is held
+    to the same limit."""
+    max_mb = frappe.conf.get("tally_migrator_max_upload_mb") or _DEFAULT_MAX_UPLOAD_MB
+    return max_mb * 1024 * 1024
+
+
 def _assert_within_size_limit(num_bytes: int) -> None:
     """Reject an oversized upload before parsing, with an actionable message."""
     max_mb = frappe.conf.get("tally_migrator_max_upload_mb") or _DEFAULT_MAX_UPLOAD_MB
-    if num_bytes > max_mb * 1024 * 1024:
+    if num_bytes > _max_upload_bytes():
         frappe.throw(
             frappe._(
                 "This file is {0} MB, above the {1} MB limit for a single import. "

--- a/tally_migrator/api.py
+++ b/tally_migrator/api.py
@@ -327,9 +327,13 @@ _SOURCE_CACHE_MAX = 4
 
 # Reject uploads above this size before parsing, with an actionable message,
 # rather than letting a multi-gigabyte file exhaust the worker. UTF-16 exports
-# decode to roughly half this many characters. Overridable via site config
-# (``tally_migrator_max_upload_mb``) for operators who need a higher ceiling.
-_DEFAULT_MAX_UPLOAD_MB = 150
+# decode to roughly half this many characters. The default is set to comfortably
+# cover a real-world large Tally book (these routinely run 200-400 MB uncompressed)
+# so a typical export imports without any per-site tuning; a heavier worker can
+# raise it, and a memory-constrained one can lower it, via site config
+# (``tally_migrator_max_upload_mb``). Note this also bounds the uncompressed size
+# of a zipped upload (the zip-bomb guard), so both paths share one ceiling.
+_DEFAULT_MAX_UPLOAD_MB = 512
 
 # Above this many master records a run is moved to a background job instead of
 # blocking the web request until it finishes (which would hit the proxy/gunicorn

--- a/tally_migrator/tally/file_source.py
+++ b/tally_migrator/tally/file_source.py
@@ -3,8 +3,14 @@ from __future__ import annotations
 import io
 import re
 import xml.etree.ElementTree as ET
+import zipfile
 
 import frappe
+
+# A ZIP local-file-header magic. A Tally export is plain XML, but a large export
+# zips ~90% (verbose UTF-16 XML), so we accept a zipped XML to slip under the
+# upload size cap. Detected by these first bytes, not the file extension.
+_ZIP_MAGIC = b"PK\x03\x04"
 
 # The Tally master record elements we extract. The streaming parser keeps only
 # these (every other element - TALLYMESSAGE wrappers, COMPANY headers, voucher
@@ -75,6 +81,71 @@ def decode_tally_bytes(raw) -> str:
         if b"\x00" in raw[:64]:
             return raw.decode("utf-16", errors="replace")
         return raw.decode("latin-1")
+
+
+def unzip_if_zip(raw, max_uncompressed_bytes: int):
+    """If ``raw`` is a ZIP archive, return the bytes of its single XML member;
+    otherwise return ``raw`` unchanged.
+
+    A genuine Tally Masters export is plain XML, but it compresses ~90%, so a
+    large export can be zipped to fit under the upload size cap. We accept that
+    transparently here - whether the bytes arrived from an upload or a Drive
+    download - so the rest of the pipeline only ever sees decoded XML bytes.
+
+    The archive must contain exactly one ``.xml`` member (ignoring directory
+    entries and the ``__MACOSX``/``._*`` resource forks the macOS Finder adds).
+
+    Zip-bomb guard: the member is rejected if its *declared* uncompressed size
+    exceeds ``max_uncompressed_bytes``, and extraction is hard-capped at that
+    many bytes in case the header under-reports - so a crafted archive can never
+    inflate past the same ceiling a raw upload is held to.
+    """
+    if not isinstance(raw, (bytes, bytearray)) or raw[:4] != _ZIP_MAGIC:
+        return raw
+    try:
+        archive = zipfile.ZipFile(io.BytesIO(raw))
+    except zipfile.BadZipFile:
+        frappe.throw(
+            "The uploaded .zip could not be opened - it may be corrupt. Re-zip "
+            "your Tally Masters XML and try again."
+        )
+    members = [
+        zi for zi in archive.infolist()
+        if not zi.is_dir()
+        and not zi.filename.startswith("__MACOSX/")
+        and not zi.filename.rsplit("/", 1)[-1].startswith("._")
+    ]
+    xml_members = [zi for zi in members if zi.filename.lower().endswith(".xml")]
+    if not xml_members:
+        frappe.throw(
+            "The .zip contains no .xml file. Zip exactly one Tally Masters XML "
+            "export (the Master.xml you exported from Tally) and try again."
+        )
+    if len(xml_members) > 1:
+        names = ", ".join(zi.filename for zi in xml_members[:5])
+        frappe.throw(
+            f"The .zip contains more than one .xml file ({names}). Zip exactly "
+            "one Tally Masters XML export and try again."
+        )
+    member = xml_members[0]
+    if member.file_size > max_uncompressed_bytes:
+        max_mb = max_uncompressed_bytes / (1024 * 1024)
+        frappe.throw(
+            f"The XML inside the .zip is {member.file_size / (1024 * 1024):.0f} MB "
+            f"uncompressed, above the {max_mb:.0f} MB limit. Split the export or "
+            "ask your administrator to raise tally_migrator_max_upload_mb."
+        )
+    with archive.open(member) as fh:
+        # Read one byte past the cap so an under-reported header is still caught.
+        data = fh.read(max_uncompressed_bytes + 1)
+    if len(data) > max_uncompressed_bytes:
+        max_mb = max_uncompressed_bytes / (1024 * 1024)
+        frappe.throw(
+            f"The XML inside the .zip expands beyond the {max_mb:.0f} MB limit and "
+            "was rejected. Split the export or ask your administrator to raise "
+            "tally_migrator_max_upload_mb."
+        )
+    return data
 
 
 def _drop_illegal_ref(match: "re.Match") -> str:

--- a/tally_migrator/tally/file_source.py
+++ b/tally_migrator/tally/file_source.py
@@ -135,9 +135,20 @@ def unzip_if_zip(raw, max_uncompressed_bytes: int):
             f"uncompressed, above the {max_mb:.0f} MB limit. Split the export or "
             "ask your administrator to raise tally_migrator_max_upload_mb."
         )
-    with archive.open(member) as fh:
-        # Read one byte past the cap so an under-reported header is still caught.
-        data = fh.read(max_uncompressed_bytes + 1)
+    try:
+        with archive.open(member) as fh:
+            # Read one byte past the cap so an under-reported header is still caught.
+            data = fh.read(max_uncompressed_bytes + 1)
+    except (zipfile.BadZipFile, RuntimeError):
+        # The central directory opened fine but the member itself can't be read -
+        # a bad CRC (truncated/corrupt entry) raises BadZipFile, an encrypted member
+        # raises RuntimeError("File is encrypted"). Either way it's not a usable
+        # export; surface the same actionable message instead of a raw 500.
+        frappe.throw(
+            "The .xml inside the .zip could not be extracted - the archive may be "
+            "corrupt or password-protected. Re-zip your Tally Masters XML (no "
+            "password) and try again."
+        )
     if len(data) > max_uncompressed_bytes:
         max_mb = max_uncompressed_bytes / (1024 * 1024)
         frappe.throw(

--- a/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
+++ b/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
@@ -84,13 +84,18 @@ class TallyMigratorPage {
 					</div>
 
 					<div class="tm-section" style="margin-top:var(--margin-lg);">
-						<strong>Then upload it here</strong>
+						<strong>Then bring it in here</strong>
 						<div style="margin-top:var(--margin-sm);">
 							<button id="btn-pick-file" class="btn btn-default btn-sm">
-								${TallyMigratorPage.navIcon("upload")} &nbsp;Choose Tally XML file
+								${TallyMigratorPage.navIcon("upload")} &nbsp;Choose Tally XML or .zip file
 							</button>
 							<span id="file-status" style="margin-left:12px;" class="text-muted"></span>
 						</div>
+						<p class="text-muted" style="margin:var(--margin-sm) 0 0 0; font-size:var(--text-sm);">
+							A large export can be zipped first (XML compresses ~90%) to keep it under the upload
+							limit. Too big even zipped? Share it on Google Drive as <strong>Anyone with the
+							link</strong>, then in the upload dialog choose <strong>Link</strong> and paste the link.
+						</p>
 					</div>
 
 					<!-- Preview of what's inside the file -->
@@ -430,7 +435,9 @@ class TallyMigratorPage {
 	pickFile() {
 		new frappe.ui.FileUploader({
 			folder: "Home/Attachments",
-			restrictions: { allowed_file_types: [".xml", "text/xml", "application/xml"] },
+			restrictions: {
+				allowed_file_types: [".xml", "text/xml", "application/xml", ".zip", "application/zip"],
+			},
 			on_success: (file_doc) => {
 				this.fileUrl = file_doc.file_url;
 				this.fileName = file_doc.file_name || file_doc.file_url;

--- a/tally_migrator/tests/test_zip_and_drive.py
+++ b/tally_migrator/tests/test_zip_and_drive.py
@@ -1,0 +1,159 @@
+"""Unit tests for the zipped-XML and Google-Drive-link import paths.
+
+No Frappe site required: ``frappe.throw`` raises, which is all these assertions
+need. The Drive download is exercised against a mocked ``requests`` so no network
+is touched.
+"""
+import io
+import unittest
+import zipfile
+from unittest import mock
+
+from tally_migrator.tally.file_source import unzip_if_zip
+from tally_migrator import api
+
+
+XML_BYTES = b"<ENVELOPE><BODY>hello tally</BODY></ENVELOPE>"
+CAP = 10 * 1024 * 1024  # 10 MB cap for the tests
+
+
+def _zip(members: dict, compression=zipfile.ZIP_DEFLATED) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression) as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+class TestUnzipIfZip(unittest.TestCase):
+    def test_plain_xml_passes_through_unchanged(self):
+        # No ZIP magic - returned byte-for-byte, no parsing attempted.
+        self.assertIs(unzip_if_zip(XML_BYTES, CAP), XML_BYTES)
+
+    def test_str_passes_through(self):
+        text = XML_BYTES.decode()
+        self.assertIs(unzip_if_zip(text, CAP), text)
+
+    def test_single_xml_member_is_extracted(self):
+        raw = _zip({"Master.xml": XML_BYTES})
+        self.assertEqual(unzip_if_zip(raw, CAP), XML_BYTES)
+
+    def test_macos_resource_forks_are_ignored(self):
+        # A Finder-created zip carries __MACOSX/._Master.xml alongside the real file.
+        raw = _zip({"Master.xml": XML_BYTES, "__MACOSX/._Master.xml": b"junk"})
+        self.assertEqual(unzip_if_zip(raw, CAP), XML_BYTES)
+
+    def test_no_xml_member_rejected(self):
+        raw = _zip({"notes.txt": b"nothing here"})
+        with self.assertRaises(Exception):
+            unzip_if_zip(raw, CAP)
+
+    def test_multiple_xml_members_rejected(self):
+        raw = _zip({"a.xml": XML_BYTES, "b.xml": XML_BYTES})
+        with self.assertRaises(Exception):
+            unzip_if_zip(raw, CAP)
+
+    def test_corrupt_zip_rejected(self):
+        # ZIP magic but garbage after it.
+        with self.assertRaises(Exception):
+            unzip_if_zip(b"PK\x03\x04corrupt-not-a-real-archive", CAP)
+
+    def test_zip_bomb_declared_size_rejected(self):
+        # Highly compressible 50 MB member, but the cap is 10 MB.
+        raw = _zip({"Master.xml": b"A" * (50 * 1024 * 1024)})
+        with self.assertRaises(Exception):
+            unzip_if_zip(raw, CAP)
+
+    def test_member_at_cap_is_allowed(self):
+        payload = b"B" * CAP
+        raw = _zip({"Master.xml": payload})
+        self.assertEqual(unzip_if_zip(raw, CAP), payload)
+
+
+class TestParseDriveId(unittest.TestCase):
+    def test_file_d_link(self):
+        url = "https://drive.google.com/file/d/1A2b3C4d5E6f7G8h9I0j/view?usp=sharing"
+        self.assertEqual(api._parse_drive_id(url), "1A2b3C4d5E6f7G8h9I0j")
+
+    def test_open_id_link(self):
+        url = "https://drive.google.com/open?id=1A2b3C4d5E6f7G8h9I0j"
+        self.assertEqual(api._parse_drive_id(url), "1A2b3C4d5E6f7G8h9I0j")
+
+    def test_uc_download_link(self):
+        url = "https://drive.google.com/uc?export=download&id=1A2b3C4d5E6f7G8h9I0j"
+        self.assertEqual(api._parse_drive_id(url), "1A2b3C4d5E6f7G8h9I0j")
+
+    def test_docs_d_link(self):
+        url = "https://docs.google.com/spreadsheets/d/1A2b3C4d5E6f7G8h9I0j/edit"
+        self.assertEqual(api._parse_drive_id(url), "1A2b3C4d5E6f7G8h9I0j")
+
+    def test_bare_id_accepted(self):
+        self.assertEqual(api._parse_drive_id("1A2b3C4d5E6f7G8h9I0j"), "1A2b3C4d5E6f7G8h9I0j")
+
+    def test_non_google_host_rejected(self):
+        with self.assertRaises(Exception):
+            api._parse_drive_id("https://evil.example.com/file/d/1A2b3C4d5E6f7G8h9I0j/view")
+
+    def test_internal_host_rejected_no_ssrf(self):
+        with self.assertRaises(Exception):
+            api._parse_drive_id("http://169.254.169.254/latest/meta-data/")
+
+    def test_empty_rejected(self):
+        with self.assertRaises(Exception):
+            api._parse_drive_id("   ")
+
+    def test_google_link_without_id_rejected(self):
+        with self.assertRaises(Exception):
+            api._parse_drive_id("https://drive.google.com/drive/folders/")
+
+
+class _FakeResp:
+    def __init__(self, chunks, status=200):
+        self._chunks = chunks
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            import requests
+            raise requests.HTTPError(f"{self.status_code}")
+
+    def iter_content(self, chunk_size=0):
+        return iter(self._chunks)
+
+    def close(self):
+        pass
+
+
+class TestDownloadDriveFile(unittest.TestCase):
+    def _patch_conf(self):
+        # _max_upload_bytes reads frappe.conf; keep it small and deterministic.
+        return mock.patch.object(api.frappe, "conf", {"tally_migrator_max_upload_mb": 10})
+
+    def test_happy_path_returns_bytes(self):
+        with self._patch_conf(), \
+                mock.patch("requests.get", return_value=_FakeResp([XML_BYTES])):
+            self.assertEqual(api._download_drive_file("abc1234567"), XML_BYTES)
+
+    def test_html_interstitial_rejected(self):
+        page = b"<!DOCTYPE html><html><body>Sign in</body></html>"
+        with self._patch_conf(), \
+                mock.patch("requests.get", return_value=_FakeResp([page])):
+            with self.assertRaises(Exception):
+                api._download_drive_file("abc1234567")
+
+    def test_oversized_stream_rejected(self):
+        big = [b"X" * (4 * 1024 * 1024)] * 4  # 16 MB streamed, cap is 10 MB
+        with self._patch_conf(), \
+                mock.patch("requests.get", return_value=_FakeResp(big)):
+            with self.assertRaises(Exception):
+                api._download_drive_file("abc1234567")
+
+    def test_empty_response_rejected(self):
+        with self._patch_conf(), \
+                mock.patch("requests.get", return_value=_FakeResp([])):
+            with self.assertRaises(Exception):
+                api._download_drive_file("abc1234567")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tally_migrator/tests/test_zip_and_drive.py
+++ b/tally_migrator/tests/test_zip_and_drive.py
@@ -58,6 +58,16 @@ class TestUnzipIfZip(unittest.TestCase):
         with self.assertRaises(Exception):
             unzip_if_zip(b"PK\x03\x04corrupt-not-a-real-archive", CAP)
 
+    def test_unreadable_member_rejected_gracefully(self):
+        # The central directory opens fine but the member's stored bytes are
+        # clobbered, so archive.open(...).read() fails (bad CRC). Must surface as a
+        # clean frappe.throw, not an unhandled 500.
+        raw = _zip({"Master.xml": b"C" * 4096}, compression=zipfile.ZIP_STORED)
+        corrupt = bytearray(raw)
+        corrupt[40:80] = b"\x00" * 40   # trash the stored member payload, leave the dir intact
+        with self.assertRaises(Exception):
+            unzip_if_zip(bytes(corrupt), CAP)
+
     def test_zip_bomb_declared_size_rejected(self):
         # Highly compressible 50 MB member, but the cap is 10 MB.
         raw = _zip({"Master.xml": b"A" * (50 * 1024 * 1024)})


### PR DESCRIPTION
Stack 3/4. Base: `perf/batched-commits-savepoints` (#42).

### Why
Hosted ERPNext (Frappe Cloud) caps uploads at ~25 MB, but a real Tally masters export runs into the hundreds of MB. Two ingestion paths solve it without the user splitting their data:

- **Zip upload** - a Tally XML export compresses ~90% (verbose UTF-16), so a 350 MB export zips well under the limit. The app detects the zip by magic bytes (not extension), extracts the single `.xml` member, and feeds it through the identical pipeline.
- **Google Drive link** - via Frappe's native FileUploader **"Link"** tab (no custom UI). The server downloads it; the page never has to move the bytes.

### Safety (this is attacker-reachable input)
- **No SSRF**: a Drive link is parsed to a file id and the fetch is host-locked to `*.google.com` via a fixed `drive.usercontent.google.com` endpoint - it can only ever reach Google, never an arbitrary URL/internal host.
- **Zip-bomb double guard**: the member is rejected if its *declared* uncompressed size exceeds the cap, and extraction is hard-capped at `cap + 1` bytes in case the header under-reports - so a crafted archive can't inflate past the same ceiling a raw upload is held to.
- **Streamed download** with the same size cap; Drive's HTML "can't scan / sign-in" interstitial is detected and rejected rather than imported as XML.
- Corrupt/encrypted zip members surface a friendly "re-zip without a password" message instead of a 500.

### Processing cap
Raised the default `tally_migrator_max_upload_mb` to **512** so a typical large book imports with no per-site tuning. This same ceiling bounds the *uncompressed* size of a zipped upload (the zip-bomb guard), so all paths share one limit. Still overridable via site config.

22+ unit tests (zip happy/forks/no-xml/multi-xml/corrupt/bomb/at-cap; Drive id parsing, non-Google rejection, SSRF/interstitial/oversize). Docs + README updated.