### PR TITLE
Fix large-file migration freeze and surface stopped runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ the awesomebar). The wizard walks you through a few guided steps:
 The Migration Log is your record of the run. It shows what was created (grouped by
 type, with clickable links to each record), what was skipped and why, and the
 reconciliation report. If a large migration is still running, it keeps going in the
-background and the log updates as it progresses.
+background; reload the log to see its latest progress. If a run stops early (for
+example the server restarts), the log says so and you can simply run it again -
+records already imported are kept.
 
 ### If something goes wrong
 

--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -496,7 +496,11 @@ from the results screen, or find it in the desk under **Tally Migration Log**.
 
 The log's **status** is one of:
 
-- **Running** - the migration is still in progress.
+- **Running** - the migration is still in progress. The log does not refresh on its
+  own, so reload it to see the latest progress. If the run stops early (for example
+  the server restarts or runs out of memory), the log detects that its background job
+  is no longer active and shows that the run stopped before completing - records
+  imported so far are kept, so you can run it again.
 - **Completed** - finished with no failures.
 - **Completed with Errors** - finished, but some records failed (everything else
   imported).

--- a/tally_migrator/api.py
+++ b/tally_migrator/api.py
@@ -454,6 +454,37 @@ def active_run(erpnext_company: str = "") -> dict:
 
 
 @frappe.whitelist(methods=["GET", "POST"])
+def run_liveness(log_name: str = "") -> dict:
+    """Whether a still-'Running' migration log's run is genuinely alive.
+
+    A hard-killed worker (OOM, redeploy) leaves the log on 'Running' forever, so the
+    log form would otherwise keep claiming "still running" indefinitely. This lets the
+    form ask RQ whether the job is actually queued/running and show a "stopped before
+    completing" state instead. Mirrors ``_active_run_log``'s liveness rule. Read-only.
+
+    Returns ``{status, alive}``: for a 'Running' log, ``alive`` is True while the job
+    is enqueued (or a job-less legacy run that isn't yet stale), False once the worker
+    is gone. For any terminal status, ``alive`` is False and ``status`` carries it.
+    ``{}`` when the log is unknown."""
+    frappe.only_for(ALLOWED_ROLES)
+    if not log_name:
+        return {}
+    row = frappe.db.get_value(
+        "Tally Migration Log", log_name, ["status", "job_id", "modified"], as_dict=True)
+    if not row:
+        return {}
+    if row.status != "Running":
+        return {"status": row.status, "alive": False}
+    alive = True
+    if row.job_id:
+        alive = _is_job_alive(row.job_id)
+    elif frappe.utils.time_diff_in_seconds(
+            frappe.utils.now(), row.modified) >= _ACTIVE_RUN_STALE_SECONDS:
+        alive = False
+    return {"status": row.status, "alive": alive}
+
+
+@frappe.whitelist(methods=["GET", "POST"])
 def run_progress(log_name: str = "") -> dict:
     """Status + latest progress percent/description for a migration run.
 

--- a/tally_migrator/migration/master_migrator.py
+++ b/tally_migrator/migration/master_migrator.py
@@ -491,13 +491,44 @@ class MasterMigrator:
         return log
 
     def _finalize_log(self, masters: ExtractedMasters, coa, summary: MigrationSummary) -> None:
-        """Record extraction/import results. Must never abort the migration."""
+        """Record extraction/import results. Must never abort the migration.
+
+        Split into two writes so a large/async run always reaches a *terminal* state:
+
+        1. Terminal state - status + import_summary - committed first. This is all the
+           wizard needs to stop polling and render the results table. It is small and
+           bounded (per-entity counts), so it is the write most likely to succeed.
+        2. Enrichment - the heavy, optional reports (created_records manifest,
+           reconciliation, per-record errors) - committed after, each guarded so one
+           failure cannot lose the others *and never reverts the status*.
+
+        Previously everything rode on a single trailing save(): if any heavy step threw
+        (a big serialization, an errors child-row, or the large save itself) the whole
+        save was lost, the status stayed "Running" forever, yet run() still published
+        100% - leaving the page frozen at a full bar with no results. Committing the
+        terminal state up front removes that failure mode."""
+        status = "Completed with Errors" if summary.has_errors else "Completed"
+        # 1. Terminal state - guaranteed. A bare db_set fallback ensures the page never
+        # hangs on "Running" even if the document save itself fails.
         try:
             self.log.reload()
-            self.log.status = "Completed with Errors" if summary.has_errors else "Completed"
+            self.log.status = status
+            self.log.import_summary = frappe.as_json(summary.as_dict())
+            self.log.save(ignore_permissions=True)
+            frappe.db.commit()
+        except Exception as exc:
+            frappe.log_error(f"Migration log finalize (status) failed: {exc}", "Tally Migrator")
+            try:
+                frappe.db.rollback()
+                self.log.db_set("status", status, commit=True)
+            except Exception as exc2:
+                frappe.log_error(f"Migration log status fallback failed: {exc2}", "Tally Migrator")
+
+        # 2. Enrichment - best-effort, must never revert the terminal state above.
+        try:
+            self.log.reload()
             self.log.extracted_counts = frappe.as_json(
                 {**masters.summary, **coa.summary, "_phase_seconds": self._timings})
-            self.log.import_summary = frappe.as_json(summary.as_dict())
             self.log.applied_edits = frappe.as_json(self.applied_edits)
             manifest = summary.created_records()
             self._track_wizard_uoms(manifest)
@@ -511,7 +542,7 @@ class MasterMigrator:
             self.log.save(ignore_permissions=True)
             frappe.db.commit()
         except Exception as exc:
-            frappe.log_error(f"Migration log finalize failed: {exc}", "Tally Migrator")
+            frappe.log_error(f"Migration log enrichment failed: {exc}", "Tally Migrator")
 
     def _track_wizard_uoms(self, manifest: dict) -> None:
         """Fold the pre-flight "create as new" UOMs into the manifest's Units entry so

--- a/tally_migrator/tally_migration/doctype/tally_migration_log/tally_migration_log.js
+++ b/tally_migrator/tally_migration/doctype/tally_migration_log/tally_migration_log.js
@@ -9,10 +9,38 @@ frappe.ui.form.on("Tally Migration Log", {
 		render_coverage(frm);
 		render_mapping(frm);
 		add_buttons(frm);
+		check_liveness(frm);
 		/* ===== ROLLBACK FEATURE - remove this line + the fenced block below to delete ===== */
 		tally_rollback_attach(frm);
 	},
 });
+
+// A log left on "Running" can mean either a genuinely long import or a worker that
+// was hard-killed (OOM, redeploy) - which never writes a terminal status. Ask the
+// server whether the background job is actually alive; if it's gone, mark the run as
+// stopped and re-render the summary + buttons so the form stops claiming "still
+// running" forever and offers a re-run instead. Best-effort: a lookup failure leaves
+// the optimistic "still running" state untouched.
+function check_liveness(frm) {
+	if (frm.is_new() || frm.doc.status !== "Running" || !frm.doc.job_id) return;
+	frappe.call({
+		method: "tally_migrator.api.run_liveness",
+		args: { log_name: frm.doc.name },
+		callback: (r) => {
+			const res = r.message || {};
+			if (res.status === "Running" && res.alive === false) {
+				frm.__run_stopped = true;
+				render_summary(frm);
+				// Rebuild the whole custom-button bar in one pass: clear first so the
+				// buttons added during refresh aren't duplicated, then re-add ours plus
+				// the rollback action (cleared by clear_custom_buttons too).
+				frm.clear_custom_buttons();
+				add_buttons(frm);
+				tally_rollback_attach(frm);
+			}
+		},
+	});
+}
 
 // ── Dark-mode theming ────────────────────────────────────────────────────────
 // Frappe flips its semantic tokens in dark mode (--text-color, --border-color…)
@@ -949,15 +977,24 @@ function render_summary(frm) {
 
 	const entries = Object.entries(summary);
 	if (!entries.length) {
-		wrapper.html(
-			section(
-				`<div class="text-muted" style="padding:6px 0;">
-					${frm.doc.status === "Running"
-						? "Migration is still running..."
-						: "No import summary recorded for this run."}
-				</div>`
-			)
-		);
+		// No results yet. A Running log is either genuinely in progress or a worker
+		// that was hard-killed - check_liveness() sets __run_stopped for the latter so
+		// the form shows an honest "stopped" state instead of "still running" forever.
+		if (frm.doc.status === "Running" && frm.__run_stopped) {
+			wrapper.html(section(callout("error", iconRow("error",
+				"This run stopped before completing - its background job is no longer " +
+				"active (it may have run out of memory or the server restarted). Records " +
+				"imported before it stopped are kept, so it's safe to run again from the " +
+				"Tally Migrator."))));
+		} else if (frm.doc.status === "Running") {
+			wrapper.html(section(callout("info", iconRow("info",
+				"Migration is still running. This page does not refresh on its own - " +
+				"reload it to see the latest progress, or watch it live in the Tally " +
+				"Migrator."))));
+		} else {
+			wrapper.html(section(callout("info", iconRow("info",
+				"No import summary recorded for this run."))));
+		}
 		return;
 	}
 
@@ -1042,10 +1079,15 @@ function render_summary(frm) {
 function add_buttons(frm) {
 	if (frm.is_new()) return;
 
-	// Re-run is only meaningful when there's a source file AND something to retry.
+	// Re-run is only meaningful when there's a source file AND something to retry: a
+	// run that finished with errors/failed, or one detected as stopped (a dead
+	// 'Running' job - see check_liveness). The server-side re-run is idempotent, so
+	// already-imported records are skipped either way.
 	const canRetry =
 		frm.doc.source_file &&
-		(frm.doc.status === "Completed with Errors" || frm.doc.status === "Failed");
+		(frm.doc.status === "Completed with Errors" ||
+			frm.doc.status === "Failed" ||
+			(frm.doc.status === "Running" && frm.__run_stopped));
 
 	if (canRetry) {
 		frm.add_custom_button(__("Re-run from Source File"), () => {

--- a/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
+++ b/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
@@ -242,6 +242,8 @@ class TallyMigratorPage {
 
 					<div id="error-section" class="tm-callout tm-callout--error" style="display:none;"></div>
 
+					<div id="stall-section" class="tm-callout tm-callout--info tm-section" style="display:none;"></div>
+
 					<div id="run-actions">
 						<div class="tm-footer" style="margin-top:0;">
 							<button id="btn-back-3" class="btn btn-default btn-sm">${TallyMigratorPage.navIcon("left")} Back</button>
@@ -2049,6 +2051,7 @@ class TallyMigratorPage {
 			.show();
 		$("#run-actions").hide();
 		$("#error-section").hide();
+		$("#stall-section").hide();
 		$("#results-section").hide();
 		$("#progress-section").show();
 		this._setupProgressStream();
@@ -2092,6 +2095,7 @@ class TallyMigratorPage {
 		$("#btn-run").prop("disabled", true);
 		$("#btn-back-3").prop("disabled", true);
 		$("#error-section").hide();
+		$("#stall-section").hide();
 		$("#results-section").hide();
 		$("#run-banner").hide();
 		$("#progress-section").show();
@@ -2202,6 +2206,7 @@ class TallyMigratorPage {
 			this._trackingLog = null;
 			frappe.realtime.off("tally_migration_progress", this._onProgress);
 			this.stopHeartbeat();
+			$("#stall-section").hide();   // clear any "taking longer" notice now the run is terminal
 			$("#progress-bar").removeClass("active progress-bar-striped").css("width", "100%").text("100%");
 			if (doc.status === "Failed") {
 				$("#progress-section").hide();   // the run failed; don't leave a stuck bar above the error
@@ -2245,19 +2250,39 @@ class TallyMigratorPage {
 			this._trackingLog = null;
 			frappe.realtime.off("tally_migration_progress", this._onProgress);
 			this.stopHeartbeat();
-			$("#run-actions").show();
 			$("#btn-run").prop("disabled", false);
 			$("#btn-back-3").prop("disabled", false);
-			$("#progress-desc").html(
-				"This is taking longer than expected. The migration may still be running - " +
-				'open <a href="#" class="err-logs-link">the migration log</a> to check its ' +
-				'status. <button class="btn btn-xs btn-default" id="btn-keep-checking">Keep checking</button>'
-			);
-			$(".err-logs-link").on("click", (e) => {
-				e.preventDefault();
+			// Freeze the bar where it stalled - drop the active animation so it no longer
+			// implies live progress, but leave it visible as context for how far it got.
+			$("#progress-bar").removeClass("active progress-bar-striped");
+			$("#progress-desc").text("This is taking longer than expected.");
+			// The stall notice and its actions live in their own callout (not inline in
+			// the progress text and not the error callout) so the "Keep checking" action
+			// reads as a real button in a tidy row rather than mid-sentence.
+			$("#stall-section")
+				.html(
+					'<div style="display:flex; align-items:center; justify-content:space-between; ' +
+						'gap:var(--margin-md); flex-wrap:wrap;">' +
+						'<span style="flex:1; min-width:240px; line-height:1.5;">' +
+							"The migration may still be running in the background. " +
+							"Keep checking, or open the migration log for its live status." +
+						"</span>" +
+						'<span style="display:flex; gap:var(--margin-sm); flex-shrink:0;">' +
+							'<button class="btn btn-default btn-sm" id="btn-open-log">Open migration log</button>' +
+							'<button class="btn btn-primary btn-sm" id="btn-keep-checking">Keep checking</button>' +
+						"</span>" +
+					"</div>"
+				)
+				.show();
+			$("#run-actions").show();
+			$("#btn-open-log").on("click", () => {
 				frappe.set_route("Form", "Tally Migration Log", logName);
 			});
-			$("#btn-keep-checking").on("click", () => this.pollLog(logName));
+			$("#btn-keep-checking").on("click", () => {
+				$("#stall-section").hide();
+				$("#progress-bar").addClass("active progress-bar-striped");
+				this.pollLog(logName);
+			});
 		};
 
 		const poll = () => {
@@ -2422,6 +2447,7 @@ class TallyMigratorPage {
 		$("#progress-section").hide();
 		$("#results-section").hide().html("");
 		$("#error-section").hide();
+		$("#stall-section").hide();
 		$("#progress-bar").css("width", "0%").text("0%");
 		$("#run-actions").show();
 		$("#btn-run").prop("disabled", false);

--- a/tally_migrator/tests/test_critical_fixes.py
+++ b/tally_migrator/tests/test_critical_fixes.py
@@ -274,6 +274,48 @@ class TestActiveRunGuard(unittest.TestCase):
             self._api()._assert_no_active_run("Acme")   # dead job -> must not raise
 
 
+class TestRunLiveness(unittest.TestCase):
+    """The log form asks run_liveness whether a 'Running' log's worker is alive, so a
+    hard-killed run shows a 'stopped' state instead of 'still running' forever."""
+
+    def _api(self):
+        from tally_migrator import api
+        return api
+
+    def test_terminal_status_is_not_alive(self):
+        row = frappe._dict({"status": "Completed", "job_id": "j", "modified": "x"})
+        with mock.patch("frappe.db.get_value", return_value=row):
+            out = self._api().run_liveness("LOG-1")
+        self.assertEqual(out, {"status": "Completed", "alive": False})
+
+    def test_running_with_live_job_is_alive(self):
+        row = frappe._dict({"status": "Running", "job_id": "tally-masters-LOG-1", "modified": "x"})
+        with mock.patch("frappe.db.get_value", return_value=row), \
+                mock.patch.object(self._api(), "_is_job_alive", return_value=True):
+            out = self._api().run_liveness("LOG-1")
+        self.assertEqual(out, {"status": "Running", "alive": True})
+
+    def test_running_with_dead_job_is_not_alive(self):
+        row = frappe._dict({"status": "Running", "job_id": "tally-masters-LOG-1", "modified": "x"})
+        with mock.patch("frappe.db.get_value", return_value=row), \
+                mock.patch.object(self._api(), "_is_job_alive", return_value=False):
+            out = self._api().run_liveness("LOG-1")
+        self.assertEqual(out, {"status": "Running", "alive": False})
+
+    def test_jobless_running_uses_age_cap(self):
+        # A legacy/sync run with no job id falls back to the staleness age cap.
+        row = frappe._dict({"status": "Running", "job_id": None, "modified": "2026-01-01 00:00:00"})
+        with mock.patch("frappe.db.get_value", return_value=row), \
+                mock.patch("frappe.utils.now", return_value="ignored"), \
+                mock.patch("frappe.utils.time_diff_in_seconds", return_value=10 * 3600):
+            out = self._api().run_liveness("LOG-1")
+        self.assertEqual(out["alive"], False)
+
+    def test_unknown_log_returns_empty(self):
+        with mock.patch("frappe.db.get_value", return_value=None):
+            self.assertEqual(self._api().run_liveness("NOPE"), {})
+
+
 class TestItemHsnRecovery(unittest.TestCase):
     """An India-Compliance HSN rejection must not lose the item: the importer
     retries once with the HSN cleared so the item still lands (HSN filled later)."""

--- a/tally_migrator/tests/test_finalize_terminal_status.py
+++ b/tally_migrator/tests/test_finalize_terminal_status.py
@@ -1,0 +1,112 @@
+"""Guard: _finalize_log must always leave the log in a terminal state, even when the
+heavy enrichment (manifest / reconciliation / per-record errors) blows up. This is the
+bug that froze the wizard on large async runs - status stayed 'Running' forever while
+run() still published 100%, so the page sat at a full bar with no results."""
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from tally_migrator.migration.master_migrator import MasterMigrator
+
+
+class _FakeLog:
+    """A stand-in for the Tally Migration Log doc - records writes without a DB."""
+
+    def __init__(self):
+        self.status = "Running"
+        self.import_summary = None
+        self.created_records = None
+        self.reconciliation_report = None
+        self._saves = 0
+
+    def reload(self):
+        pass
+
+    def set(self, field, value):
+        setattr(self, field, value)
+
+    def append(self, *a, **k):
+        pass
+
+    def db_set(self, field, value, commit=False):
+        setattr(self, field, value)
+
+    def save(self, **k):
+        self._saves += 1
+
+
+def _summary(has_errors=False, has_warnings=False):
+    return SimpleNamespace(
+        has_errors=has_errors,
+        has_warnings=has_warnings,
+        as_dict=lambda: {"Accounts": {"created": 1}},
+        created_records=lambda: {"Account": [{"name": "X"}]},
+        error_lines=lambda: "",
+        error_records=lambda: [],
+    )
+
+
+class TestFinalizeTerminalStatus(unittest.TestCase):
+    def _migrator(self, log):
+        # Bypass __init__ - we only exercise _finalize_log against a fake self.
+        m = MasterMigrator.__new__(MasterMigrator)
+        m.log = log
+        m.applied_edits = []
+        m._timings = {}
+        m.created_uoms = []
+        return m
+
+    def _masters_coa(self):
+        return SimpleNamespace(summary={}), SimpleNamespace(summary={})
+
+    @mock.patch("frappe.db")
+    @mock.patch("frappe.log_error")
+    def test_status_committed_when_enrichment_fails(self, _log_err, _db):
+        log = _FakeLog()
+        m = self._migrator(log)
+        masters, coa = self._masters_coa()
+        # Make the enrichment phase blow up at the manifest step.
+        summary = _summary()
+        summary.created_records = mock.Mock(side_effect=RuntimeError("boom"))
+        m._finalize_log(masters, coa, summary)
+        # Terminal state survived the enrichment failure.
+        self.assertEqual(log.status, "Completed")
+        self.assertIsNotNone(log.import_summary)
+
+    @mock.patch("frappe.db")
+    @mock.patch("frappe.log_error")
+    def test_status_reflects_errors(self, _log_err, _db):
+        log = _FakeLog()
+        m = self._migrator(log)
+        masters, coa = self._masters_coa()
+        summary = _summary(has_errors=True)
+        m._reconciliation = lambda *a: {}
+        m._track_wizard_uoms = lambda *a: None
+        m._finalize_log(masters, coa, summary)
+        self.assertEqual(log.status, "Completed with Errors")
+
+    @mock.patch("frappe.db")
+    @mock.patch("frappe.log_error")
+    def test_status_fallback_when_first_save_fails(self, _log_err, _db):
+        log = _FakeLog()
+        # First save() raises; the db_set fallback must still set a terminal status.
+        original_save = log.save
+        calls = {"n": 0}
+
+        def flaky_save(**k):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("save exploded")
+            return original_save(**k)
+
+        log.save = flaky_save
+        m = self._migrator(log)
+        m._reconciliation = lambda *a: {}
+        m._track_wizard_uoms = lambda *a: None
+        masters, coa = self._masters_coa()
+        m._finalize_log(masters, coa, _summary())
+        self.assertEqual(log.status, "Completed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

On large (background-job) migrations, the wizard would freeze at a full progress bar with no results, and the migration log would sit on **Running** forever. Two separate problems behind it:

1. **The freeze itself.** `_finalize_log` built every report and saved them in a single trailing `save()` inside a catch-all that only logged. On a big run, any throw in that block (a large serialization, an `errors` child-row, or the heavy save) lost the `status="Completed"` write, yet `run()` still published 100%. The page polls `status`, never sees a terminal value, and freezes.
2. **No signal when a worker dies.** A hard-killed worker (OOM, redeploy) never writes a terminal status, so the log claimed "still running" indefinitely with no way forward.

## What changed

**Freeze fix** (`master_migrator.py`)
- `_finalize_log` now commits the terminal state (`status` + `import_summary`, small and bounded) **first**, with a bare `db_set` fallback, then enriches with the heavy/optional reports best-effort - which can never revert the status. Any enrichment failure still leaves a terminal, renderable log.

**Stopped-run detection** (`api.py`, log form)
- New whitelisted `run_liveness(log_name)` asks RQ whether a `Running` log's job is actually alive, reusing `_active_run_log`'s liveness rule.
- The log form checks it on open and, when the job is gone, shows a clear "stopped before completing - records kept, safe to re-run" state and enables the **Re-run** button (previously only for Completed-with-Errors / Failed). The custom-button bar is rebuilt in one pass to avoid duplicates.
- The "still running" / "stopped" / "no summary" states now reuse the log's existing `section`/`callout`/`iconRow` vocabulary for consistent spacing.

**Stall UI** (wizard step 5)
- The 30-minute stall notice moves out of the progress text into its own info callout with a tidy button row (`Open migration log` / `Keep checking`) instead of a button jammed mid-sentence, and the bar de-animates so it no longer implies live progress.

**Docs**
- README and the user guide's log-status section updated to match (reload to refresh; stopped-early behavior).

## Validation

- Full suite: **479 tests** OK (+8 new).
- Real-DB checks: reproduced the old single-save freeze (status stuck `Running`) vs the new behavior (`Completed` + summary saved); and `run_liveness` returning `alive: false` for a `Running` log whose RQ job is gone, via the real `is_job_enqueued`.
- All Frappe APIs used (`frm.clear_custom_buttons`, `is_job_enqueued`) verified against source.

## Scope notes

- This makes every **exception-driven** finalize failure terminal-safe. A worker **killed mid-import** (before finalize) still leaves `Running` - now surfaced honestly by the liveness check and the wizard's existing stall path. Cutting the worker's peak memory (the underlying OOM risk) remains separate, parked work.