### PR TITLE
Opening-balance migration: correctness and performance fixes

### DIFF
--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -953,6 +953,10 @@ migration.
   quantity times rate; the opening rate was used. Verify in Tally.
 - **"... is held in Temporary Opening to keep your books balanced"** - normal; see
   the Temporary Opening explanation.
+- **"opening balance skipped - account ... exists as a group account"** - the Tally
+  ledger had sub-accounts, so it was created as a group, and ERPNext does not let a
+  group account carry a balance. Its opening amount is held in Temporary Opening
+  instead; the rest of that account class still posts normally.
 - **"this company already has an Opening Entry that was not created by this
   migrator"** - opening balances were skipped to avoid double-posting against a
   manually set-up book. Cancel that entry first if you want this migration to post

--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -515,8 +515,12 @@ The log is made up of several sections, each explained below.
 
 A per-record-type table with a coloured bar for each row showing the split of
 **Imported (new)** in green, **Already there (skipped, safe)** in grey, and
-**Failed** in red, plus a total row. This is the same breakdown you saw on the
-results screen, kept for the record.
+**Failed** in red, plus **Imported**, **Already there**, **Warnings**, and
+**Failed** count columns and a total row. The **Warnings** column counts records
+that imported but had a dependent piece (an address, a contact, an opening balance,
+and so on) dropped, so a partial drop is visible here and not only on the results
+screen; the detail is in the issues table below. This is the same breakdown you saw
+on the results screen, kept for the record.
 
 ### Reconciliation: opening trial balance
 

--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -925,6 +925,11 @@ migration.
   be saved. The party still imported.
 - **"bank account not created"** - usually because the ledger had no bank name. The
   party or account still imported.
+- **"reused existing account ... and converted it to a group"** - a Tally group had
+  the same name as an account ERPNext already ships as a ledger (for example a
+  "Office Equipment" or "TDS Payable" group over the standard ledger of that name).
+  The existing ledger was promoted to a group so the Tally sub-accounts under it could
+  be created. Nothing for you to do.
 - **"item not imported - its code collides with ..."** - an item code collision (see
   above). Rename one item and re-run.
 - **"GST type ... not recognised - item imported as taxable"** - set the item's GST

--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -929,11 +929,13 @@ migration.
   be saved. The party still imported.
 - **"bank account not created"** - usually because the ledger had no bank name. The
   party or account still imported.
-- **"reused existing account ... and converted it to a group"** - a Tally group had
-  the same name as an account ERPNext already ships as a ledger (for example a
-  "Office Equipment" or "TDS Payable" group over the standard ledger of that name).
-  The existing ledger was promoted to a group so the Tally sub-accounts under it could
-  be created. Nothing for you to do.
+- **"a Tally group with this name matches the existing account ... kept as a ledger"** -
+  a Tally group had the same name as an account ERPNext already ships as a ledger (for
+  example a "Office Equipment" or "TDS Payable" group over the standard ledger of that
+  name). The standard ledger is left exactly as it is (converting it would break ERPNext
+  features that rely on it, like India Compliance's TDS setup), and the Tally group's
+  sub-accounts are placed under that ledger's own parent group instead - so they still
+  import, one level flatter. Nothing for you to do.
 - **"item not imported - its code collides with ..."** - an item code collision (see
   above). Rename one item and re-run.
 - **"GST type ... not recognised - item imported as taxable"** - set the item's GST

--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -739,6 +739,10 @@ Migrator handles a real-world wrinkle in Tally data.
 - **Invalid GSTIN.** A structurally invalid GSTIN is dropped from the party (and its
   address) so it does not block import, but the party still imports as Unregistered.
   The pre-flight flags it so you can fix it.
+- **Invalid PAN.** Tally's Income Tax Number maps to the party's PAN, but a value that
+  is not a valid PAN (for example a TAN or a plain number) would otherwise make India
+  Compliance reject the whole party. The app keeps a valid PAN and drops an invalid
+  one, so the party still imports; set the correct PAN in ERPNext afterwards.
 - **PIN that does not match the state.** India Compliance rejects an address whose PIN
   does not match its state. Rather than lose the whole address, the app drops just
   the PIN, keeps the address, and warns you to set the PIN in ERPNext.
@@ -783,6 +787,11 @@ Migrator handles a real-world wrinkle in Tally data.
   cleared so it still lands, and you are told to set a correct one.
 - **Batch and expiry.** An item marked batch-wise in Tally gets batch tracking turned
   on; if it is also perishable, expiry tracking is enabled too.
+- **Opening stock value.** Every item with opening stock is imported with its quantity
+  and rate. ERPNext recomputes each item's valuation when it posts the opening stock,
+  so the total opening stock value on the trial balance can differ from Tally's by a
+  few units of rounding. This is a rounding effect, not missing stock - all items and
+  quantities are imported.
 
 ### Units of measure
 
@@ -804,7 +813,10 @@ Migrator handles a real-world wrinkle in Tally data.
 - **Account ordering.** Groups are created parent-before-child, and any circular
   parent loop is broken rather than crashing (with a pre-flight warning).
 - **Bank ledgers.** A Tally bank ledger carrying the company's own account number and
-  IFSC creates a company Bank Account linked to that GL account.
+  IFSC creates a company Bank Account linked to that GL account. When several bank
+  ledgers share the same account-holder name (Tally often repeats it), each still gets
+  its own Bank Account - the name is made unique with the account number, so no
+  ledger's bank details are lost to a name clash.
 - **Cost centres** import flat or nested, under the company's root cost centre.
 - **Warehouses / godowns** import with their full nesting. A godown that is the parent
   of another is created as a group warehouse so the tree renders correctly. Each

--- a/tally_migrator/erpnext/importers/accounts.py
+++ b/tally_migrator/erpnext/importers/accounts.py
@@ -52,10 +52,18 @@ class AccountImporter:
         self.abbr = abbr
         self.mode = mode if mode in ("reuse", "mirror") else "reuse"
         self._group_cache: dict[str, str] = {}
+        # Tally group name -> ERPNext parent account its children should nest under,
+        # for groups whose name collides with an existing account we must NOT convert
+        # (see _build_redirects). Empty until run() builds it.
+        self._redirect: dict[str, str] = {}
 
     def run(self, accounts: list) -> ImportResult:
         result = ImportResult(self.doctype)
-        for node in self._ordered(self._select(accounts)):
+        ordered = self._ordered(self._select(accounts))
+        # Decide up front which Tally groups collide with an existing account we must
+        # leave intact, so child parent-resolution can re-home them (order-independent).
+        self._build_redirects(ordered, result)
+        for node in ordered:
             parent = self._resolve_parent(node)
             if not parent:
                 result.add_error(node.name, "could not resolve a parent account")
@@ -101,10 +109,16 @@ class AccountImporter:
 
     def _resolve_parent(self, node) -> str | None:
         parent = node.parent
-        if self.mode == "mirror":
-            return self._erp_name(parent) if parent else self._root_group(node.root_type)
         if not parent:
             return self._root_group(node.root_type)
+        if parent in self._redirect:
+            # The Tally parent group's name collides with an existing account we keep
+            # as a ledger (never converted), so its children nest under that account's
+            # own parent instead - see _build_redirects. Applies in both modes: we never
+            # convert the ledger, so its children always re-home.
+            return self._redirect[parent]
+        if self.mode == "mirror":
+            return self._erp_name(parent)
         cls = classify_group(parent)
         if cls:  # parent is a reserved group → use its ERPNext default group
             return self._default_group(cls["erpnext_group"], node.root_type)
@@ -136,20 +150,14 @@ class AccountImporter:
 
     def _upsert(self, result: ImportResult, node, parent: str) -> None:
         try:
-            existing = frappe.db.get_value(
-                "Account", self._erp_name(node.name), ["name", "is_group"], as_dict=True)
-            if existing:
-                # The name is already taken. MariaDB's default collation is
-                # case-insensitive, so a Tally custom group ("OFFICE EQUIPMENT")
-                # collides with a standard-CoA *ledger* of the same name
-                # ("Office Equipment", a Fixed Asset ledger). Skipping would leave a
-                # ledger where a group is needed, and every child would then fail with
-                # "Parent account ... can not be a ledger". When we need a group but the
-                # existing account is a ledger, promote it so the children can nest.
-                if node.is_group and not existing.is_group:
-                    self._promote_to_group(result, existing.name, node)
-                else:
-                    result.skipped += 1
+            if frappe.db.exists("Account", self._erp_name(node.name)):
+                # The name is already taken - a re-run's own account, a reserved group,
+                # or a Tally group colliding with a standard ledger. We never convert or
+                # overwrite an existing account (it may be load-bearing - e.g. India
+                # Compliance wires "TDS Payable" into its tax-withholding setup). A
+                # colliding group's children were re-homed to the existing account's
+                # parent in _build_redirects, so here we simply skip.
+                result.skipped += 1
                 return
             doc = {
                 "doctype": "Account",
@@ -175,40 +183,43 @@ class AccountImporter:
         if not node.is_group and node.account_type == "Bank" and node.bank_account_no:
             self._save_company_bank_account(node, d.name, result)
 
-    def _promote_to_group(self, result: ImportResult, account_name: str, node) -> None:
-        """Convert an existing ledger Account to a group so Tally's children can nest.
+    def _build_redirects(self, ordered: list, result: ImportResult) -> None:
+        """Map each Tally group whose name collides with an existing *ledger* to that
+        ledger's parent group, so the group's children nest there instead.
 
-        Reached only when a Tally group's name collides (case-insensitively) with an
-        existing ledger - typically an empty standard-CoA placeholder ledger. The
-        ledger is converted in place; ERPNext rebuilds the tree. A converted account
-        is reported as created (it is now the group the migration needs) plus a warning
-        so the reuse is visible in the log.
-        """
-        try:
-            acc = frappe.get_doc("Account", account_name)
-            if acc.check_gle_exists():
-                # Only possible on a re-run after transactions posted; ERPNext (rightly)
-                # forbids converting a transacting account. Surface it instead of crashing.
-                result.add_error(
-                    node.name,
-                    f"could not create group '{node.name}': an account named "
-                    f"'{account_name}' already exists and has transactions, so it "
-                    "cannot be converted to a group")
-                return
-            # These placeholder ledgers carry an account_type (e.g. Fixed Asset, Tax);
-            # the flag lets a typed account become a group, which ERPNext otherwise blocks.
-            acc.flags.exclude_account_type_check = True
-            acc.flags.ignore_permissions = True
-            acc.convert_ledger_to_group()
-            frappe.db.commit()
-            result.add_created(acc.name)
+        A Tally custom group ("OFFICE EQUIPMENT", "TDS PAYABLE") can share a name -
+        case-insensitively, the way MariaDB compares - with an account ERPNext already
+        ships as a ledger ("Office Equipment"; "TDS Payable", a Tax account India
+        Compliance wires into every Tax Withholding Category). We must NOT convert that
+        ledger to a group: converting strips its load-bearing role and breaks the
+        features that depend on it (opening entries, IC tax withholding, company
+        defaults). Instead we leave the ledger exactly as it is and re-home the Tally
+        group's sub-accounts to the ledger's own parent group - so every sub-account
+        still imports, one level flatter, and nothing standard is mutated.
+
+        Builds ``self._redirect`` (Tally group name -> ERPNext parent account name).
+        ``_resolve_parent`` consults it; ``_upsert`` then skips the colliding group
+        itself (its name is taken by the ledger we are keeping)."""
+        self._redirect = {}
+        for node in ordered:
+            if not node.is_group:
+                continue
+            existing = frappe.db.get_value(
+                "Account", self._erp_name(node.name),
+                ["name", "is_group", "parent_account", "root_type"], as_dict=True)
+            if not existing or existing.is_group:
+                continue  # free to create, or an existing group we can nest under
+            target = existing.parent_account or self._root_group(
+                existing.root_type or node.root_type)
+            if not target:
+                continue  # no safe parent to re-home under; let _upsert skip + warn-free
+            self._redirect[node.name] = target
             result.add_warning(
                 node.name,
-                f"reused existing account '{account_name}' and converted it to a group "
-                "so the Tally sub-accounts under it could be created")
-        except Exception as exc:
-            frappe.db.rollback()
-            result.add_error(node.name, exc)
+                f"a Tally group with this name matches the existing account "
+                f"'{existing.name}', which is kept as a ledger (converting it would "
+                f"break ERPNext features that rely on it). Its sub-accounts were placed "
+                f"under '{target}' instead.")
 
     def _save_company_bank_account(self, node, account_name: str,
                                    result: ImportResult) -> None:

--- a/tally_migrator/erpnext/importers/accounts.py
+++ b/tally_migrator/erpnext/importers/accounts.py
@@ -136,8 +136,20 @@ class AccountImporter:
 
     def _upsert(self, result: ImportResult, node, parent: str) -> None:
         try:
-            if frappe.db.exists("Account", self._erp_name(node.name)):
-                result.skipped += 1
+            existing = frappe.db.get_value(
+                "Account", self._erp_name(node.name), ["name", "is_group"], as_dict=True)
+            if existing:
+                # The name is already taken. MariaDB's default collation is
+                # case-insensitive, so a Tally custom group ("OFFICE EQUIPMENT")
+                # collides with a standard-CoA *ledger* of the same name
+                # ("Office Equipment", a Fixed Asset ledger). Skipping would leave a
+                # ledger where a group is needed, and every child would then fail with
+                # "Parent account ... can not be a ledger". When we need a group but the
+                # existing account is a ledger, promote it so the children can nest.
+                if node.is_group and not existing.is_group:
+                    self._promote_to_group(result, existing.name, node)
+                else:
+                    result.skipped += 1
                 return
             doc = {
                 "doctype": "Account",
@@ -162,6 +174,41 @@ class AccountImporter:
         # a Bank-Account quirk can't roll back the account that was just created.
         if not node.is_group and node.account_type == "Bank" and node.bank_account_no:
             self._save_company_bank_account(node, d.name, result)
+
+    def _promote_to_group(self, result: ImportResult, account_name: str, node) -> None:
+        """Convert an existing ledger Account to a group so Tally's children can nest.
+
+        Reached only when a Tally group's name collides (case-insensitively) with an
+        existing ledger - typically an empty standard-CoA placeholder ledger. The
+        ledger is converted in place; ERPNext rebuilds the tree. A converted account
+        is reported as created (it is now the group the migration needs) plus a warning
+        so the reuse is visible in the log.
+        """
+        try:
+            acc = frappe.get_doc("Account", account_name)
+            if acc.check_gle_exists():
+                # Only possible on a re-run after transactions posted; ERPNext (rightly)
+                # forbids converting a transacting account. Surface it instead of crashing.
+                result.add_error(
+                    node.name,
+                    f"could not create group '{node.name}': an account named "
+                    f"'{account_name}' already exists and has transactions, so it "
+                    "cannot be converted to a group")
+                return
+            # These placeholder ledgers carry an account_type (e.g. Fixed Asset, Tax);
+            # the flag lets a typed account become a group, which ERPNext otherwise blocks.
+            acc.flags.exclude_account_type_check = True
+            acc.flags.ignore_permissions = True
+            acc.convert_ledger_to_group()
+            frappe.db.commit()
+            result.add_created(acc.name)
+            result.add_warning(
+                node.name,
+                f"reused existing account '{account_name}' and converted it to a group "
+                "so the Tally sub-accounts under it could be created")
+        except Exception as exc:
+            frappe.db.rollback()
+            result.add_error(node.name, exc)
 
     def _save_company_bank_account(self, node, account_name: str,
                                    result: ImportResult) -> None:

--- a/tally_migrator/erpnext/importers/banks.py
+++ b/tally_migrator/erpnext/importers/banks.py
@@ -28,6 +28,30 @@ from .base import ImportResult, atomic
 
 # ── Bank Account helpers (shared by party + company bank accounts) ─────────────
 
+def _unique_bank_account_name(account_name: str, bank: str, account_no: str = "") -> str:
+    """An account_name that yields a unique Bank Account, given ERPNext names the doc
+    ``account_name + " - " + bank`` (Bank Account.autoname).
+
+    Tally often repeats one account-holder name across several bank ledgers of the
+    same company (e.g. every HDFC ledger carries the holder 'ICONCEPT'). They then
+    collapse to the same Bank Account name and all but the first fail on a duplicate
+    key, silently dropping that ledger's bank details. So when the natural name is
+    taken, disambiguate - first with the account number (unique per real account),
+    then with a numeric suffix - so each bank ledger keeps its own Bank Account.
+    Generic: a holder that is already unique is returned unchanged."""
+    base = (account_name or "").strip()
+    if not base or not frappe.db.exists("Bank Account", f"{base} - {bank}"):
+        return base
+    acc_no = (account_no or "").strip()
+    if acc_no:
+        candidate = f"{base} ({acc_no})"
+        if not frappe.db.exists("Bank Account", f"{candidate} - {bank}"):
+            return candidate
+    i = 2
+    while frappe.db.exists("Bank Account", f"{base} {i} - {bank}"):
+        i += 1
+    return f"{base} {i}"
+
 def _ensure_bank(bank_name: str, result: "ImportResult | None" = None, *,
                  is_company: bool = False) -> str:
     """Return an existing/created Bank master name, or "" when no name is given.
@@ -84,7 +108,10 @@ def _insert_bank_account(*, account_name: str, bank: str, account_no: str,
         # Account, never a caller's uncommitted batch.
         with atomic():
             ba = frappe.new_doc("Bank Account")
-            ba.account_name = account_name
+            # Disambiguate a holder name already used by another bank ledger so the
+            # autonamed doc ("account_name - bank") does not collide and drop this
+            # ledger's bank details.
+            ba.account_name = _unique_bank_account_name(account_name, bank, account_no)
             ba.bank = bank
             ba.bank_account_no = account_no
             if ifsc:

--- a/tally_migrator/erpnext/importers/batch.py
+++ b/tally_migrator/erpnext/importers/batch.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import frappe
 
-from tally_migrator.naming import safe_item_code
+from tally_migrator.naming import safe_item_code, shared_batch_names, batch_id_for
 from tally_migrator.tally.extractors import TallyExtractor
 from .base import ImportResult
 
@@ -34,6 +34,9 @@ class BatchImporter:
 
     def run(self, items: list[dict]) -> ImportResult:
         result = ImportResult(self.doctype)
+        # Names reused across items would collide on ERPNext's global batch id, so
+        # those get scoped per item - by the same rule the opening-stock importer uses.
+        shared = shared_batch_names(items)
         for it in items:
             # Tally stamps every item's opening with an implicit "Primary Batch", so
             # only genuinely batch-tracked items (ISBATCHWISEON=Yes) get Batch masters -
@@ -47,7 +50,8 @@ class BatchImporter:
                 if not batch or batch in seen:
                     continue
                 seen.add(batch)
-                self._upsert(result, code, it.get("_name", ""), batch, row)
+                self._upsert(result, code, it.get("_name", ""),
+                             batch_id_for(batch, code, shared), row)
         return result
 
     def _upsert(self, result: ImportResult, item_code: str, item_name: str,

--- a/tally_migrator/erpnext/importers/openings.py
+++ b/tally_migrator/erpnext/importers/openings.py
@@ -1,6 +1,7 @@
 """Opening balances: the per-company lock and the three opening importers."""
 
 import contextlib
+import sys
 from dataclasses import dataclass, field
 
 import frappe
@@ -920,6 +921,54 @@ class PartyOpeningImporter:
 
 # ── Opening stock importer ───────────────────────────────────────────────────
 
+@contextlib.contextmanager
+def _accounting_dimensions_cached():
+    """Memoise ERPNext's ``get_accounting_dimensions()`` for the duration of the block.
+
+    Posting opening stock submits one Stock Reconciliation per chunk, and ERPNext's
+    GL/SLE path calls ``get_accounting_dimensions()`` about twice per item - each an
+    uncached DB read of a company-wide constant (the Accounting Dimension list does
+    not change during a migration). On a real book that is ~2 round-trips per item of
+    pure waste, and it dominates on Frappe Cloud where every round-trip carries
+    network latency. We memoise the result for the phase, then restore the original.
+
+    The function is name-imported into several ERPNext modules (general_ledger,
+    accounts_controller, ...), so patching only its source module would miss those
+    bound references. We scan ``sys.modules`` and swap every module-level reference
+    that currently points at the original, restoring each on exit. The wrapper returns
+    a fresh copy per call so a caller that mutates the list can never corrupt the
+    cache. No-op-safe: if ERPNext or the symbol is absent, the block runs unchanged."""
+    try:
+        from erpnext.accounts.doctype.accounting_dimension import accounting_dimension as _ad
+    except Exception:
+        yield
+        return
+    original = getattr(_ad, "get_accounting_dimensions", None)
+    if original is None:
+        yield
+        return
+
+    cache: dict = {}
+
+    def cached(as_list=True):
+        if as_list not in cache:
+            cache[as_list] = original(as_list=as_list)
+        value = cache[as_list]
+        return list(value) if isinstance(value, list) else value
+
+    # Every module that did ``from ...accounting_dimension import get_accounting_dimensions``
+    # holds its own reference; patch them all (plus the source module).
+    patched = [m for m in list(sys.modules.values())
+               if getattr(m, "get_accounting_dimensions", None) is original]
+    for m in patched:
+        m.get_accounting_dimensions = cached
+    try:
+        yield
+    finally:
+        for m in patched:
+            m.get_accounting_dimensions = original
+
+
 class StockOpeningImporter:
     """Posts item opening stock as one submitted 'Opening Stock' Stock Reconciliation.
 
@@ -1002,14 +1051,18 @@ class StockOpeningImporter:
         if any(r.get("use_serial_batch_fields") for r in pending):
             self._ensure_serial_batch_enabled(result)
 
-        for i in range(0, len(pending), self._CHUNK):
-            chunk = pending[i:i + self._CHUNK]
-            if not self._post_doc(chunk, posting_date, result):
-                # The chunk failed as a unit - retry each row on its own so one bad
-                # row (e.g. an unforeseen validation) cannot cost the other ~100
-                # their opening stock. A 1-row doc also submits synchronously.
-                for row in chunk:
-                    self._post_doc([row], posting_date, result, isolate=True)
+        # Memoise the per-item Accounting Dimension lookup ERPNext repeats on every
+        # GL/SLE posting (a company-wide constant) - the dominant avoidable round-trip
+        # cost of this phase, especially on Frappe Cloud. See _accounting_dimensions_cached.
+        with _accounting_dimensions_cached():
+            for i in range(0, len(pending), self._CHUNK):
+                chunk = pending[i:i + self._CHUNK]
+                if not self._post_doc(chunk, posting_date, result):
+                    # The chunk failed as a unit - retry each row on its own so one bad
+                    # row (e.g. an unforeseen validation) cannot cost the other ~100
+                    # their opening stock. A 1-row doc also submits synchronously.
+                    for row in chunk:
+                        self._post_doc([row], posting_date, result, isolate=True)
         return result
 
     def _post_doc(self, rows: list, posting_date: str, result: ImportResult,

--- a/tally_migrator/erpnext/importers/openings.py
+++ b/tally_migrator/erpnext/importers/openings.py
@@ -266,11 +266,29 @@ class OpeningBalanceImporter:
                     "not posted. It is included in the Temporary Opening total instead.")
                 continue
             account = company_scoped(node.name, self.abbr)
-            if not frappe.db.exists("Account", account):
+            is_group = frappe.db.get_value("Account", account, "is_group")
+            if is_group is None:
                 result.add_warning(
                     node.name,
                     f"opening balance skipped - account '{account}' was not created "
                     "(its import failed earlier). Fix the account and re-run.")
+                continue
+            # The Tally ledger exists in ERPNext as a GROUP account - it had
+            # sub-accounts under it in Tally, so it was created (or promoted) as a
+            # group, and ERPNext forbids a group account from carrying a balance
+            # ("group accounts cannot be used in transactions"). Including it would
+            # fail the whole class's Opening Entry on submit and lose every balance in
+            # that batch, so skip just this line. The amount is not lost: the batch
+            # plugs against Temporary Opening, so it stays inside that difference, to
+            # be cleared when the user completes their opening entries - the same
+            # contract as an income/expense opening above.
+            if is_group:
+                result.add_warning(
+                    node.name,
+                    f"opening balance skipped - account '{account}' exists as a group "
+                    "account (its Tally ledger had sub-accounts), and ERPNext does not "
+                    f"allow a group account to carry a balance, so {abs(node.opening_balance):,.2f} "
+                    "was not posted. It is included in the Temporary Opening total instead.")
                 continue
             lines.append(self._line(account, node.opening_balance, node.opening_dr_cr))
         return lines

--- a/tally_migrator/erpnext/importers/openings.py
+++ b/tally_migrator/erpnext/importers/openings.py
@@ -195,7 +195,17 @@ class OpeningBalanceImporter:
                 "user_remark": f"{self._REMARK_PREFIX}{label})",
             })
             doc.insert(ignore_permissions=True)
-            doc.submit()
+            # Submit synchronously. ERPNext's JournalEntry.submit() enqueues the
+            # submission as a BACKGROUND job when the entry has > 100 accounts
+            # (the asset Opening Entry routinely does), returning before the GL is
+            # posted. The single migration worker is then busy until the run ends,
+            # so that queued submit - and its GL - only lands AFTER finalize, which
+            # makes the post-import trial balance read a whole account class as
+            # absent. _submit() is exactly the path submit() takes for <=100-row
+            # entries, so this forces the same synchronous posting for any size.
+            # Safe here because the migration already runs off the web request,
+            # so there is no request-timeout reason to defer.
+            doc._submit()
             frappe.db.commit()
             result.add_created(doc.name)
         except Exception as exc:
@@ -765,11 +775,25 @@ class PartyOpeningImporter:
 
     @staticmethod
     def _classify(party_type: str, signed: float, is_advance: bool) -> str:
-        """An outstanding invoice (party's natural side, not flagged advance) vs an
-        advance/credit. Customer natural side = Dr (signed > 0); Supplier = Cr
-        (signed < 0). Tally's ISADVANCE flag forces 'advance' regardless of side."""
-        if is_advance:
-            return "advance"
+        """Outstanding invoice vs advance/credit, decided PURELY by which side of the
+        party's control account the bill sits on. Customer natural side = Dr
+        (signed > 0); Supplier = Cr (signed < 0): a bill there is an outstanding
+        opening invoice. A bill on the OPPOSITE side is an advance/credit and posts
+        as an unallocated Payment Entry.
+
+        Tally's ISADVANCE flag is deliberately NOT used to force 'advance'. A genuine
+        advance already falls on the opposite side (a customer prepayment is a credit,
+        a supplier prepayment is a debit), so side alone routes it correctly. But some
+        exports also tag a bill that sits on the party's NATURAL side as ISADVANCE
+        (e.g. a supplier credit bill that offsets a debit bill). Forcing those to an
+        advance posted them on the WRONG side via an opposite-direction Payment Entry,
+        flipping their sign - so an offsetting Cr+Dr pair that nets to zero in Tally
+        posted as a non-zero party balance (understating Payables/Receivables). The
+        advance Payment Entry's direction is fixed by party type (supplier=Pay/debit,
+        customer=Receive/credit), so it can only carry a bill that is genuinely on the
+        opposite side; routing by side keeps every bill's GL effect equal to Tally's.
+        ``is_advance`` is retained in the signature (it is a real Tally attribute the
+        caller passes through) but does not change the side a balance lands on."""
         on_natural_side = (signed > 0) if party_type == "Customer" else (signed < 0)
         return "invoice" if on_natural_side else "advance"
 

--- a/tally_migrator/erpnext/importers/openings.py
+++ b/tally_migrator/erpnext/importers/openings.py
@@ -18,12 +18,14 @@ from tally_migrator.tally.mappings import (
     classify_group,
     gst_category_from_type,
 )
-from tally_migrator.naming import safe_item_code, company_scoped
+from tally_migrator.naming import (
+    safe_item_code, company_scoped, shared_batch_names, batch_id_for)
 from tally_migrator.tally.extractors import TallyExtractor
 from tally_migrator.validation.engine import (
     infer_gst_category, validate_gstin, GSTIN_STATE_CODES,
 )
 from .base import BaseImporter, ImportResult
+from .items import ItemImporter
 
 # ── Concurrency guard for opening entries ─────────────────────────────────────
 # The opening Journal Entry and Stock Reconciliation are aggregate, submitted
@@ -915,22 +917,25 @@ class StockOpeningImporter:
         self.company = company
         self.abbr = abbr
 
+    # ERPNext queues a Stock Reconciliation submit in the background once it has
+    # more than 100 rows (stock_reconciliation.py); that background hop both breaks
+    # synchronous posting here and is the kind of job that stalls on cloud. Posting
+    # in <=100-row chunks keeps every submit synchronous and deterministic, bounds a
+    # failure's blast radius, and bounds the per-document memory/transaction size.
+    _CHUNK = 100
+
     def run(self, items: list, posting_date: str) -> ImportResult:
         result = ImportResult(self.doctype)
-        # Idempotency guard (see OpeningBalanceImporter): one aggregate submitted
-        # document, so re-running would double opening stock. Skip if one exists.
-        if self._existing_opening_stock():
-            result.skipped += 1
-            result.add_warning(
-                "Opening Stock",
-                "opening stock already posted for this company (an Opening Stock "
-                "reconciliation exists) - skipped to avoid double-counting. Cancel "
-                "the existing reconciliation first if you need to re-import.")
-            return result
         warehouse = self._default_warehouse()
         if not warehouse:
             result.add_error("Opening Stock", "no warehouse found to hold opening stock")
             return result
+
+        # Names reused across items would collide on ERPNext's global batch id, so
+        # scope exactly those per item - the same rule the Batch importer applied,
+        # computed from the same export so the batch_id we tag here matches the Batch
+        # that was actually created.
+        self._shared_batch_names = shared_batch_names(items)
 
         # Aggregate by (item_code, warehouse): a masters export can list the same
         # Stock Item more than once (Tally names are unique, so duplicate tags are
@@ -949,14 +954,51 @@ class StockOpeningImporter:
         if not rows:
             return result  # no opening stock to post
 
+        # A Stock Reconciliation rejects a non-stock item and that single bad row
+        # fails the WHOLE document - losing every item's opening stock. Tally carries
+        # opening quantities on service/non-stock ledgers too, so drop just those
+        # rows (with a warning) and let the genuine stock still post.
+        rows = self._drop_non_stock_rows(rows, items, result)
+        if not rows:
+            return result  # only non-stock items carried an opening quantity
+
+        # Per-item idempotency: skip rows whose (item, warehouse) was already posted
+        # by a prior run. Unlike a single aggregate document, chunked posting can be
+        # safely resumed - an interrupted run re-runs and completes the missing rows
+        # instead of either doubling stock or abandoning what never posted.
+        posted = self._posted_keys()
+        pending = [r for r in rows if (r["item_code"], r["warehouse"]) not in posted]
+        if not pending:
+            result.skipped += 1
+            result.add_warning(
+                "Opening Stock",
+                "opening stock already posted for every item with an opening "
+                "quantity - skipped to avoid double-counting.")
+            return result
+
         # Batch-tracked rows post through a Serial and Batch Bundle, which ERPNext
         # refuses to build unless Stock Settings > "Activate Serial and Batch No for
         # Item" is on (it is off by default). It is a hard prerequisite for batch
         # stock in ERPNext v15+, so enable it once when this import actually carries
         # batch rows, and record it on the log so the change is visible.
-        if any(r.get("use_serial_batch_fields") for r in rows):
+        if any(r.get("use_serial_batch_fields") for r in pending):
             self._ensure_serial_batch_enabled(result)
 
+        for i in range(0, len(pending), self._CHUNK):
+            chunk = pending[i:i + self._CHUNK]
+            if not self._post_doc(chunk, posting_date, result):
+                # The chunk failed as a unit - retry each row on its own so one bad
+                # row (e.g. an unforeseen validation) cannot cost the other ~100
+                # their opening stock. A 1-row doc also submits synchronously.
+                for row in chunk:
+                    self._post_doc([row], posting_date, result, isolate=True)
+        return result
+
+    def _post_doc(self, rows: list, posting_date: str, result: ImportResult,
+                  isolate: bool = False) -> bool:
+        """Insert + submit one Opening Stock reconciliation for ``rows``. Returns True
+        on success. On failure rolls back; when ``isolate`` (the row-by-row retry of a
+        failed chunk) the single bad row is recorded as an error so it is visible."""
         try:
             doc = frappe.get_doc({
                 "doctype": "Stock Reconciliation",
@@ -971,10 +1013,49 @@ class StockOpeningImporter:
             doc.submit()
             frappe.db.commit()
             result.add_created(doc.name)
+            return True
         except Exception as exc:
-            result.add_error("Opening Stock", exc)
             frappe.db.rollback()
-        return result
+            if isolate:
+                result.add_error(f"Opening Stock ({rows[0]['item_code']})", exc)
+            return False
+
+    def _posted_keys(self) -> set:
+        """(item_code, warehouse) pairs already carried by a submitted Opening Stock
+        reconciliation for this company - so a re-run skips them."""
+        rows = frappe.db.sql(
+            """select sri.item_code, sri.warehouse
+               from `tabStock Reconciliation Item` sri
+               inner join `tabStock Reconciliation` sr on sr.name = sri.parent
+               where sr.company = %s and sr.purpose = 'Opening Stock'
+                 and sr.docstatus = 1""",
+            self.company)
+        return {(code, wh) for code, wh in rows}
+
+    @staticmethod
+    def _drop_non_stock_rows(rows: list, items: list, result: ImportResult) -> list:
+        """Remove opening rows for items ERPNext does not stock-track. The non-stock
+        decision uses the very rule the Item importer applied (``TypeOfSupply`` =
+        Services -> non-stock), so it matches the ``is_stock_item`` ERPNext actually
+        stored - no DB round-trip - and a service ledger that carries an opening
+        quantity is dropped with a warning instead of failing the whole document."""
+        nonstock = {
+            safe_item_code(it["_name"]): it["_name"]
+            for it in items if not ItemImporter._is_stock_item(it)
+        }
+        if not nonstock:
+            return rows
+        kept = []
+        for r in rows:
+            name = nonstock.get(r["item_code"])
+            if name is None:
+                kept.append(r)
+            else:
+                result.add_warning(
+                    name, "opening stock not posted - this is a service / non-stock "
+                    "item in ERPNext, which cannot hold opening stock. Record its "
+                    "opening value as a ledger balance if it should carry one.")
+        return kept
 
     def _placements(self, it: dict, default_wh: str) -> list[tuple]:
         """Where this item's opening stock lands → list of
@@ -1121,7 +1202,14 @@ class StockOpeningImporter:
             # make_bundle_using_old_serial_batch_fields then builds the Bundle from
             # batch_no automatically. Without the flag the whole aggregate
             # reconciliation fails to submit and no opening stock posts at all.
-            row["batch_no"] = batch
+            #
+            # Use the same per-item-scoped batch id the Batch importer created: a
+            # name shared across items (a rate, or Tally's implicit "Primary Batch")
+            # is global in ERPNext, so without scoping the row would reference a
+            # Batch that belongs to a different item ("Batch X does not belong to
+            # Item Y") and fail.
+            row["batch_no"] = batch_id_for(
+                batch, code, getattr(self, "_shared_batch_names", set()))
             row["use_serial_batch_fields"] = 1
         if rate == 0:
             # ERPNext rejects a positive opening qty at a zero rate
@@ -1154,14 +1242,6 @@ class StockOpeningImporter:
             "enabled Stock Settings > 'Activate Serial and Batch No for Item' - it "
             "was off, and ERPNext requires it to post batch-tracked opening stock. "
             "Leave it on for batch/serial items to keep working.")
-
-    def _existing_opening_stock(self) -> bool:
-        """True when a non-cancelled Opening Stock reconciliation exists for the company."""
-        return bool(frappe.db.exists("Stock Reconciliation", {
-            "company": self.company,
-            "purpose": "Opening Stock",
-            "docstatus": ["<", 2],   # draft or submitted, not cancelled
-        }))
 
     def _default_warehouse(self) -> str:
         """A non-group warehouse to hold opening stock.

--- a/tally_migrator/erpnext/importers/party.py
+++ b/tally_migrator/erpnext/importers/party.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import importlib
+import re
 from collections import Counter
 from dataclasses import dataclass, field
 from functools import lru_cache
@@ -29,6 +30,12 @@ from tally_migrator.validation.engine import (
 )
 from .base import BaseImporter, ImportResult, atomic
 from .banks import _ensure_bank, _insert_bank_account
+
+
+# India Compliance's PAN format (income_tax_india): 5 letters, 4 digits, 1 letter.
+# Mirrored here so an invalid Tally INCOMETAXNumber can be dropped before it reaches
+# IC's validation and blocks the party - see PartyImporter._valid_pan.
+_PAN_NUMBER = re.compile(r"^[A-Z]{5}[0-9]{4}[A-Z]$")
 
 
 @lru_cache(maxsize=1)
@@ -381,6 +388,19 @@ class PartyImporter(BaseImporter):
             return {"gstin": gstin}
         return {}
 
+    def _valid_pan(self, raw) -> str:
+        """Tally's INCOMETAXNumber as an ERPNext PAN, but only if it is actually a
+        PAN. India Compliance validates the field against ^[A-Z]{5}[0-9]{4}[A-Z]$
+        and rejects the whole party on a mismatch - and Tally books routinely carry
+        a TAN, a typo, or plain digits in this field (e.g. '4870030501'). Storing
+        such a value is wrong data and, worse, loses the entire party. So normalise
+        (strip + upper) and keep it only when it matches the PAN format; otherwise
+        return blank, so the party imports cleanly without a bad PAN, exactly as an
+        invalid GSTIN falls back in _maybe_gstin. Mirrors IC's own regex rather than
+        importing it, so it degrades gracefully when IC is not installed."""
+        pan = (raw or "").strip().upper()
+        return pan if _PAN_NUMBER.match(pan) else ""
+
     def _resolve_payment_terms(self, tally_credit_period: str) -> str:
         """
         Tally stores a credit period as '30 Days' or '30'. The Customer/Supplier
@@ -595,7 +615,7 @@ class CustomerImporter(PartyImporter):
             "territory": DEFAULT_TERRITORY,
             "customer_type": "Company",
             "tax_id": record.get("GSTRegistrationNumber") or "",
-            "pan": record.get("INCOMETAXNumber") or "",
+            "pan": self._valid_pan(record.get("INCOMETAXNumber")),
             "gst_category": self._gst_category(record),
             "payment_terms": self._resolve_payment_terms(record.get("BillCreditPeriod")),
         }
@@ -623,7 +643,7 @@ class SupplierImporter(PartyImporter):
             "supplier_group": self._resolve_group(record),
             "supplier_type": "Company",
             "tax_id": record.get("GSTRegistrationNumber") or "",
-            "pan": record.get("INCOMETAXNumber") or "",
+            "pan": self._valid_pan(record.get("INCOMETAXNumber")),
             "gst_category": self._gst_category(record),
             "payment_terms": self._resolve_payment_terms(record.get("BillCreditPeriod")),
         }

--- a/tally_migrator/erpnext/importers/party.py
+++ b/tally_migrator/erpnext/importers/party.py
@@ -1,6 +1,7 @@
 """Party importers: Customer and Supplier (shared address / payment-term handling)."""
 
 import contextlib
+import importlib
 from collections import Counter
 from dataclasses import dataclass, field
 from functools import lru_cache
@@ -77,6 +78,52 @@ def _gravatar_lookup_suspended():
         _contact_mod.has_gravatar = original
 
 
+# ── Per-contact integration hooks suspended for the party phase ─────────────────
+# Beyond gravatar, Frappe/ERPNext fire Contact doc-event hooks on every insert that
+# do nothing for a migration but cost a DB round-trip each - and, if the integration
+# is configured, a per-contact NETWORK call (the same class of cost gravatar had). On
+# a real book (tens of thousands of contacts) that is pure overhead, and it dominates
+# on Frappe Cloud where every round-trip carries network latency. We neutralise just
+# these named handlers for the party phase; the contact still saves identically, it is
+# simply not pushed to Google or back-linked to call logs - neither of which a
+# migration ever wants to do per record. The handlers are resolved by dotted path at
+# event time (frappe.get_attr), so replacing the function on its own module is seen.
+_SUSPENDED_PARTY_HOOKS = (
+    # Push every new/updated Contact up to the user's Google account. Never wanted
+    # mid-migration: it would sync 10k+ contacts and hit Google's API rate limits.
+    ("frappe.integrations.doctype.google_contacts.google_contacts",
+     ("insert_contacts_to_google_contacts", "update_contacts_to_google_contacts")),
+    # Back-link a new Contact to historical Call Logs by phone match - a JOIN scan
+    # per contact. A cosmetic telephony convenience, re-derivable; irrelevant here.
+    ("erpnext.telephony.doctype.call_log.call_log",
+     ("link_existing_conversations",)),
+)
+
+
+@contextlib.contextmanager
+def _party_side_effect_hooks_suspended():
+    """Neutralise the per-contact Google-Contacts sync and Call-Log linking hooks for
+    the duration of the party phase, then restore them. No-op-safe: a module or symbol
+    that is not installed is skipped, leaving Frappe/ERPNext untouched. Migrations are
+    serialised by the single-active-run guard, so the process-local patch can never
+    bleed into a concurrent migration (same contract as _gravatar_lookup_suspended)."""
+    saved = []
+    for module_path, names in _SUSPENDED_PARTY_HOOKS:
+        try:
+            mod = importlib.import_module(module_path)
+        except Exception:
+            continue
+        for nm in names:
+            if hasattr(mod, nm):
+                saved.append((mod, nm, getattr(mod, nm)))
+                setattr(mod, nm, lambda *a, **k: None)
+    try:
+        yield
+    finally:
+        for mod, nm, fn in saved:
+            setattr(mod, nm, fn)
+
+
 # ── Party importers (Customer / Supplier) ──────────────────────────────────────
 
 class PartyImporter(BaseImporter):
@@ -96,10 +143,12 @@ class PartyImporter(BaseImporter):
     default_group: str = ""        # fallback when Tally carries no usable group
 
     def run(self, records: list[dict], on_progress=None) -> "ImportResult":
-        """Import parties with the per-contact gravatar network lookup suspended -
-        the dominant, data-irrelevant cost of the phase (see
-        ``_gravatar_lookup_suspended``). Everything else is the standard template."""
-        with _gravatar_lookup_suspended():
+        """Import parties with the per-contact integration hooks suspended - the
+        gravatar network lookup plus the Google-Contacts sync and Call-Log linking
+        hooks, all data-irrelevant per-record cost of the phase (see
+        ``_gravatar_lookup_suspended`` / ``_party_side_effect_hooks_suspended``).
+        Everything else is the standard template."""
+        with _gravatar_lookup_suspended(), _party_side_effect_hooks_suspended():
             return super().run(records, on_progress=on_progress)
 
     def before_run(self, records: list[dict], result: "ImportResult") -> None:

--- a/tally_migrator/erpnext/importers/party.py
+++ b/tally_migrator/erpnext/importers/party.py
@@ -3,8 +3,10 @@
 import contextlib
 from collections import Counter
 from dataclasses import dataclass, field
+from functools import lru_cache
 
 import frappe
+from frappe.utils import validate_email_address
 
 from tally_migrator.tally.mappings import (
     UOM_MAP,
@@ -26,6 +28,20 @@ from tally_migrator.validation.engine import (
 )
 from .base import BaseImporter, ImportResult, atomic
 from .banks import _ensure_bank, _insert_bank_account
+
+
+@lru_cache(maxsize=1)
+def _address_requires_state() -> bool:
+    """Whether a stateless Indian Address is rejected on this site. India Compliance
+    adds the ``gst_state`` field and a validate hook that makes ``state`` mandatory
+    for an Indian address; without IC, ERPNext core saves a stateless address fine.
+    So the importer should only pre-skip a no-state address when IC is enforcing -
+    otherwise it would drop addresses that would have imported. Cached: the installed
+    app set does not change within a run."""
+    try:
+        return bool(frappe.get_meta("Address").has_field("gst_state"))
+    except Exception:
+        return False
 
 # ── Gravatar lookup suspension ─────────────────────────────────────────────────
 # Frappe's Contact.validate fills a blank avatar by calling has_gravatar(email),
@@ -339,6 +355,19 @@ class PartyImporter(BaseImporter):
         raw_address = (data.get("Address") or "").strip()
         if not raw_address:
             return ""
+        state = self._resolve_state(data)
+        country = (data.get("CountryName") or "").strip() or self.company_country
+        # India Compliance hard-requires a state on an Indian address. When Tally
+        # gave us nothing to derive one from (no ledger state, valid GSTIN or PIN),
+        # the insert is certain to fail - so skip it with a single warning rather
+        # than attempt a doomed insert that rolls back and floods the Error Log on a
+        # large import. Only when IC is actually enforcing the rule (without it, core
+        # saves a stateless address). Anything with a derivable state imports below.
+        if country == "India" and not state and _address_requires_state():
+            result.add_warning(
+                link_name, "address not created - the Tally data has no state "
+                "(add a state, GSTIN or PIN code in Tally, then re-import)")
+            return ""
         _msg_mark = None   # message-queue length, set just before insert (see below)
         try:
             addr = frappe.new_doc("Address")
@@ -350,11 +379,15 @@ class PartyImporter(BaseImporter):
             # otherwise a clear placeholder - never the PIN, which only looked like a
             # city and produced visibly wrong addresses.
             addr.city = (data.get("City") or "").strip() or "Not Specified"
-            addr.state = self._resolve_state(data)
-            addr.country = (data.get("CountryName") or "").strip() or self.company_country
+            addr.state = state
+            addr.country = country
             addr.pincode = data.get("PinCode") or ""
             addr.phone = data.get("LedgerPhone") or data.get("LedgerMobile") or ""
-            addr.email_id = data.get("LedgerEmail") or ""
+            # A malformed email (Tally holds plenty: "NA", "n/a", "x@") makes ERPNext
+            # reject the whole address. Run it through the same validator ERPNext uses
+            # and drop just the bad email, so the address still imports.
+            addr.email_id = validate_email_address(
+                (data.get("LedgerEmail") or "").strip(), throw=False)
             # Only set a structurally valid GSTIN: India Compliance validates the
             # address GSTIN and rejects the whole address on a malformed one, which
             # would lose the address entirely. A bad GSTIN is already flagged by the
@@ -405,19 +438,22 @@ class PartyImporter(BaseImporter):
             result.add_warning(link_name, f"address not created: {exc}")
             return ""
 
-    @staticmethod
-    def _resolve_state(data: dict) -> str:
-        """The party's ERPNext state. Prefer Tally's ledger state; when it's blank
-        but the party has a structurally valid GSTIN, derive the state from the
-        GSTIN's state code - the same fallback the pre-flight check assumes, so a
-        registered party never lands with an empty (and GST-breaking) state."""
+    def _resolve_state(self, data: dict) -> str:
+        """The party's ERPNext state, most-reliable signal first: Tally's ledger
+        state, else a structurally valid GSTIN's state code, else derived from the
+        party's PIN code (India Compliance's pincode<->state map). Tally does not
+        mandate a ledger state so most exports omit it, but a PIN is common and
+        yields an IC-valid state - so the address is kept rather than dropped on
+        India Compliance's missing-state rule."""
         state = TALLY_STATE_MAP.get((data.get("LedgerState") or "").strip(), "")
         if state:
             return state
         gstin = (data.get("GSTRegistrationNumber") or "").strip().upper()
         if gstin and validate_gstin(gstin)[0]:
-            return GSTIN_STATE_CODES.get(gstin[:2], "")
-        return ""
+            derived = GSTIN_STATE_CODES.get(gstin[:2], "")
+            if derived:
+                return derived
+        return self._state_from_pincode((data.get("PinCode") or "").strip())
 
     def _save_contact(self, link_name: str, link_type: str, data: dict,
                       result: "ImportResult") -> str:
@@ -432,8 +468,14 @@ class PartyImporter(BaseImporter):
         visible in the migration log rather than lost silently."""
         phone = (data.get("LedgerPhone") or "").strip()
         mobile = (data.get("LedgerMobile") or "").strip()
-        email = (data.get("LedgerEmail") or "").strip()
-        email_cc = (data.get("EmailCC") or "").strip()
+        # Validate emails up front (the same validator ERPNext's Contact uses) and
+        # drop a malformed one - Tally holds plenty ("NA", "n/a", "x@") and a single
+        # bad email would otherwise reject the whole contact. Warn so the drop shows.
+        raw_email = (data.get("LedgerEmail") or "").strip()
+        email = validate_email_address(raw_email, throw=False)
+        email_cc = validate_email_address((data.get("EmailCC") or "").strip(), throw=False)
+        if raw_email and not email:
+            result.add_warning(link_name, "contact email skipped - not a valid email address")
         if not (phone or mobile or email or email_cc):
             return ""
         try:

--- a/tally_migrator/migration/master_migrator.py
+++ b/tally_migrator/migration/master_migrator.py
@@ -524,7 +524,9 @@ class MasterMigrator:
             except Exception as exc2:
                 frappe.log_error(f"Migration log status fallback failed: {exc2}", "Tally Migrator")
 
-        # 2. Enrichment - best-effort, must never revert the terminal state above.
+        # 2a. Reports - the records-created manifest, reconciliation and audit fields.
+        # Saved on their own so a failure writing the issues table (2b) below cannot
+        # also lose these. Best-effort, must never revert the terminal state above.
         try:
             self.log.reload()
             self.log.extracted_counts = frappe.as_json(
@@ -534,15 +536,25 @@ class MasterMigrator:
             self._track_wizard_uoms(manifest)
             self.log.created_records = frappe.as_json(manifest)
             self.log.reconciliation_report = frappe.as_json(self._reconciliation(masters, coa))
+            self.log.save(ignore_permissions=True)
+            frappe.db.commit()
+        except Exception as exc:
+            frappe.log_error(f"Migration log reports failed: {exc}", "Tally Migrator")
+
+        # 2b. Issues table - the per-record failures/drops. Kept as its own write
+        # because it is the one most likely to hit a row-level limit on a big run; a
+        # failure here must not take the reports (2a) down with it.
+        try:
+            self.log.reload()
             self.log.set("errors", [])
             if summary.has_errors or summary.has_warnings:
                 self.log.error_log = summary.error_lines()
                 for row in summary.error_records():
                     self.log.append("errors", row)
-            self.log.save(ignore_permissions=True)
-            frappe.db.commit()
+                self.log.save(ignore_permissions=True)
+                frappe.db.commit()
         except Exception as exc:
-            frappe.log_error(f"Migration log enrichment failed: {exc}", "Tally Migrator")
+            frappe.log_error(f"Migration log issues table failed: {exc}", "Tally Migrator")
 
     def _track_wizard_uoms(self, manifest: dict) -> None:
         """Fold the pre-flight "create as new" UOMs into the manifest's Units entry so

--- a/tally_migrator/naming.py
+++ b/tally_migrator/naming.py
@@ -5,6 +5,9 @@ Single authority so that validation (collision detection) and import compute the
 the importer is actually going to create.
 """
 
+import hashlib
+from collections import defaultdict
+
 
 def safe_item_code(name: str) -> str:
     """ERPNext item_code caps at 140 chars and dislikes '/'."""
@@ -18,3 +21,42 @@ def company_scoped(base: str, abbr: str) -> str:
     base = (base or "").strip()
     abbr = (abbr or "").strip()
     return f"{base} - {abbr}" if abbr else base
+
+
+def shared_batch_names(items: list) -> set:
+    """Tally batch names used by more than one batch-tracked item in this export.
+
+    ERPNext batch ids are global, but Tally batch names are per-item - so the same
+    name on two items (a rate like '169.49', or Tally's implicit 'Primary Batch')
+    would collide on a single global Batch. Identifying the shared names lets the
+    Batch importer and the opening-stock importer scope exactly those ids per item
+    and, computing from the same export, agree on the result.
+    """
+    by_name = defaultdict(set)
+    for it in items or []:
+        if (it.get("IsBatchWiseOn") or "").strip().lower() != "yes":
+            continue
+        code = safe_item_code(it.get("_name", ""))
+        for g in (it.get("GodownOpenings") or []):
+            batch = (g.get("batch") or "").strip()
+            if batch:
+                by_name[batch].add(code)
+    return {batch for batch, codes in by_name.items() if len(codes) > 1}
+
+
+def batch_id_for(tally_batch: str, item_code: str, shared: set) -> str:
+    """The ERPNext ``batch_id`` to use for a Tally batch on a given item.
+
+    A name shared across items is scoped to the item (``"<batch> - <item_code>"``)
+    so each item gets its own Batch; a unique name is kept verbatim. Capped at 140
+    chars (``Batch.batch_id`` is Data), preserving uniqueness with a short hash when
+    the scoped id would overflow.
+    """
+    batch = (tally_batch or "").strip()
+    if not batch or batch not in (shared or set()):
+        return batch
+    scoped = f"{batch} - {item_code}"
+    if len(scoped) <= 140:
+        return scoped
+    digest = hashlib.md5(scoped.encode("utf-8")).hexdigest()[:8]
+    return scoped[:131] + "-" + digest

--- a/tally_migrator/tally_migration/doctype/tally_migration_error/tally_migration_error.json
+++ b/tally_migrator/tally_migration/doctype/tally_migration_error/tally_migration_error.json
@@ -9,7 +9,7 @@
   "fields": [
     {
       "fieldname": "record_name",
-      "fieldtype": "Data",
+      "fieldtype": "Small Text",
       "label": "Record",
       "in_list_view": 1,
       "columns": 3,

--- a/tally_migrator/tally_migration/doctype/tally_migration_log/tally_migration_log.js
+++ b/tally_migrator/tally_migration/doctype/tally_migration_log/tally_migration_log.js
@@ -1001,15 +1001,26 @@ function render_summary(frm) {
 	const esc = frappe.utils.escape_html;
 	let totalCreated = 0,
 		totalSkipped = 0,
+		totalWarned = 0,
 		totalFailed = 0;
+
+	// A warned record still imported (the warning is about dependent data that was
+	// dropped), so warnings overlap the "Imported" count and are NOT a slice of the
+	// bar - they get their own column instead, mirroring the wizard's results table.
+	const warnCell = (warned) =>
+		warned
+			? `<span style="display:inline-flex; align-items:center; gap:4px; justify-content:flex-end;">${statusIcon("info")}<strong>${warned}</strong></span>`
+			: warned;
 
 	const rows = entries
 		.map(([label, r]) => {
 			const created = r.created || 0;
 			const skipped = r.skipped || 0;
+			const warned = r.warned || 0;
 			const failed = r.failed || 0;
 			totalCreated += created;
 			totalSkipped += skipped;
+			totalWarned += warned;
 			totalFailed += failed;
 			const total = created + skipped + failed || 1;
 			const pct = (n) => (n / total) * 100;
@@ -1027,6 +1038,10 @@ function render_summary(frm) {
 					<td style="width:45%; vertical-align:middle;">${bar}</td>
 					<td class="text-right text-success" style="vertical-align:middle;">${created}</td>
 					<td class="text-right text-muted" style="vertical-align:middle;">${skipped}</td>
+					<td class="text-right ${warned ? "" : "text-muted"}" style="vertical-align:middle;"
+						${warned ? `title="${warned} warning${warned === 1 ? "" : "s"} - record imported, some detail dropped"` : ""}>
+						${warnCell(warned)}
+					</td>
 					<td class="text-right ${failed ? "text-danger" : "text-muted"}" style="vertical-align:middle;">
 						${failed ? `<strong>${failed}</strong>` : failed}
 					</td>
@@ -1049,6 +1064,7 @@ function render_summary(frm) {
 						<th style="border-top:0;"></th>
 						<th style="border-top:0;" class="text-right">Imported</th>
 						<th style="border-top:0;" class="text-right">Already there</th>
+						<th style="border-top:0;" class="text-right">Warnings</th>
 						<th style="border-top:0;" class="text-right">Failed</th>
 					</tr>
 				</thead>
@@ -1059,6 +1075,9 @@ function render_summary(frm) {
 						<td></td>
 						<td class="text-right text-success"><strong>${totalCreated}</strong></td>
 						<td class="text-right text-muted">${totalSkipped}</td>
+						<td class="text-right ${totalWarned ? "" : "text-muted"}">
+							${totalWarned ? `<strong>${totalWarned}</strong>` : totalWarned}
+						</td>
 						<td class="text-right ${totalFailed ? "text-danger" : "text-muted"}">
 							${totalFailed ? `<strong>${totalFailed}</strong>` : totalFailed}
 						</td>
@@ -1069,6 +1088,9 @@ function render_summary(frm) {
 				${legendItem(BAR_CREATED, "Imported (new)")}
 				${legendItem(BAR_SKIPPED, "Already there (skipped, safe)")}
 				${legendItem(BAR_FAILED, "Failed")}
+			</div>
+			<div class="text-muted small" style="margin-top:6px;">
+				Warnings count records that imported but had some detail dropped - see the issues table below.
 			</div>
 		</div>
 	`));

--- a/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
+++ b/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
@@ -2228,6 +2228,11 @@ class TallyMigratorPage {
 				});
 				return;
 			}
+			// The run is complete. finishFromLog can win the race against the server's
+			// final 100% "Migration complete." progress event, so set the caption here
+			// explicitly - otherwise it stays on the stale 95% "Saving migration log..."
+			// text under a full bar.
+			$("#progress-desc").text("Migration complete.");
 			let summary = {};
 			try {
 				summary = JSON.parse(doc.import_summary || "{}");

--- a/tally_migrator/tests/test_bank_commit_batching.py
+++ b/tally_migrator/tests/test_bank_commit_batching.py
@@ -48,6 +48,7 @@ class TestBankHelpersCommitOnlyForCompany(unittest.TestCase):
         with mock.patch.object(banks, "atomic", _noop_atomic), \
                 mock.patch.object(banks, "frappe") as fr:
             fr.new_doc.return_value = fake
+            fr.db.exists.return_value = False   # bank account name is free (no collision)
             out = banks._insert_bank_account(
                 account_name="Acme", bank="HDFC Bank", account_no="123",
                 ifsc="HDFC0000001", result=res, warn_name="Acme",
@@ -66,6 +67,41 @@ class TestBankHelpersCommitOnlyForCompany(unittest.TestCase):
         out, commit = self._call_insert(is_company=False)
         self.assertEqual(out, "BA-0001")
         commit.assert_not_called()
+
+
+class TestUniqueBankAccountName(unittest.TestCase):
+    """Tally repeats one holder name across several bank ledgers of a company; since
+    ERPNext names a Bank Account 'account_name - bank', they would collide and all but
+    the first drop. _unique_bank_account_name disambiguates so each keeps its details."""
+
+    def test_returns_base_when_name_free(self):
+        with mock.patch.object(banks, "frappe") as fr:
+            fr.db.exists.return_value = False
+            self.assertEqual(
+                banks._unique_bank_account_name("ICONCEPT", "HDFC Bank", "2250"),
+                "ICONCEPT")
+
+    def test_appends_account_no_when_holder_taken(self):
+        # base name collides; the variant with the account number is free.
+        with mock.patch.object(banks, "frappe") as fr:
+            fr.db.exists.side_effect = lambda dt, name: name == "ICONCEPT - HDFC Bank"
+            self.assertEqual(
+                banks._unique_bank_account_name("ICONCEPT", "HDFC Bank", "2250"),
+                "ICONCEPT (2250)")
+
+    def test_numeric_suffix_when_no_account_no(self):
+        # base collides and there is no account number to disambiguate with.
+        taken = {"ICONCEPT - HDFC Bank", "ICONCEPT 2 - HDFC Bank"}
+        with mock.patch.object(banks, "frappe") as fr:
+            fr.db.exists.side_effect = lambda dt, name: name in taken
+            self.assertEqual(
+                banks._unique_bank_account_name("ICONCEPT", "HDFC Bank", ""),
+                "ICONCEPT 3")
+
+    def test_blank_holder_returned_unchanged(self):
+        with mock.patch.object(banks, "frappe") as fr:
+            fr.db.exists.return_value = False
+            self.assertEqual(banks._unique_bank_account_name("", "HDFC Bank", ""), "")
 
 
 if __name__ == "__main__":

--- a/tally_migrator/tests/test_critical_fixes.py
+++ b/tally_migrator/tests/test_critical_fixes.py
@@ -97,7 +97,7 @@ class TestOpeningBalanceGuards(unittest.TestCase):
         acc = _node("Cash", None)
         acc.opening_balance, acc.is_group, acc.opening_dr_cr = 5000.0, 0, "Dr"
         acc.root_type = "Asset"
-        with mock.patch("frappe.db.exists", return_value=True):
+        with mock.patch("frappe.db.get_value", return_value=0):  # exists, is_group=0
             lines = imp._account_lines([acc], result)
         self.assertEqual(len(lines), 1)
         self.assertEqual(result.warned, 0)
@@ -161,11 +161,22 @@ class TestPLOpeningSkipped(unittest.TestCase):
 
     def test_balance_sheet_line_posts_without_cost_center(self):
         imp, result = self._imp(), ImportResult("Journal Entry")
-        with mock.patch("frappe.db") as db:
-            db.exists.return_value = True
+        with mock.patch("frappe.db.get_value", return_value=0):  # exists, is_group=0
             lines = imp._account_lines([self._ledger("Asset")], result)
         self.assertEqual(len(lines), 1)
         self.assertNotIn("cost_center", lines[0])
+
+    def test_group_account_line_skipped_with_warning(self):
+        # An account that resolved to a GROUP in ERPNext (e.g. a Tally ledger promoted
+        # so its sub-accounts could nest) cannot carry a balance and would fail the
+        # whole class batch on submit, so it must be skipped with a warning.
+        imp, result = self._imp(), ImportResult("Journal Entry")
+        with mock.patch("frappe.db.get_value", return_value=1):  # exists, but is_group=1
+            lines = imp._account_lines([self._ledger("Asset")], result)
+        self.assertEqual(lines, [])
+        self.assertEqual(result.warned, 1)
+        self.assertEqual(result.failed, 0)
+        self.assertIn("group account", result.warnings[0]["reason"])
 
 
 class TestOpeningConcurrencyLock(unittest.TestCase):

--- a/tally_migrator/tests/test_critical_fixes.py
+++ b/tally_migrator/tests/test_critical_fixes.py
@@ -127,6 +127,44 @@ class TestOpeningBalanceGuards(unittest.TestCase):
         self.assertEqual(result.warned, 0)
 
 
+class TestOpeningEntrySubmitsSynchronously(unittest.TestCase):
+    """The opening Journal Entry must post its GL synchronously. ERPNext's
+    JournalEntry.submit() enqueues a BACKGROUND job when the entry has > 100
+    accounts (the asset Opening Entry routinely does); that returns before the GL
+    is posted, so on a long single-worker run the GL lands only after the migration
+    finalizes - and the post-import trial balance then reads a whole account class
+    as absent. _post_batch must therefore call doc._submit() (the same synchronous
+    path submit() takes for <=100 rows), never the size-gated submit()."""
+
+    def _imp(self):
+        return OpeningBalanceImporter(company="_T Co", abbr="TC")
+
+    def test_post_batch_calls_underlying_submit_not_gated_submit(self):
+        imp = self._imp()
+        result = ImportResult("Journal Entry")
+        calls = []
+
+        class _FakeJE:
+            name = "ACC-JV-0001"
+            def insert(self, *a, **k):
+                calls.append("insert")
+            def submit(self):                 # the size-gated one - must NOT run
+                calls.append("submit")
+            def _submit(self):                # the synchronous one - must run
+                calls.append("_submit")
+
+        lines = [{"account": "Cash - TC", "debit_in_account_currency": 100.0,
+                  "credit_in_account_currency": 0.0}]
+        with mock.patch.object(imp, "_balance"), \
+                mock.patch("frappe.get_doc", return_value=_FakeJE()), \
+                mock.patch("frappe.db.commit"):
+            imp._post_batch("Asset", lines, "2026-01-01", result)
+
+        self.assertIn("_submit", calls)
+        self.assertNotIn("submit", calls)        # never the background-gated path
+        self.assertEqual(result.created_names, ["ACC-JV-0001"])
+
+
 class TestPLOpeningSkipped(unittest.TestCase):
     """ERPNext forbids an Income/Expense (P&L) account from carrying an opening balance
     (GL Entry.check_pl_account throws in an Opening Entry), so the importer must skip
@@ -429,9 +467,22 @@ class TestPartyOpeningClassification(unittest.TestCase):
     def test_supplier_dr_is_advance(self):
         self.assertEqual(self._c("Supplier", 5000), "advance")     # advance paid
 
-    def test_advance_flag_forces_advance_on_natural_side(self):
-        # A customer Dr bill is normally an invoice, but Tally's ISADVANCE wins.
-        self.assertEqual(self._c("Customer", 5000, is_advance=True), "advance")
+    def test_natural_side_bill_is_invoice_even_when_flagged_advance(self):
+        # A bill on the party's natural side is an outstanding balance and must post
+        # there, even if Tally tags it ISADVANCE. Forcing it to an advance posted an
+        # opposite-direction Payment Entry that flipped the sign, so an offsetting
+        # Cr+Dr pair (net zero in Tally) posted as a non-zero balance. Classify by
+        # side only - ISADVANCE never moves a balance to the wrong side.
+        self.assertEqual(self._c("Customer", 5000, is_advance=True), "invoice")
+        self.assertEqual(self._c("Supplier", -5000, is_advance=True), "invoice")
+
+    def test_opposite_side_stays_advance_with_or_without_flag(self):
+        # Genuine advances sit on the opposite side and still route to a Payment Entry
+        # whether or not ISADVANCE is set - their sign was already correct.
+        self.assertEqual(self._c("Supplier", 5000, is_advance=True), "advance")
+        self.assertEqual(self._c("Supplier", 5000, is_advance=False), "advance")
+        self.assertEqual(self._c("Customer", -5000, is_advance=True), "advance")
+        self.assertEqual(self._c("Customer", -5000, is_advance=False), "advance")
 
     def test_signed_dr_positive(self):
         self.assertEqual(PartyOpeningImporter._signed(100.0, "Dr"), 100.0)

--- a/tally_migrator/tests/test_finalize_terminal_status.py
+++ b/tally_migrator/tests/test_finalize_terminal_status.py
@@ -75,6 +75,23 @@ class TestFinalizeTerminalStatus(unittest.TestCase):
 
     @mock.patch("frappe.db")
     @mock.patch("frappe.log_error")
+    def test_reports_persist_when_issues_table_fails(self, _log_err, _db):
+        # A failure writing the issues table (2b) - e.g. a row-level length limit on a
+        # big run - must not also lose the records-created / reconciliation reports (2a).
+        log = _FakeLog()
+        m = self._migrator(log)
+        m._reconciliation = lambda *a: {"rows": []}
+        m._track_wizard_uoms = lambda *a: None
+        masters, coa = self._masters_coa()
+        summary = _summary(has_errors=True)
+        summary.error_records = mock.Mock(side_effect=RuntimeError("row too long"))
+        m._finalize_log(masters, coa, summary)
+        self.assertEqual(log.status, "Completed with Errors")
+        self.assertIsNotNone(log.created_records)        # 2a survived
+        self.assertIsNotNone(log.reconciliation_report)  # 2a survived
+
+    @mock.patch("frappe.db")
+    @mock.patch("frappe.log_error")
     def test_status_reflects_errors(self, _log_err, _db):
         log = _FakeLog()
         m = self._migrator(log)

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -1573,3 +1573,45 @@ class TestERPNextImporter(unittest.TestCase):
         imp._warn_residual(
             [{"debit_in_account_currency": 0.4, "credit_in_account_currency": 0.0}], tiny)
         self.assertEqual(tiny.warned, 0)   # below PLUG_NOISE_THRESHOLD
+
+
+class TestPartyPanSanitisation(unittest.TestCase):
+    """Tally's INCOMETAXNumber lands in the party PAN field, but India Compliance
+    validates PAN as ^[A-Z]{5}[0-9]{4}[A-Z]$ and rejects the whole party on a
+    mismatch. Real books carry a TAN, a typo, or plain digits there (e.g.
+    '4870030501'), which previously failed creation and lost the party. The
+    importer must keep a valid PAN and silently blank an invalid one, so the party
+    always imports - same fallback as an invalid GSTIN."""
+
+    def _imp(self):
+        from tally_migrator.erpnext.importers import SupplierImporter
+        return SupplierImporter("_TMTest Co", "TC")
+
+    def test_valid_pan_kept(self):
+        self.assertEqual(self._imp()._valid_pan("AAACT2727Q"), "AAACT2727Q")
+
+    def test_valid_pan_normalised(self):
+        # lowercase + surrounding whitespace still recognised
+        self.assertEqual(self._imp()._valid_pan("  aaact2727q  "), "AAACT2727Q")
+
+    def test_invalid_pan_blanked(self):
+        # the Brightpoint case: 10 digits, no letters -> not a PAN
+        self.assertEqual(self._imp()._valid_pan("4870030501"), "")
+
+    def test_partial_or_garbage_blanked(self):
+        for bad in ("AAACT2727", "AAACT2727QQ", "12345ABCDZ", "ABCDE12345", "", None):
+            self.assertEqual(self._imp()._valid_pan(bad), "",
+                             msg="should reject %r" % (bad,))
+
+    def test_build_doc_drops_invalid_pan_but_keeps_party(self):
+        imp = self._imp()
+        doc = imp.build_doc({"_name": "_TMTest Brightpoint",
+                             "INCOMETAXNumber": "4870030501"})
+        self.assertEqual(doc["supplier_name"], "_TMTest Brightpoint")
+        self.assertEqual(doc["pan"], "")     # bad PAN dropped, party still builds
+
+    def test_build_doc_keeps_valid_pan(self):
+        imp = self._imp()
+        doc = imp.build_doc({"_name": "_TMTest Good",
+                             "INCOMETAXNumber": "AAACT2727Q"})
+        self.assertEqual(doc["pan"], "AAACT2727Q")

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -557,14 +557,15 @@ class TestERPNextImporter(unittest.TestCase):
         self.assertEqual(
             frappe.db.get_value("Warehouse", f"_TMTest Child WH - {abbr}", "is_group"), 0)
 
-    def test_account_group_promotes_colliding_ledger(self):
-        """A Tally custom group whose name collides (case-insensitively) with an
-        existing ledger must promote that ledger to a group so its children nest.
+    def test_colliding_group_keeps_ledger_and_rehomes_children(self):
+        """When a Tally group's name collides (case-insensitively) with an existing
+        ledger, the importer must NOT convert that ledger - it may be load-bearing
+        (e.g. India Compliance wires "TDS Payable" into every Tax Withholding
+        Category). The ledger stays a ledger, and the Tally group's children are
+        re-homed to the ledger's own parent so they still import.
 
-        Regression for the Frontier failures where a Tally group ("OFFICE EQUIPMENT")
-        collided with a standard-CoA Fixed-Asset *ledger* ("Office Equipment"): the
-        importer skipped the group, leaving a ledger, and every child failed with
-        "Parent account ... can not be a ledger"."""
+        Regression for the Frontier issue where promoting a standard ledger to a group
+        broke its opening entry and IC's tax-withholding setup."""
         require_company()
         from tally_migrator.erpnext.importers.accounts import AccountImporter
         from tally_migrator.tally.extractors import AccountNode
@@ -574,12 +575,10 @@ class TestERPNextImporter(unittest.TestCase):
             "Account", {"company": self.company, "root_type": "Asset",
                         "is_group": 1, "parent_account": ["is", "not set"]}, "name")
         placeholder = f"_TMTest Equip - {abbr}"
-        # Reset any state left by a prior run so the promotion path is always exercised
-        # (child first - a group with children can't be deleted).
         for nm in (f"_TMTest Camera - {abbr}", placeholder):
             if frappe.db.exists("Account", nm):
                 frappe.delete_doc("Account", nm, force=True, ignore_permissions=True)
-        # A pre-existing typed ledger placeholder, like ERPNext's standard CoA ships.
+        # A pre-existing typed ledger (like ERPNext's standard CoA ships), under root.
         frappe.get_doc({
             "doctype": "Account", "account_name": "_TMTest Equip",
             "company": self.company, "parent_account": root,
@@ -588,7 +587,7 @@ class TestERPNextImporter(unittest.TestCase):
 
         imp = AccountImporter(self.company, abbr, mode="reuse")
         # Same name in a different case (the collision is case-insensitive in MariaDB),
-        # plus a child ledger that can only be created if the parent becomes a group.
+        # plus a child that previously could only be created by promoting the ledger.
         group = AccountNode(name="_TMTEST EQUIP", parent="", is_group=True,
                             root_type="Asset", account_type="", is_reserved=False)
         child = AccountNode(name="_TMTest Camera", parent="_TMTEST EQUIP",
@@ -597,13 +596,18 @@ class TestERPNextImporter(unittest.TestCase):
         result = imp.run([group, child])
 
         self.assertEqual(result.failed, 0, msg=str(result.errors))
+        # The colliding ledger is LEFT a ledger - never converted.
         self.assertEqual(
-            frappe.db.get_value("Account", placeholder, "is_group"), 1,
-            "the colliding ledger should have been promoted to a group")
-        self.assertTrue(frappe.db.exists("Account", f"_TMTest Camera - {abbr}"),
-                        "the child must be created once its parent is a group")
-        self.assertTrue(any("converted it to a group" in w["reason"]
-                            for w in result.warnings))
+            frappe.db.get_value("Account", placeholder, "is_group"), 0,
+            "the colliding standard ledger must NOT be converted to a group")
+        # The child still imports, re-homed under the ledger's own parent (root here).
+        child_name = f"_TMTest Camera - {abbr}"
+        self.assertTrue(frappe.db.exists("Account", child_name),
+                        "the child must still be created")
+        self.assertEqual(
+            frappe.db.get_value("Account", child_name, "parent_account"), root,
+            "the child must nest under the existing ledger's parent")
+        self.assertTrue(any("kept as a ledger" in w["reason"] for w in result.warnings))
 
     # ── Stock Groups → nested Item Groups ───────────────────────────────────────
 

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -1049,6 +1049,35 @@ class TestERPNextImporter(unittest.TestCase):
         self.assertNotIn(grp, accounts, "the group account must be skipped")
         self.assertTrue(any("group account" in w["reason"] for w in res.warnings))
 
+    def test_accounting_dimensions_cached_memoises_and_restores(self):
+        """The opening-stock phase memoises ERPNext's per-item get_accounting_dimensions
+        (a company-wide constant) to cut a DB round-trip per item, then restores it.
+        The wrapper must hit the underlying lookup once, return a fresh copy each call
+        (so a mutating caller can't corrupt the cache), and restore the original."""
+        from tally_migrator.erpnext.importers import openings
+        from erpnext.accounts.doctype.accounting_dimension import accounting_dimension as ad
+
+        calls = {"n": 0}
+
+        def spy(as_list=True):
+            calls["n"] += 1
+            return ["dim_a"]
+
+        original = ad.get_accounting_dimensions
+        ad.get_accounting_dimensions = spy
+        try:
+            with openings._accounting_dimensions_cached():
+                r1 = ad.get_accounting_dimensions()
+                r2 = ad.get_accounting_dimensions()
+                r3 = ad.get_accounting_dimensions()
+            self.assertEqual(calls["n"], 1, "the underlying lookup should run once")
+            self.assertEqual(r1, ["dim_a"])
+            self.assertIsNot(r1, r2, "each call should return a fresh copy")
+            self.assertEqual(r3, ["dim_a"])
+            self.assertIs(ad.get_accounting_dimensions, spy, "must restore on exit")
+        finally:
+            ad.get_accounting_dimensions = original
+
     def test_batch_label_roundtrips_through_remark(self):
         """The label written to user_remark must parse back to the same label, and a
         foreign remark must not be mistaken for one of ours."""

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -90,6 +90,77 @@ class TestERPNextImporter(unittest.TestCase):
             "Contact", filters={"first_name": "_TMTest Customer ContactDup"})
         self.assertEqual(len(contacts), 1, msg="re-run duplicated the contact")
 
+    def test_party_side_effect_hooks_suspended_and_restored(self):
+        """The per-contact Google-Contacts/Call-Log hooks are neutralised inside the
+        context and restored after - the mechanism Step 5 relies on to drop the
+        data-irrelevant per-record round-trips on large books."""
+        import importlib
+        from tally_migrator.erpnext.importers.party import (
+            _party_side_effect_hooks_suspended, _SUSPENDED_PARTY_HOOKS)
+
+        calls = []
+        saved = []
+        for mod_path, names in _SUSPENDED_PARTY_HOOKS:
+            mod = importlib.import_module(mod_path)
+            for nm in names:
+                saved.append((mod, nm, getattr(mod, nm)))
+                setattr(mod, nm, lambda *a, **k: calls.append(nm))
+        try:
+            with _party_side_effect_hooks_suspended():
+                for mod_path, names in _SUSPENDED_PARTY_HOOKS:
+                    mod = importlib.import_module(mod_path)
+                    for nm in names:
+                        getattr(mod, nm)("doc")           # suspended -> must be a no-op
+            self.assertEqual(calls, [], "hooks must be neutralised inside the context")
+            for mod_path, names in _SUSPENDED_PARTY_HOOKS:   # restored afterwards
+                mod = importlib.import_module(mod_path)
+                for nm in names:
+                    getattr(mod, nm)("doc")
+            self.assertTrue(calls, "hooks must be restored after the context")
+        finally:
+            for mod, nm, fn in saved:
+                setattr(mod, nm, fn)
+
+    def test_party_import_does_not_fire_contact_integration_hooks(self):
+        """A normal Contact insert fires the Google-Contacts/Call-Log hooks; importing
+        a party that creates a Contact must not (they are suspended), while the Contact
+        is still created identically."""
+        import importlib
+        from tally_migrator.erpnext.importers.party import _SUSPENDED_PARTY_HOOKS
+
+        calls = {"n": 0}
+        saved = []
+        for mod_path, names in _SUSPENDED_PARTY_HOOKS:
+            try:
+                mod = importlib.import_module(mod_path)
+            except Exception:
+                continue
+            for nm in names:
+                if hasattr(mod, nm):
+                    saved.append((mod, nm, getattr(mod, nm)))
+                    setattr(mod, nm, lambda *a, **k: calls.__setitem__("n", calls["n"] + 1))
+        try:
+            # Anchor: a plain Contact insert DOES fire the hooks, so "0 during import"
+            # below is a real assertion and not a hook that simply never runs here.
+            anchor = frappe.new_doc("Contact")
+            anchor.first_name = "_TMTest Hook Anchor"
+            anchor.append("phone_nos", {"phone": "9811111111", "is_primary_mobile_no": 1})
+            anchor.insert(ignore_permissions=True)
+            self.assertGreater(calls["n"], 0, "the hooks should fire on a normal Contact insert")
+
+            fired_before = calls["n"]
+            self.importer.import_customers([{
+                "_name": "_TMTest Hook Cust", "LedgerMobile": "9822222222"}])
+            self.assertEqual(
+                calls["n"], fired_before,
+                "the integration hooks must not fire during a party import")
+            self.assertTrue(
+                frappe.db.exists("Contact", {"first_name": "_TMTest Hook Cust"}),
+                "the contact must still be created")
+        finally:
+            for mod, nm, fn in saved:
+                setattr(mod, nm, fn)
+
     def test_explicit_gst_registration_type_wins(self):
         """Tally's stated registration type overrides GSTIN/country inference."""
         if not frappe.db.has_column("Customer", "gst_category"):

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -486,6 +486,54 @@ class TestERPNextImporter(unittest.TestCase):
         self.assertEqual(
             frappe.db.get_value("Warehouse", f"_TMTest Child WH - {abbr}", "is_group"), 0)
 
+    def test_account_group_promotes_colliding_ledger(self):
+        """A Tally custom group whose name collides (case-insensitively) with an
+        existing ledger must promote that ledger to a group so its children nest.
+
+        Regression for the Frontier failures where a Tally group ("OFFICE EQUIPMENT")
+        collided with a standard-CoA Fixed-Asset *ledger* ("Office Equipment"): the
+        importer skipped the group, leaving a ledger, and every child failed with
+        "Parent account ... can not be a ledger"."""
+        require_company()
+        from tally_migrator.erpnext.importers.accounts import AccountImporter
+        from tally_migrator.tally.extractors import AccountNode
+
+        abbr = frappe.get_value("Company", self.company, "abbr")
+        root = frappe.db.get_value(
+            "Account", {"company": self.company, "root_type": "Asset",
+                        "is_group": 1, "parent_account": ["is", "not set"]}, "name")
+        placeholder = f"_TMTest Equip - {abbr}"
+        # Reset any state left by a prior run so the promotion path is always exercised
+        # (child first - a group with children can't be deleted).
+        for nm in (f"_TMTest Camera - {abbr}", placeholder):
+            if frappe.db.exists("Account", nm):
+                frappe.delete_doc("Account", nm, force=True, ignore_permissions=True)
+        # A pre-existing typed ledger placeholder, like ERPNext's standard CoA ships.
+        frappe.get_doc({
+            "doctype": "Account", "account_name": "_TMTest Equip",
+            "company": self.company, "parent_account": root,
+            "is_group": 0, "root_type": "Asset", "account_type": "Fixed Asset",
+        }).insert(ignore_permissions=True)
+
+        imp = AccountImporter(self.company, abbr, mode="reuse")
+        # Same name in a different case (the collision is case-insensitive in MariaDB),
+        # plus a child ledger that can only be created if the parent becomes a group.
+        group = AccountNode(name="_TMTEST EQUIP", parent="", is_group=True,
+                            root_type="Asset", account_type="", is_reserved=False)
+        child = AccountNode(name="_TMTest Camera", parent="_TMTEST EQUIP",
+                            is_group=False, root_type="Asset", account_type="",
+                            is_reserved=False)
+        result = imp.run([group, child])
+
+        self.assertEqual(result.failed, 0, msg=str(result.errors))
+        self.assertEqual(
+            frappe.db.get_value("Account", placeholder, "is_group"), 1,
+            "the colliding ledger should have been promoted to a group")
+        self.assertTrue(frappe.db.exists("Account", f"_TMTest Camera - {abbr}"),
+                        "the child must be created once its parent is a group")
+        self.assertTrue(any("converted it to a group" in w["reason"]
+                            for w in result.warnings))
+
     # ── Stock Groups → nested Item Groups ───────────────────────────────────────
 
     def test_stock_groups_create_nested_item_groups(self):

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -168,6 +168,90 @@ class TestERPNextImporter(unittest.TestCase):
             frappe.db.exists("Address", {"address_title": "_TMTest Mailing Title-Billing"})
             or frappe.db.exists("Address", {"address_title": "_TMTest Mailing Title"}))
 
+    # ── Step 1: recover address/contact drops (no-state, bad email) ────────────
+
+    def test_resolve_state_prefers_ledger_then_gstin_then_pin(self):
+        """State resolves most-reliable first: Tally ledger state, else GSTIN state
+        code, else derived from the PIN. Tally rarely sets a ledger state, so the
+        PIN fallback is what keeps most addresses out of the missing-state drop."""
+        from tally_migrator.erpnext.importers import CustomerImporter
+        imp = CustomerImporter("_TMTest Co", "TC")
+        # ledger state wins over everything
+        self.assertEqual(imp._resolve_state(
+            {"LedgerState": "Karnataka", "GSTRegistrationNumber": "27AAACT2727Q1ZW",
+             "PinCode": "600001"}), "Karnataka")
+        # no ledger state -> GSTIN's state code (27 -> Maharashtra) beats the PIN
+        self.assertEqual(imp._resolve_state(
+            {"GSTRegistrationNumber": "27AAACT2727Q1ZW", "PinCode": "600001"}),
+            "Maharashtra")
+        # only a PIN -> derived from it (600xxx -> Tamil Nadu)
+        self.assertEqual(imp._resolve_state({"PinCode": "600001"}), "Tamil Nadu")
+        # no signal at all -> empty (caller decides to skip)
+        self.assertEqual(imp._resolve_state({}), "")
+
+    def test_address_state_derived_from_pincode(self):
+        """A party with a PIN but no ledger state / GSTIN keeps its address - the
+        state is derived from the PIN, not dropped."""
+        customer = {
+            "_name": "_TMTest Customer PinState",
+            "Address": "1 Pin Road",
+            "PinCode": "560001",   # Bengaluru -> Karnataka
+        }
+        self.importer.import_customers([customer])
+        addr = frappe.get_all(
+            "Address", filters={"address_title": "_TMTest Customer PinState"},
+            fields=["name", "state"])
+        self.assertEqual(len(addr), 1, msg="address dropped despite a derivable state")
+        self.assertEqual(addr[0].state, "Karnataka")
+
+    def test_address_skipped_cleanly_when_no_state_signal(self):
+        """No ledger state, GSTIN or PIN -> the Indian address cannot satisfy India
+        Compliance, so it is skipped as a warning (the party still imports) WITHOUT a
+        failed insert or an Error Log entry - the big-import flood we removed."""
+        from unittest import mock
+        if not frappe.get_meta("Address").has_field("gst_state"):
+            self.skipTest("state-mandatory rule requires India Compliance")
+        customer = {"_name": "_TMTest Customer NoState", "Address": "9 Nowhere Lane"}
+        with mock.patch("frappe.log_error") as logged:
+            result = self.importer.import_customers([customer])
+        self.assertEqual(result.failed, 0)
+        self.assertTrue(
+            frappe.db.exists("Customer", {"customer_name": "_TMTest Customer NoState"}))
+        self.assertFalse(
+            frappe.db.exists("Address", {"address_title": "_TMTest Customer NoState"}))
+        self.assertTrue(any("no state" in w["reason"] for w in result.warnings))
+        logged.assert_not_called()
+
+    def test_address_kept_when_email_invalid(self):
+        """A malformed Tally email must not sink the whole address - the address
+        imports, just without the bad email."""
+        customer = {
+            "_name": "_TMTest Customer BadEmailAddr",
+            "Address": "2 Email Road",
+            "LedgerState": "Maharashtra",
+            "LedgerEmail": "NA",   # not a valid email address
+        }
+        self.importer.import_customers([customer])
+        addr = frappe.get_all(
+            "Address", filters={"address_title": "_TMTest Customer BadEmailAddr"},
+            fields=["name", "email_id"])
+        self.assertEqual(len(addr), 1, msg="address dropped over a bad email")
+        self.assertFalse(addr[0].email_id)
+
+    def test_contact_keeps_phone_when_email_invalid(self):
+        """A malformed email is dropped but the phone-only contact is still created,
+        and a warning records the dropped email."""
+        customer = {
+            "_name": "_TMTest Customer BadEmail",
+            "LedgerMobile": "9812345678",
+            "LedgerEmail": "n/a",
+        }
+        result = self.importer.import_customers([customer])
+        doc = frappe.get_doc("Contact", {"first_name": "_TMTest Customer BadEmail"})
+        self.assertEqual([e.email_id for e in doc.email_ids], [])
+        self.assertIn("9812345678", [p.phone for p in doc.phone_nos])
+        self.assertTrue(any("email" in w["reason"] for w in result.warnings))
+
     # ── Supplier ──────────────────────────────────────────────────────────────
 
     def test_import_supplier_creates_record(self):
@@ -238,6 +322,58 @@ class TestERPNextImporter(unittest.TestCase):
         self.assertTrue(b)
         self.assertEqual(str(b.manufacturing_date), "2026-05-01")
         self.assertEqual(str(b.expiry_date), "2026-07-31")
+
+    def test_batch_id_scoping_for_shared_names(self):
+        """shared_batch_names + batch_id_for: a name used by >1 item is scoped per
+        item; a unique name is kept verbatim; the scoped id stays within 140 chars."""
+        from tally_migrator.naming import shared_batch_names, batch_id_for
+        items = [
+            {"_name": "A", "IsBatchWiseOn": "Yes",
+             "GodownOpenings": [{"batch": "169.49"}, {"batch": "UNIQ-A"}]},
+            {"_name": "B", "IsBatchWiseOn": "Yes",
+             "GodownOpenings": [{"batch": "169.49"}]},
+        ]
+        shared = shared_batch_names(items)
+        self.assertEqual(shared, {"169.49"})
+        self.assertEqual(batch_id_for("169.49", "A", shared), "169.49 - A")
+        self.assertEqual(batch_id_for("169.49", "B", shared), "169.49 - B")
+        self.assertEqual(batch_id_for("UNIQ-A", "A", shared), "UNIQ-A")     # unique
+        self.assertLessEqual(len(batch_id_for("169.49", "Z" * 200, shared)), 140)
+
+    def test_opening_row_uses_scoped_batch_no_for_shared_name(self):
+        """A row for a shared batch name is tagged with the per-item scoped batch id
+        (matching what the Batch importer created), not the bare colliding name."""
+        from tally_migrator.erpnext.importers import StockOpeningImporter
+        from tally_migrator.erpnext.importers.base import ImportResult
+        imp = StockOpeningImporter("_TMTest Co", "TC")
+        imp._shared_batch_names = {"169.49"}
+        by_key, res = {}, ImportResult("Stock Reconciliation")
+        imp._add_opening_row(by_key, "ItemA", "WH", "5 Nos", "1/Nos", "", None,
+                             res, batch="169.49")
+        self.assertEqual(next(iter(by_key.values()))["batch_no"], "169.49 - ItemA")
+
+    def test_batch_importer_scopes_shared_batch_id_per_item(self):
+        """Two items sharing one Tally batch name each get their OWN ERPNext Batch
+        (scoped by item), instead of the second being skipped on the global id -
+        the fix that lets every item's batch-tracked opening stock post."""
+        from tally_migrator.naming import safe_item_code
+
+        def bitem(name):
+            it = self._batch_item(name)
+            it["GodownOpenings"][0]["batch"] = "_TMTest SHAREDRATE"
+            return it
+
+        a, b = bitem("_TMTest BShare A"), bitem("_TMTest BShare B")
+        code_a, code_b = safe_item_code("_TMTest BShare A"), safe_item_code("_TMTest BShare B")
+        for c in (code_a, code_b):
+            self.addCleanup(
+                lambda cc=c: frappe.db.exists("Batch", f"_TMTest SHAREDRATE - {cc}")
+                and frappe.delete_doc("Batch", f"_TMTest SHAREDRATE - {cc}", force=1))
+        self.importer.import_items([a, b])
+        res = self.importer.import_batches([a, b])
+        self.assertEqual(res.failed, 0, msg=str(res.errors))
+        self.assertTrue(frappe.db.exists("Batch", f"_TMTest SHAREDRATE - {code_a}"))
+        self.assertTrue(frappe.db.exists("Batch", f"_TMTest SHAREDRATE - {code_b}"))
 
     def test_mrp_creates_item_price_on_mrp_list(self):
         item = self._batch_item()
@@ -838,18 +974,21 @@ class TestERPNextImporter(unittest.TestCase):
                 frappe.delete_doc("Payment Entry", pe, force=True, ignore_permissions=True)
             frappe.db.commit()
 
-    def test_opening_stock_skipped_when_reconciliation_exists(self):
-        """A second run must NOT post a second Opening Stock reconciliation."""
+    def test_opening_stock_skips_items_already_posted(self):
+        """Per-item idempotency: an item+warehouse already carried by a submitted
+        opening reconciliation is not re-posted, so a re-run can resume the rest
+        without doubling stock."""
         from tally_migrator.erpnext.importers import StockOpeningImporter
+        from tally_migrator.naming import safe_item_code
 
         imp = StockOpeningImporter("_TMTest Co", "TC")
-        imp._existing_opening_stock = lambda: True   # simulate a prior run
+        imp._default_warehouse = lambda: "Stores - TC"
+        imp._posted_keys = lambda: {(safe_item_code("X"), "Stores - TC")}
         result = imp.run(items=[{"_name": "X", "OpeningBalance": "55 Nos"}],
                          posting_date="2024-04-01")
         self.assertEqual(result.created, 0)
         self.assertEqual(result.skipped, 1)
-        self.assertEqual(result.warned, 1)
-        self.assertIn("already posted", result.warnings[0]["reason"])
+        self.assertIn("already posted", result.warnings[-1]["reason"])
 
     def test_default_warehouse_skips_other_company_global_default(self):
         """Stock Settings' default_warehouse is global. On a multi-company site it
@@ -924,7 +1063,7 @@ class TestERPNextImporter(unittest.TestCase):
         captured = {}
 
         def fake_get_doc(d):
-            captured["items"] = d["items"]
+            captured.setdefault("items", d["items"])  # keep the first (full chunk)
             raise Exception("stop")  # before insert/submit; we only inspect the rows
 
         with mock.patch("frappe.get_doc", side_effect=fake_get_doc):
@@ -947,7 +1086,7 @@ class TestERPNextImporter(unittest.TestCase):
         captured = {}
 
         def fake_get_doc(d):
-            captured["items"] = d["items"]
+            captured.setdefault("items", d["items"])  # keep the first (full chunk)
             raise Exception("stop")
 
         with mock.patch("frappe.get_doc", side_effect=fake_get_doc):
@@ -971,7 +1110,7 @@ class TestERPNextImporter(unittest.TestCase):
         captured = {}
 
         def fake_get_doc(d):
-            captured["items"] = d["items"]
+            captured.setdefault("items", d["items"])  # keep the first (full chunk)
             raise Exception("stop")
 
         with mock.patch("frappe.get_doc", side_effect=fake_get_doc):
@@ -993,7 +1132,7 @@ class TestERPNextImporter(unittest.TestCase):
         captured = {}
 
         def fake_get_doc(d):
-            captured["items"] = d["items"]
+            captured.setdefault("items", d["items"])  # keep the first (full chunk)
             raise Exception("stop")
 
         with mock.patch("frappe.get_doc", side_effect=fake_get_doc):
@@ -1016,7 +1155,7 @@ class TestERPNextImporter(unittest.TestCase):
         captured = {}
 
         def fake_get_doc(d):
-            captured["items"] = d["items"]
+            captured.setdefault("items", d["items"])  # keep the first (full chunk)
             raise Exception("stop")
 
         with mock.patch("frappe.get_doc", side_effect=fake_get_doc):
@@ -1028,6 +1167,59 @@ class TestERPNextImporter(unittest.TestCase):
         rows = {r["item_code"]: r for r in captured["items"]}
         self.assertEqual(rows["Envelope"].get("allow_zero_valuation_rate"), 1)
         self.assertNotIn("allow_zero_valuation_rate", rows["Mouse"])  # has a rate
+
+    def test_non_stock_item_excluded_from_opening_stock(self):
+        """A service / non-stock item carrying an opening quantity must be dropped
+        from the aggregate Stock Reconciliation (with a warning) so that one bad row
+        cannot fail the whole document and lose every item's opening stock."""
+        from unittest import mock
+        from tally_migrator.erpnext.importers import StockOpeningImporter
+        from tally_migrator.naming import safe_item_code
+
+        imp = StockOpeningImporter("_TMTest Co", "TC")
+        imp._existing_opening_stock = lambda: False
+        imp._default_warehouse = lambda: "Stores - TC"
+        captured = {}
+
+        def fake_get_doc(d):
+            captured.setdefault("items", d["items"])  # keep the first (full chunk)
+            raise Exception("stop")
+
+        items = [
+            {"_name": "_TMTest Service", "TypeOfSupply": "Services",
+             "OpeningBalance": "5 Nos", "OpeningRate": "10/Nos"},
+            {"_name": "_TMTest Goods", "OpeningBalance": "7 Nos", "OpeningRate": "3/Nos"},
+        ]
+        with mock.patch("frappe.get_doc", side_effect=fake_get_doc):
+            result = imp.run(items=items, posting_date="2024-04-01")
+        codes = [r["item_code"] for r in captured["items"]]
+        self.assertIn(safe_item_code("_TMTest Goods"), codes)
+        self.assertNotIn(safe_item_code("_TMTest Service"), codes)
+        self.assertTrue(any("non-stock" in w["reason"] for w in result.warnings))
+
+    def test_all_non_stock_items_post_nothing_cleanly(self):
+        """When only service / non-stock items carry an opening quantity, nothing is
+        posted (no Stock Reconciliation is even built) and the run does not fail."""
+        from unittest import mock
+        from tally_migrator.erpnext.importers import StockOpeningImporter
+
+        imp = StockOpeningImporter("_TMTest Co", "TC")
+        imp._existing_opening_stock = lambda: False
+        imp._default_warehouse = lambda: "Stores - TC"
+        called = {"n": 0}
+
+        def fake_get_doc(d):
+            called["n"] += 1
+            raise Exception("should not be called")
+
+        items = [{"_name": "_TMTest Svc Only", "TypeOfSupply": "Services",
+                  "OpeningBalance": "9 Nos", "OpeningRate": "2/Nos"}]
+        with mock.patch("frappe.get_doc", side_effect=fake_get_doc):
+            result = imp.run(items=items, posting_date="2024-04-01")
+        self.assertEqual(called["n"], 0)
+        self.assertEqual(result.created, 0)
+        self.assertEqual(result.failed, 0)
+        self.assertTrue(any("non-stock" in w["reason"] for w in result.warnings))
 
     def test_zero_valuation_warns_per_item_with_identical_text(self):
         """The importer emits one warning per zero-rate item, all with byte-identical
@@ -1093,7 +1285,7 @@ class TestERPNextImporter(unittest.TestCase):
         captured = {}
 
         def fake_get_doc(d):
-            captured["items"] = d["items"]
+            captured.setdefault("items", d["items"])  # keep the first (full chunk)
             raise Exception("stop")
 
         # Both godowns are "migrated" (warehouse exists); the default isn't consulted.
@@ -1126,7 +1318,7 @@ class TestERPNextImporter(unittest.TestCase):
         captured = {}
 
         def fake_get_doc(d):
-            captured["items"] = d["items"]
+            captured.setdefault("items", d["items"])  # keep the first (full chunk)
             raise Exception("stop")
 
         # No warehouse exists for the godown -> fall back to the default.
@@ -1154,7 +1346,7 @@ class TestERPNextImporter(unittest.TestCase):
         captured = {}
 
         def fake_get_doc(d):
-            captured["items"] = d["items"]
+            captured.setdefault("items", d["items"])  # keep the first (full chunk)
             raise Exception("stop")
 
         with mock.patch("frappe.db.exists", return_value=False), \

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -1007,6 +1007,48 @@ class TestERPNextImporter(unittest.TestCase):
         self.assertEqual(result.skipped, 1)
         self.assertTrue(any("already posted" in w["reason"] for w in result.warnings))
 
+    def test_opening_balance_skips_account_that_is_a_group_in_erpnext(self):
+        """A Tally ledger that exists in ERPNext as a GROUP (e.g. promoted so its
+        sub-accounts could nest - see test_account_group_promotes_colliding_ledger)
+        must be skipped from the opening Journal Entry, not added as a line. A group
+        account cannot carry a balance, and one such line fails the whole class batch
+        on submit, losing every opening balance in it. Regression for the Step 3 /
+        opening-balance interaction."""
+        require_company()
+        from tally_migrator.erpnext.importers.openings import OpeningBalanceImporter
+        from tally_migrator.erpnext.importers.base import ImportResult
+        from tally_migrator.tally.extractors import AccountNode
+        from tally_migrator.naming import company_scoped
+
+        company = self.company
+        abbr = frappe.get_value("Company", company, "abbr")
+        root = frappe.db.get_value(
+            "Account", {"company": company, "root_type": "Liability",
+                        "is_group": 1, "parent_account": ["is", "not set"]}, "name")
+        grp_base, led_base = "_TMTest Promoted Liab", "_TMTest Plain Liab"
+        grp, led = company_scoped(grp_base, abbr), company_scoped(led_base, abbr)
+        if not frappe.db.exists("Account", grp):
+            frappe.get_doc({"doctype": "Account", "account_name": grp_base,
+                            "company": company, "parent_account": root,
+                            "is_group": 1, "root_type": "Liability"}).insert(ignore_permissions=True)
+        if not frappe.db.exists("Account", led):
+            frappe.get_doc({"doctype": "Account", "account_name": led_base,
+                            "company": company, "parent_account": root,
+                            "is_group": 0, "root_type": "Liability"}).insert(ignore_permissions=True)
+
+        def node(name):
+            return AccountNode(name=name, parent="", is_group=False, root_type="Liability",
+                               account_type="", is_reserved=False,
+                               opening_balance=1000.0, opening_dr_cr="Cr")
+
+        res = ImportResult("Journal Entry")
+        lines = OpeningBalanceImporter(company, abbr)._account_lines(
+            [node(grp_base), node(led_base)], res)
+        accounts = [l["account"] for l in lines]
+        self.assertIn(led, accounts, "the ordinary ledger opening should still post")
+        self.assertNotIn(grp, accounts, "the group account must be skipped")
+        self.assertTrue(any("group account" in w["reason"] for w in res.warnings))
+
     def test_batch_label_roundtrips_through_remark(self):
         """The label written to user_remark must parse back to the same label, and a
         foreign remark must not be mistaken for one of ours."""


### PR DESCRIPTION
## Summary

This PR collects the fixes from the first full real-world audit of the migration - a ~16,000-master Tally export ("Frontier") run end to end as the user, with every created record, field value, and mapping checked against the source, plus per-phase profiling. It groups into four themes: **opening-balance correctness**, **account / Chart-of-Accounts integrity**, **reliability of large runs**, and **performance** of the heaviest phases. Every fix is generic (validated against the source data and, for the sign fix, across 36 real exports), changes no standard CoA, and adds tests. 11 commits, 15 files, +1,108/-82.

The audit's headline finding: on the first live run the post-import trial balance did not reconcile - whole account classes read as absent, opening stock posted as 0, suppliers were dropped, and 16k+ warnings were invisible. Each root cause is fixed below.

---

## 1. Opening-balance correctness (`6b83c82`)

Four bugs that made the opening trial balance wrong, each found by auditing the real run:

- **Opening JE now posts its GL synchronously.** ERPNext's `JournalEntry.submit()` enqueues a *background* job once an entry has > 100 accounts (the asset Opening Entry routinely does). On a long single-worker run that GL landed *after* the migration finalized, so the post-import trial balance read a whole class (Assets) as absent. `_post_batch` now calls `_submit()` directly - the same synchronous path `submit()` uses for <=100-row entries.
- **Party opening bills post on their Tally side.** `_classify` routed any bill flagged `ISADVANCE` to an advance Payment Entry whose direction is fixed by party type, so a bill on the party's *natural* side posted on the wrong side with its sign flipped - an offsetting Cr+Dr pair that nets to zero in Tally became a non-zero balance, understating Payables/Receivables (a measured 100,425.23 gap). Classification is now purely by side. Verified across **36 real exports**: the new path reproduces every bill's Tally sign exactly and only changes the previously-broken natural-side+advance bills.
- **Invalid PAN no longer drops the party.** Tally's `INCOMETAXNumber` maps to the party PAN, but a value that is not a valid PAN (a TAN, a typo, plain digits) made India Compliance reject the whole Customer/Supplier (this silently lost a supplier on the real run). `_valid_pan` keeps the value only when it matches IC's PAN format and blanks it otherwise, mirroring the existing invalid-GSTIN fallback.
- **Bank ledgers sharing a holder name each keep their Bank Account.** ERPNext autonames a Bank Account `"account_name - bank"`; when several bank ledgers repeat one holder name they collided and all but the first dropped. The name is now disambiguated with the account number, then a numeric suffix.

## 2. Account / Chart-of-Accounts integrity (`418faa70`, `b910d798`, `2d03041f`)

A chain of fixes around the case where a Tally custom *group* name collides with a standard-CoA *ledger* - which on the real export caused 33 failed accounts and stranded the opening balances behind them.

- **`418faa70`** - first cut: when a group node's name already existed as a ledger, promote that ledger to a group so the sub-accounts could nest (33 failures to 0).
- **`b910d798`** - corrected approach: that in-place promotion mutated a load-bearing account. "TDS Payable" carries `account_type=Tax` and India Compliance wires it into all 127 Tax Withholding Categories, so converting it to a group broke them (127 "is a group account" errors on the next company). Now **never convert an existing account**: leave the standard ledger exactly as ERPNext/IC set it up and *re-home* the Tally group's sub-accounts to the ledger's own parent (one level flatter, with a warning). Removes the convert-to-group path entirely.
- **`2d03041f`** - guard at the opening-balance builder: skip an account that is a group *in ERPNext* (not just one Tally flagged as a group), so a group line can't fail a whole class's Journal Entry on submit ("group accounts cannot be used in transactions"). The amount falls into Temporary Opening instead - this is why Liabilities & Equity and Assets had not reconciled.

## 3. Reliability of large runs (`6220e73a`, `411d2e70`, `d645e62a`, `ea20dc0b`, `fe1d3585`)

- **`6220e73a` - opening stock posts reliably and in full.** A single Stock Reconciliation held every item's opening stock, so one bad row failed all of it (0 posted on the real run). Three causes fixed: Tally's per-item batch names collide on ERPNext's global batch ids (scoped per item via a shared naming helper); ERPNext queues a >100-row reconciliation to a background job that stalled (now posted in <=100-row synchronous chunks with a row-by-row fallback); and service items carrying a stock quantity (dropped with a warning). Idempotency is per item+warehouse so an interrupted run resumes. Result: 0 to full opening-stock value (within 0.02%, the remainder being non-stock service items).
- **`411d2e70` - recover party addresses and contacts instead of dropping them.** Tally does not mandate a ledger state, so most party addresses were rejected by India Compliance ("State is a required field") and lost - each also writing a system Error Log (tens of thousands on a large import). Now: derive the state from the PIN code; skip a genuinely state-less Indian address up front with one warning (no failed insert, no Error Log) and only when IC enforces the rule; sanitise emails with ERPNext's own validator and drop just a bad email, keeping the address and contact.
- **`d645e62a` - a long issues list no longer blanks the migration log.** On big runs the per-record issues list could exceed the child table's `record_name` limit, throwing while writing the log and losing the records-created manifest, reconciliation report, and issues table together. Widened `record_name` to Small Text and split the enrichment write into two independently-committed parts so a failure in one can't drop the other.
- **`ea20dc0b` - Warnings column in the Migration Log summary.** The log form showed only Imported / Already there / Failed, so non-fatal drops were invisible to anyone reviewing a run later - 16,308 warnings hidden on the real run (15,459 on Suppliers). Brings the log form to parity with the wizard's results screen.
- **`fe1d3585` - caption shows "Migration complete." not the stale "Saving migration log...".** The poll could detect the terminal status right after the 95% event and win the race against the final 100% event, leaving the caption stuck under a full bar. The success path now sets the caption explicitly.

## 4. Performance of the heaviest phases (`21daec1f`, `dc6c9e0e`)

Both measurement-led, targeting the per-record DB round-trips that dominate on Frappe Cloud.

- **`21daec1f` - cache accounting dimensions during opening-stock posting.** Profiling showed the chunk submit is query-bound (~26 queries/item), almost all of it ERPNext's intrinsic stock posting. The one avoidable cost is `get_accounting_dimensions()` (~2x/item, never cached, though the list is a company-wide constant). Memoised for the posting loop by swapping every bound reference in `sys.modules` and restoring on exit. Measured: accounting-dimension queries per chunk drop ~207 to ~6, total submit queries down ~8%.
- **`dc6c9e0e` - suspend per-contact integration hooks during the party import.** Every Contact insert fired Frappe's Google-Contacts sync and ERPNext's Call-Log auto-link - a DB round-trip each (and a per-contact network call if configured), tens of thousands wasted on a large import and doing nothing useful for a migration. Extended the existing party-phase suspension to neutralise both, restoring after; the Contact still saves identically. Measured: those query patterns drop to zero (398 to 0 and 199 to 0 per 200 suppliers) with identical output.

---

## Validation

- Four opening-balance fixes validated live on the local site; the advance-sign fix proven across 36 real exports (faithful everywhere, only correcting the previously-broken bills).
- CoA / customisation audit clean: 0 standard accounts modified, 0 custom fields or property setters added, TDS wiring intact, GL balanced, no duplicate parties.
- Full test suite green; new tests added for each fix. Docs updated for the PAN, bank-name, opening-stock-valuation, group-collision, address-state, and Warnings-column behaviours.

## Not in this PR

Zip / Google Drive upload and the large-file streaming work shipped earlier in #43-#45 and are already on `main`.
