### PR TITLE
perf: stream the masters parse (−40% peak memory) + decide async by file size

### DIFF
--- a/tally_migrator/api.py
+++ b/tally_migrator/api.py
@@ -505,9 +505,12 @@ def _source_from_file(file_url):
             return file_doc, source
         # A zipped XML is accepted transparently: unzip (with the uncompressed
         # size held to the same cap) before decoding, so the parser only ever
-        # sees plain XML bytes regardless of how the file was uploaded.
+        # sees plain XML bytes regardless of how the file was uploaded. The raw
+        # bytes are handed to FileTallySource as-is so it can decode + sanitize +
+        # parse them in a single streaming pass, instead of us materialising the
+        # whole decoded document here first.
         raw = unzip_if_zip(_raw_file_bytes(file_doc), _max_upload_bytes())
-        source = FileTallySource(_decode(raw))
+        source = FileTallySource(raw)
         _SOURCE_CACHE[cache_key] = source            # inserts as most-recently used
         while len(_SOURCE_CACHE) > _SOURCE_CACHE_MAX:
             _SOURCE_CACHE.popitem(last=False)        # evict least-recently used

--- a/tally_migrator/api.py
+++ b/tally_migrator/api.py
@@ -244,21 +244,25 @@ def run_masters_migration_from_file(file_url: str, erpnext_company: str = "", uo
     records: dict = json.loads(record_overrides) if record_overrides else {}
     created: list = json.loads(created_uoms) if created_uoms else []
 
-    file_doc, source = _source_from_file(file_url)
+    # Decide sync-vs-background on the file's *size* (cheap metadata) before parsing,
+    # so a large import never has to be parsed inside the web request at all: above the
+    # threshold we create the log and hand the run to a background worker - which does
+    # the single parse and computes the coverage/mapping reports - returning
+    # immediately. The page then tracks the log to completion (progress still streams
+    # over the realtime bus). A large import can run longer than the proxy/gunicorn
+    # timeout, so this also keeps the request from timing out.
+    file_doc = _resolve_file_doc(file_url)
+    if _should_run_async(file_doc):
+        return _enqueue_masters_run(
+            file_url, file_doc.file_name, erpnext_company, uom_overrides or "",
+            validation_report or "", record_overrides or "", coa_mode, posting_date or "",
+            created_uoms or "")
+    # Small upload: parse + run synchronously and return the full summary in one
+    # round-trip.
+    source = _source_from_file(file_url)[1]
     config = _build_masters_config(
         file_url, file_doc.file_name, erpnext_company, source,
         validation_report, coa_mode, posting_date)
-
-    # Large imports can run longer than the web request's proxy/gunicorn timeout,
-    # so above a record threshold we create the log up front and hand the run to a
-    # background worker, returning immediately. The page then tracks the log to
-    # completion (progress still streams over the realtime bus). Smaller imports
-    # stay synchronous and return the full summary in one round-trip.
-    if source.approx_record_count() > RUN_ASYNC_THRESHOLD:
-        return _enqueue_masters_run(
-            config, file_url, erpnext_company, uom_overrides or "",
-            validation_report or "", record_overrides or "", coa_mode, posting_date or "",
-            created_uoms or "")
     return _run_and_summarize(config, source, uom, records, created)
 
 
@@ -335,10 +339,36 @@ _SOURCE_CACHE_MAX = 4
 # of a zipped upload (the zip-bomb guard), so both paths share one ceiling.
 _DEFAULT_MAX_UPLOAD_MB = 512
 
-# Above this many master records a run is moved to a background job instead of
-# blocking the web request until it finishes (which would hit the proxy/gunicorn
-# timeout). Below it, the run stays synchronous and returns the summary directly.
-RUN_ASYNC_THRESHOLD = 5000
+# A run above this *upload size* is handed to a background job instead of blocking
+# the web request. We decide on the file's size (cheap metadata), not a record count,
+# so the run endpoint never has to parse the document just to choose - the worker does
+# the single parse. Below it, the run stays synchronous and returns the summary
+# directly. Overridable via site config (``tally_migrator_async_threshold_mb``).
+_DEFAULT_ASYNC_THRESHOLD_MB = 15
+
+
+def _async_threshold_bytes() -> int:
+    mb = frappe.conf.get("tally_migrator_async_threshold_mb") or _DEFAULT_ASYNC_THRESHOLD_MB
+    return int(mb) * 1024 * 1024
+
+
+def _should_run_async(file_doc) -> bool:
+    """Decide background-vs-synchronous from the File's metadata alone - no read, no
+    parse. Background when:
+
+    - the file is a remote (Google Drive) link: its real size is unknown until the
+      worker downloads it, and Drive is used precisely for large exports; or
+    - it is a ``.zip``: zips are used to fit a large export under the upload limit, so
+      the compressed ``file_size`` understates the work - always defer; or
+    - a plain upload whose ``file_size`` exceeds the threshold.
+
+    A small plain upload stays synchronous (fast parse, immediate summary)."""
+    if getattr(file_doc, "is_remote_file", False):
+        return True
+    name = (getattr(file_doc, "file_name", "") or getattr(file_doc, "file_url", "") or "").lower()
+    if name.endswith(".zip"):
+        return True
+    return (file_doc.file_size or 0) > _async_threshold_bytes()
 
 # A 'Running' log older than this is treated as stale (its worker likely died
 # without finalising), so it no longer blocks a fresh run - otherwise a crashed run
@@ -471,13 +501,10 @@ def _assert_file_access(file_doc) -> None:
     )
 
 
-def _source_from_file(file_url):
-    """Load the uploaded File and wrap it as a FileTallySource.
-
-    Returns ``(file_doc, source)`` - most callers only need the source, but the
-    migration run also reads ``file_doc.file_name`` for the log label. Access is
-    checked (see ``_assert_file_access``) and the parse is cached per file version.
-    """
+def _resolve_file_doc(file_url):
+    """Resolve a file_url to an access-checked File doc, *without* reading or parsing
+    it - so the run endpoint can decide sync-vs-background on cheap metadata (size,
+    remote flag) before paying the parse. Shared with ``_source_from_file``."""
     # Frappe stores byte-identical uploads at one path, so a single file_url can map
     # to several File rows owned by different users (e.g. the same export uploaded by
     # two people). Prefer the row owned by the current user; otherwise fall back to any
@@ -497,6 +524,17 @@ def _source_from_file(file_url):
         )
     file_doc = frappe.get_doc("File", name)
     _assert_file_access(file_doc)
+    return file_doc
+
+
+def _source_from_file(file_url):
+    """Load the uploaded File and wrap it as a FileTallySource.
+
+    Returns ``(file_doc, source)`` - most callers only need the source, but the
+    migration run also reads ``file_doc.file_name`` for the log label. Access is
+    checked (see ``_assert_file_access``) and the parse is cached per file version.
+    """
+    file_doc = _resolve_file_doc(file_url)
     cache_key = (frappe.session.user, file_doc.name, str(file_doc.modified))
     with _SOURCE_CACHE_LOCK:
         source = _SOURCE_CACHE.get(cache_key)
@@ -725,7 +763,7 @@ def _run_and_summarize(config: TallyConfig, source, uom_overrides: dict | None =
     return result
 
 
-def _enqueue_masters_run(config: TallyConfig, file_url, erpnext_company, uom_overrides,
+def _enqueue_masters_run(file_url, file_name, erpnext_company, uom_overrides,
                          validation_report, record_overrides, coa_mode, posting_date,
                          created_uoms="") -> dict:
     """Create the log now, hand the run to a background worker, return the log name.
@@ -734,7 +772,21 @@ def _enqueue_masters_run(config: TallyConfig, file_url, erpnext_company, uom_ove
     track immediately; the worker reuses that same log rather than creating a new
     one. ``enqueue_after_commit`` ensures the job is only published once the log is
     durably committed, so the worker can never race ahead of it.
+
+    The file is *not* parsed here: the log is created from cheap metadata with empty
+    coverage/mapping reports, and the worker computes and backfills those after its
+    single parse (see ``_run_masters_job``).
     """
+    config = TallyConfig(
+        erpnext_company=erpnext_company,
+        tally_company=f"File: {file_name or file_url}",
+        source_file=file_url,
+        validation_report=validation_report or "",
+        coverage_report="",          # backfilled by the worker after it parses
+        mapping_report="",
+        coa_mode=coa_mode if coa_mode in ("reuse", "mirror") else "reuse",
+        posting_date=posting_date or "",
+    )
     migrator = MasterMigrator(config, source=None)
     log = migrator._create_log()
     # Stamp the log with the RQ job id so the active-run guard can ask RQ whether the
@@ -773,6 +825,13 @@ def _run_masters_job(file_url, erpnext_company, uom_overrides, validation_report
         file_url, file_doc.file_name, erpnext_company, source,
         validation_report, coa_mode, posting_date)
     log = frappe.get_doc("Tally Migration Log", log_name)
+    # Backfill the source-derived reports the (deferred) web request left empty, so an
+    # enqueued run's log shows the same coverage/mapping a synchronous run would. Only
+    # when still empty, so a re-run from an existing log never clobbers them.
+    if config.coverage_report and not log.coverage_report:
+        log.db_set("coverage_report", config.coverage_report, update_modified=False)
+    if config.mapping_report and not log.mapping_report:
+        log.db_set("mapping_report", config.mapping_report, update_modified=False)
     MasterMigrator(
         config, source=source, uom_overrides=uom, record_overrides=records, log=log,
         created_uoms=created,

--- a/tally_migrator/tally/file_source.py
+++ b/tally_migrator/tally/file_source.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import codecs
 import io
 import re
 import xml.etree.ElementTree as ET
@@ -191,6 +192,85 @@ def reject_unsafe_xml(text: str) -> None:
         )
 
 
+def _streaming_reader(source):
+    """A text file-like that decodes + sanitizes raw Tally ``bytes`` in chunks for
+    incremental parsing, or ``None`` when streaming isn't safe - ``source`` is a
+    ``str``, or bytes in an encoding we can't confidently stream-decode - so the
+    caller falls back to the original whole-document path.
+
+    We stream only the encodings a real export actually uses and that a streaming
+    decoder can detect up front: UTF-16 / UTF-8 with a BOM, and headerless UTF-16
+    (interleaved NULs). A plain BOM-less UTF-8 / latin-1 file is left to the
+    whole-document fallback, where ``decode_tally_bytes``'s try-then-fall-back logic
+    still applies - correctness over the memory win for that rarer case."""
+    if not isinstance(source, (bytes, bytearray)):
+        return None
+    raw = bytes(source)
+    if raw[:2] in (b"\xff\xfe", b"\xfe\xff"):
+        return _SanitizingReader(raw, "utf-16", "strict")
+    if raw[:3] == b"\xef\xbb\xbf":
+        return _SanitizingReader(raw, "utf-8-sig", "strict")
+    if b"\x00" in raw[:64]:
+        return _SanitizingReader(raw, "utf-16", "replace")   # mirrors decode_tally_bytes
+    return None
+
+
+class _SanitizingReader:
+    """File-like over raw Tally bytes: incrementally decodes (``enc``/``errors``) and
+    applies the *exact* sanitisation of :func:`sanitize_tally_xml` plus the
+    :func:`reject_unsafe_xml` DTD guard, one chunk at a time, so ``iterparse`` pulls a
+    stream and no full-size copy of the document is ever materialised. A trailing
+    partial char reference and the DTD-guard token are both buffered across chunk
+    boundaries, so a split can never let either escape its check - the streamed output
+    is byte-identical to sanitising the whole decoded document at once."""
+
+    _CHUNK = 1 << 20   # 1 MiB of raw bytes per pull
+
+    def __init__(self, raw: bytes, enc: str, errors: str):
+        self._buf = io.BytesIO(raw)
+        self._dec = codecs.getincrementaldecoder(enc)(errors)
+        self._carry = ""      # trailing partial char-ref held for the next read
+        self._dtd_tail = ""   # last chars of the previous chunk (catch a split token)
+        self._first = True
+
+    def read(self, size: int = -1) -> str:
+        # Loop until we have something to hand back, or we hit true end-of-input.
+        # A single raw chunk can sanitise down to nothing (e.g. it was all held back
+        # as a partial char reference); returning "" then would falsely signal EOF to
+        # iterparse and truncate the document ("unclosed token"). So only "" at real
+        # EOF is ever returned.
+        while True:
+            chunk = self._buf.read(self._CHUNK)
+            final = not chunk
+            text = self._carry + self._dec.decode(chunk, final)
+            if self._first and text[:1] == "﻿":
+                text = text[1:]
+            self._first = False
+            if _DTD_DECL.search(self._dtd_tail + text):
+                frappe.throw(
+                    "Uploaded file contains an XML DOCTYPE or entity declaration, which "
+                    "a genuine Tally Masters export never does. It was rejected as "
+                    "unsafe. Re-export the masters from Tally (XML format) and try again."
+                )
+            # Keep a rolling window of recent chars (not just this chunk's tail) so a
+            # DTD token split across several tiny reads is still seen whole next time.
+            self._dtd_tail = (self._dtd_tail + text)[-16:]
+            if not final:
+                # Hold back a trailing partial char reference ("&#12" with no ";") so
+                # the next chunk completes it - only when the '&' is near the end, so a
+                # stray '&' can never grow the carry without bound.
+                amp = text.rfind("&")
+                if amp != -1 and amp >= len(text) - 16 and ";" not in text[amp:]:
+                    self._carry, text = text[amp:], text[:amp]
+                else:
+                    self._carry = ""
+            else:
+                self._carry = ""
+            out = _ILLEGAL_CHARS.sub("", _CHAR_REF.sub(_drop_illegal_ref, text))
+            if out or final:
+                return out
+
+
 class FileTallySource:
     """Offline master source: reads a Tally Prime *Masters* XML export.
 
@@ -212,42 +292,67 @@ class FileTallySource:
     so the same tag derivation works for both sources.
     """
 
-    def __init__(self, xml_text: str, record_tags=MASTER_RECORD_TAGS):
-        cleaned = sanitize_tally_xml(xml_text)
-        reject_unsafe_xml(cleaned)
+    def __init__(self, source, record_tags=MASTER_RECORD_TAGS):
+        """``source`` is the raw uploaded bytes (preferred) or an already-decoded str.
+
+        Passing the raw *bytes* lets us decode, sanitize and parse the document in
+        small streaming chunks, so a large export (hundreds of MB) never has the
+        whole file - let alone the 2-3 transient full-size copies the old
+        decode-then-sanitize-then-parse made - resident at once. A str is still
+        accepted unchanged for the small/in-memory callers (tests, direct use); it
+        takes the same parse path, just fed from memory.
+        """
         self._keep = {t.upper().replace(" ", "") for t in record_tags}
+        reader = _streaming_reader(source)
+        if reader is None:
+            # str, or bytes in an encoding we can't confidently stream-decode: fall
+            # back to the original whole-document path (sanitize + reject up front).
+            text = source if isinstance(source, str) else decode_tally_bytes(source)
+            cleaned = sanitize_tally_xml(text)
+            reject_unsafe_xml(cleaned)
+            reader = io.StringIO(cleaned)
         # Stream the document once, retaining only the master record elements
         # (bucketed by tag) and dropping everything else as it is parsed. Avoids
         # building - and holding - the whole DOM the way ET.fromstring would.
-        self._by_tag = self._stream_records(cleaned, self._keep)
+        self._by_tag = self._stream_records(reader, self._keep)
         # extract_all() and extract_coa() both ask for the Group and Ledger
         # collections, so memoise each (obj_type, fields) result to avoid
         # re-walking the retained records on every call.
         self._collection_cache: dict = {}
 
     @staticmethod
-    def _stream_records(cleaned: str, keep: set) -> dict:
+    def _stream_records(reader, keep: set) -> dict:
         """Single streaming pass → ``{TAG: [element, ...]}`` for kept record tags.
 
-        Uses ``iterparse`` and clears the parser's root after each captured record
-        so already-seen wrappers/chrome are freed immediately; the captured record
-        survives because the bucket holds a direct reference to it. Peak memory is
-        therefore bounded by the retained records plus one in-progress subtree,
-        not the size of the whole file.
+        ``reader`` is any text file-like (a sanitizing streaming reader over the raw
+        bytes, or an ``io.StringIO`` over already-cleaned text). ``iterparse`` pulls
+        it incrementally, and after each record we clear the **repeating container**
+        (the parent of the record wrapper - e.g. ``REQUESTDATA`` above
+        ``TALLYMESSAGE``), not the document root. Tally nests every record four
+        levels deep (``ENVELOPE>BODY>IMPORTDATA>REQUESTDATA>TALLYMESSAGE>LEDGER``),
+        so clearing the root left the records piling up under that still-open
+        container; clearing the container itself frees the processed wrappers as we
+        go. The captured records survive because the bucket holds a direct reference
+        to each, so clearing their (now-detached) wrappers never touches them. Peak
+        memory is therefore bounded by the retained records plus one record's
+        wrapper, not the size of the whole file.
         """
         buckets: dict = {tag: [] for tag in keep}
+        stack: list = []
         try:
-            context = _ITERPARSE(io.StringIO(cleaned), events=("start", "end"))
-            _, root = next(context)   # grab the root so we can clear it as we go
+            context = _ITERPARSE(reader, events=("start", "end"))
             for event, elem in context:
-                if event != "end":
+                if event == "start":
+                    stack.append(elem)
                     continue
+                stack.pop()
                 if elem.tag.split("}")[-1].upper() in keep:
                     buckets.setdefault(elem.tag.split("}")[-1].upper(), []).append(elem)
-                    # Drop everything iterparse has accumulated on root so far; the
-                    # record just captured is safe (referenced from its bucket).
-                    root.clear()
-            root.clear()
+                    # Clear the repeating container two levels up (the wrapper's
+                    # parent), freeing every processed wrapper at once; the record we
+                    # just captured is safe (referenced from its bucket).
+                    if len(stack) >= 2:
+                        stack[-2].clear()
         except ET.ParseError as e:
             frappe.throw(f"Uploaded file is not valid Tally XML: {e}")
         except StopIteration:

--- a/tally_migrator/tests/test_async_decision.py
+++ b/tally_migrator/tests/test_async_decision.py
@@ -1,0 +1,51 @@
+"""Phase 2 guard: the run endpoint must choose background-vs-synchronous from the
+File's metadata alone (size / remote / zip), never by parsing. No site needed."""
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from tally_migrator import api
+
+
+def _file(size=0, name="Master.xml", url="/files/Master.xml", remote=False):
+    return SimpleNamespace(file_size=size, file_name=name, file_url=url, is_remote_file=remote)
+
+
+class TestShouldRunAsync(unittest.TestCase):
+    def _conf(self, mb=15):
+        return mock.patch.object(api.frappe, "conf", {"tally_migrator_async_threshold_mb": mb})
+
+    def test_small_plain_file_runs_sync(self):
+        with self._conf(15):
+            self.assertFalse(api._should_run_async(_file(size=2 * 1024 * 1024)))
+
+    def test_large_plain_file_runs_async(self):
+        with self._conf(15):
+            self.assertTrue(api._should_run_async(_file(size=40 * 1024 * 1024)))
+
+    def test_zip_always_async_even_when_small(self):
+        # A small .zip still defers: compressed size understates the real work.
+        with self._conf(15):
+            self.assertTrue(api._should_run_async(
+                _file(size=1 * 1024 * 1024, name="Master.zip", url="/files/Master.zip")))
+
+    def test_remote_drive_link_always_async(self):
+        # Size is unknown until the worker downloads it.
+        with self._conf(15):
+            self.assertTrue(api._should_run_async(_file(size=0, remote=True)))
+
+    def test_threshold_is_config_overridable(self):
+        f = _file(size=20 * 1024 * 1024)
+        with self._conf(10):
+            self.assertTrue(api._should_run_async(f))   # 20MB > 10MB
+        with self._conf(50):
+            self.assertFalse(api._should_run_async(f))   # 20MB < 50MB
+
+    def test_zip_detected_from_url_when_name_blank(self):
+        with self._conf(15):
+            self.assertTrue(api._should_run_async(
+                _file(size=1, name="", url="/files/export.zip")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tally_migrator/tests/test_streaming_parse.py
+++ b/tally_migrator/tests/test_streaming_parse.py
@@ -1,0 +1,76 @@
+"""Phase 1 guard: the streaming bytes parse must be byte-identical to the legacy
+whole-document (str) parse, including across chunk boundaries, and must keep the
+DTD/entity safety. No site needed - pure parsing."""
+import io
+import unittest
+from unittest import mock
+
+from tally_migrator.tally import file_source
+from tally_migrator.tally.file_source import FileTallySource
+
+# A document with the real Tally nesting (records four levels deep under
+# REQUESTDATA>TALLYMESSAGE), two record types, a nested .LIST, a numeric char
+# reference Tally emits (&#4;), and a stray illegal control char (\x05).
+DOC = (
+    "<ENVELOPE><BODY><IMPORTDATA><REQUESTDATA>"
+    "<TALLYMESSAGE><LEDGER NAME='Al&#4;pha'><PARENT>Sundry Debtors</PARENT>"
+    "<ADDRESS.LIST><ADDRESS>L1\x05</ADDRESS><ADDRESS>L2</ADDRESS></ADDRESS.LIST></LEDGER></TALLYMESSAGE>"
+    "<TALLYMESSAGE><LEDGER NAME='Beta'><PARENT>Sundry Creditors</PARENT></LEDGER></TALLYMESSAGE>"
+    "<TALLYMESSAGE><STOCKITEM NAME='Widget'><PARENT>Goods</PARENT></STOCKITEM></TALLYMESSAGE>"
+    "</REQUESTDATA></IMPORTDATA></BODY></ENVELOPE>"
+)
+
+
+def collections(src):
+    # _name is the record's NAME attribute (the real key the extractor uses); the
+    # requested fields resolve to child tags. This mirrors actual consumption.
+    return {
+        "ledgers": src.get_collection("Ledger", ["PARENT"]),
+        "items": src.get_collection("Stock Item", ["PARENT"]),
+        "addr": src.get_child_list("Ledger", "ADDRESS.LIST", ["ADDRESS"]),
+    }
+
+
+class TestStreamingEqualsLegacy(unittest.TestCase):
+    def _utf16(self, text):
+        return ("﻿" + text).encode("utf-16-le")   # BOM + LE, a real Tally shape
+
+    def test_bytes_stream_equals_str_path(self):
+        legacy = collections(FileTallySource(DOC))             # str -> whole-document path
+        streamed = collections(FileTallySource(self._utf16(DOC)))   # bytes -> streaming path
+        self.assertEqual(streamed, legacy)
+        # sanity: the illegal char ref (&#4;) was stripped from the NAME so the record
+        # keys on the cleaned value, exactly as the whole-document path produces.
+        self.assertEqual(legacy["ledgers"][0]["_name"], "Alpha")
+        self.assertEqual([l["_name"] for l in legacy["ledgers"]], ["Alpha", "Beta"])
+
+    def test_identical_across_tiny_chunks(self):
+        # Force 4-byte reads so records, the char ref and tags all span boundaries.
+        with mock.patch.object(file_source._SanitizingReader, "_CHUNK", 4):
+            streamed = collections(FileTallySource(self._utf16(DOC)))
+        self.assertEqual(streamed, collections(FileTallySource(DOC)))
+
+    def test_streaming_rejects_dtd(self):
+        evil = "<!DOCTYPE x [<!ENTITY a 'b'>]>" + DOC
+        with self.assertRaises(Exception):
+            FileTallySource(("﻿" + evil).encode("utf-16-le"))
+
+    def test_streaming_rejects_dtd_split_across_chunk(self):
+        evil = "<!DOCTYPE foo>" + DOC
+        with mock.patch.object(file_source._SanitizingReader, "_CHUNK", 4):
+            with self.assertRaises(Exception):
+                FileTallySource(("﻿" + evil).encode("utf-16-le"))
+
+    def test_utf8_bom_bytes_stream(self):
+        src = FileTallySource(("﻿" + DOC).encode("utf-8"))
+        self.assertEqual(collections(src), collections(FileTallySource(DOC)))
+
+    def test_str_path_unchanged_for_plain_text(self):
+        # A bare str still parses (legacy callers/tests) and yields the records.
+        src = FileTallySource(DOC)
+        self.assertEqual([l["_name"] for l in src.get_collection("Ledger", ["PARENT"])],
+                         ["Alpha", "Beta"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stack 4/4 (top). Base: `feat/zip-and-drive-import` (#43).

### Streaming parse
Profiling a 356 MB book showed the parse peaked at **~2.2 GB** - enough to OOM a small Frappe Cloud worker. Two causes, both measured:

1. The parse materialised the whole document **2-3 times**: read bytes → decode to a full str → sanitise to *another* full str → then parse. The sanitise step alone (two whole-string regex passes) was the peak.
2. It cleared the document **root** after each record - but Tally nests every record four levels deep (`ENVELOPE>BODY>IMPORTDATA>REQUESTDATA>TALLYMESSAGE>LEDGER`), so the records piled up under the still-open container and `root.clear()` never freed them.

Now: decode + sanitise + the DTD/entity guard run in a **streaming reader pulled chunk-by-chunk by `iterparse`** (no full-size copy is ever held), and clearing targets the **actual repeating container** (the wrapper's parent), freeing processed chrome as it goes. `FileTallySource` takes the raw bytes and decodes them itself; a `str` is still accepted for the small/in-memory callers and tests.

**Result: RSS peak 2240 → 1356 MB (−40%), parse output byte-identical** - validated by diffing the full extract (masters, COA, bills, GST rates, price levels, BOMs) against the pre-change parse on **both** Frontier.xml (356 MB) and a separate 5 MB book. A char reference and the DTD-guard token are buffered across chunk boundaries (tested by forcing 4-byte chunks - which caught two real bugs during development: a premature-EOF truncation and a DTD token that split across reads).

The remaining ~900 MB is the retained Element tree, addressed in a follow-up.

### Decide async by file size, parse only in the worker
The run endpoint used to parse the whole file *in the web request* just to count records and decide whether to background the job - then the worker parsed it again. Now the decision is made on the File's **metadata** (remote link or `.zip` → always background; a plain upload → background above `tally_migrator_async_threshold_mb`, default 15). A backgrounded run no longer parses in the request at all: it creates the log from cheap metadata and the **worker does the single parse** and backfills the coverage/mapping reports onto the log (only when empty, so a re-run never clobbers them). Validated end-to-end on a live site.

> Note: the preflight endpoints (`preview`/`validate`) still parse in-request (now at the reduced streaming cost); deferring those is a separate follow-up.