### PR TITLE
Opening stock: post true value across godowns; reconcile like-for-like

### DIFF
--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -869,10 +869,14 @@ Migrator handles a real-world wrinkle in Tally data.
   that item, whatever the per-godown detail looks like. A godown breakdown that cannot
   be posted as is - because it includes a negative allocation (a transfer or oversold
   godown that ERPNext opening stock cannot hold) or does not add up to the item's total
-  quantity - falls back to a single item-level line at the default warehouse, so the
-  value is always kept; only that one item's per-warehouse split is sacrificed. A whole
-  item with no rate, value, or standard cost anywhere posts at a zero valuation rate,
-  with a warning, so its quantity is still recorded.
+  quantity - falls back, for a non-batch item, to a single item-level line at the
+  default warehouse, so the value is always kept and only that item's per-warehouse
+  split is sacrificed. A **batch-tracked** item cannot fall back this way (every row
+  needs a batch), and such a breakdown - typically a batch quantity that nets negative -
+  cannot be represented as ERPNext opening stock at all, so that one item is skipped
+  with a warning to set it manually, rather than posted at a wrong value. A whole item
+  with no rate, value, or standard cost anywhere posts at a zero valuation rate, with a
+  warning, so its quantity is still recorded.
 - **Service / non-stock items with an opening quantity.** ERPNext cannot hold stock for
   a service item, so its opening quantity is not posted as stock (with a warning to
   record it as a ledger balance instead). The reconciliation does not count it on the
@@ -973,6 +977,11 @@ migration.
   edge cases above.
 - **"opening stock not posted - Tally reports a negative opening quantity"** - set
   this item's opening stock manually.
+- **"opening stock not posted - this batch-tracked item's Tally batch allocations
+  cannot be represented as ERPNext opening stock"** - a batch quantity is negative or
+  the per-batch split does not reconcile to the item's total, which ERPNext opening
+  stock cannot hold. Set this item's opening stock manually; the reconciliation shows
+  these as a small Stock value shortfall to review.
 - **"opening stock posted with a zero valuation rate"** - Tally carried no value for
   the item; set a valuation rate in ERPNext if it should carry value.
 - **"opening stock value does not reconcile"** - Tally's recorded value did not match

--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -788,10 +788,11 @@ Migrator handles a real-world wrinkle in Tally data.
 - **Batch and expiry.** An item marked batch-wise in Tally gets batch tracking turned
   on; if it is also perishable, expiry tracking is enabled too.
 - **Opening stock value.** Every item with opening stock is imported with its quantity
-  and rate. ERPNext recomputes each item's valuation when it posts the opening stock,
-  so the total opening stock value on the trial balance can differ from Tally's by a
-  few units of rounding. This is a rounding effect, not missing stock - all items and
-  quantities are imported.
+  and rate, and each item is valued at the rate Tally states for it (its opening rate,
+  or its opening value divided by quantity), so the opening stock value on the trial
+  balance ties back to Tally's. ERPNext stores each rate at its currency precision, so
+  the total can differ by a sub-rupee rounding fraction - that, and only that, is what
+  the trial balance's stock tolerance absorbs; it is never missing stock.
 
 ### Units of measure
 
@@ -861,11 +862,22 @@ Migrator handles a real-world wrinkle in Tally data.
   the original invoice number and reconciles directly. If a bill id clashes with an
   existing document, the invoice is auto-named instead, with a warning, and the Tally
   id stays recoverable.
-- **Opening stock** posts as one Stock Reconciliation. Where Tally carries godown-wise
-  and batch-wise detail, stock is placed per warehouse and per batch. A negative
-  opening quantity cannot be posted and is dropped with a warning. An item with no
-  rate, value, or standard cost posts at a zero valuation rate, with a warning, so its
-  quantity is still recorded.
+- **Opening stock** posts as Stock Reconciliations. Where Tally carries godown-wise
+  and batch-wise detail, stock is placed per warehouse and per batch - but only when
+  that breakdown can be posted faithfully. Each item is valued at the rate Tally states
+  for the item as a whole, so the total always equals Tally's opening stock value for
+  that item, whatever the per-godown detail looks like. A godown breakdown that cannot
+  be posted as is - because it includes a negative allocation (a transfer or oversold
+  godown that ERPNext opening stock cannot hold) or does not add up to the item's total
+  quantity - falls back to a single item-level line at the default warehouse, so the
+  value is always kept; only that one item's per-warehouse split is sacrificed. A whole
+  item with no rate, value, or standard cost anywhere posts at a zero valuation rate,
+  with a warning, so its quantity is still recorded.
+- **Service / non-stock items with an opening quantity.** ERPNext cannot hold stock for
+  a service item, so its opening quantity is not posted as stock (with a warning to
+  record it as a ledger balance instead). The reconciliation does not count it on the
+  Stock value line - which would look like missing stock - but discloses its value as a
+  separate "opening value not migrated as stock" figure, so nothing is hidden.
 
 ### Foreign currency
 

--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -871,12 +871,15 @@ Migrator handles a real-world wrinkle in Tally data.
   godown that ERPNext opening stock cannot hold) or does not add up to the item's total
   quantity - falls back, for a non-batch item, to a single item-level line at the
   default warehouse, so the value is always kept and only that item's per-warehouse
-  split is sacrificed. A **batch-tracked** item cannot fall back this way (every row
-  needs a batch), and such a breakdown - typically a batch quantity that nets negative -
-  cannot be represented as ERPNext opening stock at all, so that one item is skipped
-  with a warning to set it manually, rather than posted at a wrong value. A whole item
-  with no rate, value, or standard cost anywhere posts at a zero valuation rate, with a
-  warning, so its quantity is still recorded.
+  split is sacrificed. A **batch-tracked** item cannot fall back to a batch-less
+  item-level line (every row needs a batch), so instead its full opening quantity x rate
+  is posted under the single real batch that held the most stock (the largest positive
+  bucket), with a warning. The value and total are always kept and only that item's
+  per-batch split is sacrificed - set the per-batch opening manually if you need it. In
+  the rare case where none of its positive batches map to an existing Batch master, the
+  item is skipped with a warning to set it manually, rather than posted at a wrong value.
+  A whole item with no rate, value, or standard cost anywhere posts at a zero valuation
+  rate, with a warning, so its quantity is still recorded.
 - **Service / non-stock items with an opening quantity.** ERPNext cannot hold stock for
   a service item, so its opening quantity is not posted as stock (with a warning to
   record it as a ledger balance instead). The reconciliation does not count it on the
@@ -977,11 +980,17 @@ migration.
   edge cases above.
 - **"opening stock not posted - Tally reports a negative opening quantity"** - set
   this item's opening stock manually.
+- **"opening stock posted as a single batch line"** - this batch-tracked item's Tally
+  batch breakdown includes a negative or non-reconciling batch quantity that ERPNext
+  opening stock cannot hold per batch, so its full opening quantity x rate was posted
+  under one batch (the one that held the most stock). The item's total and value are
+  correct; only the per-batch split was not preserved. Set the per-batch opening stock
+  manually if your business needs batch-level accuracy for this item.
 - **"opening stock not posted - this batch-tracked item's Tally batch allocations
-  cannot be represented as ERPNext opening stock"** - a batch quantity is negative or
-  the per-batch split does not reconcile to the item's total, which ERPNext opening
-  stock cannot hold. Set this item's opening stock manually; the reconciliation shows
-  these as a small Stock value shortfall to review.
+  cannot be represented as ERPNext opening stock"** - the rarer case where none of the
+  item's positive batches map to an existing Batch master, so its value could not be
+  homed anywhere. Set this item's opening stock manually; the reconciliation shows it as
+  a small Stock value shortfall to review.
 - **"opening stock posted with a zero valuation rate"** - Tally carried no value for
   the item; set a valuation rate in ERPNext if it should carry value.
 - **"opening stock value does not reconcile"** - Tally's recorded value did not match

--- a/tally_migrator/erpnext/importers/items.py
+++ b/tally_migrator/erpnext/importers/items.py
@@ -18,6 +18,7 @@ from tally_migrator.tally.mappings import (
     ERPNEXT_ROOT_GROUPS,
     classify_group,
     gst_category_from_type,
+    is_stock_item,
 )
 from tally_migrator.naming import safe_item_code, company_scoped
 from tally_migrator.tally.extractors import TallyExtractor
@@ -246,9 +247,10 @@ class ItemImporter(BaseImporter):
     def _is_stock_item(record: dict) -> int:
         """A Tally Stock Item whose GST supply type is 'Services' maps to a
         non-stock Item in ERPNext (read from GSTDETAILS.LIST/SUPPLYTYPE); every
-        other supply type stays a stock item."""
-        supply = (record.get("TypeOfSupply") or "").strip().lower()
-        return 0 if supply in ("services", "service") else 1
+        other supply type stays a stock item. Delegates to the shared, pure rule
+        (mappings.is_stock_item) so the reconciliation counts stock for exactly
+        the items posted here."""
+        return is_stock_item(record)
 
     @staticmethod
     def _gst_treatment(gst_type: str):

--- a/tally_migrator/erpnext/importers/openings.py
+++ b/tally_migrator/erpnext/importers/openings.py
@@ -1037,7 +1037,7 @@ class StockOpeningImporter:
         # an item legitimately carry opening stock in several godowns.
         by_key: dict[tuple, dict] = {}
         for it in items:
-            for wh, raw_qty, raw_rate, raw_value, batch in self._placements(it, warehouse):
+            for wh, raw_qty, raw_rate, raw_value, batch in self._placements(it, warehouse, result):
                 self._add_opening_row(
                     by_key, it["_name"], wh, raw_qty, raw_rate, raw_value,
                     it.get("StandardCost"), result, batch=batch)
@@ -1152,7 +1152,8 @@ class StockOpeningImporter:
                     "opening value as a ledger balance if it should carry one.")
         return kept
 
-    def _placements(self, it: dict, default_wh: str) -> list[tuple]:
+    def _placements(self, it: dict, default_wh: str,
+                    result: "ImportResult | None" = None) -> list[tuple]:
         """Where this item's opening stock lands → list of
         ``(warehouse, raw_qty, raw_rate, raw_value, batch)`` buckets fed to
         :meth:`_add_opening_row`.
@@ -1175,26 +1176,35 @@ class StockOpeningImporter:
           at zero value) or internally inconsistent with the item total.
         - When the godown split is not faithfully postable (a net-negative bucket,
           which ERPNext opening stock cannot hold, or buckets that do not tie to the
-          item-level quantity) → fall back to the single item-level row, which always
-          reconciles. The per-warehouse detail is sacrificed for that one item, not
-          its value, and the run records a warning via the zero/negative handling.
+          item-level quantity) → a NON-batch item falls back to the single item-level
+          row, which always reconciles (per-warehouse detail is sacrificed for that one
+          item, not its value). A BATCH-tracked item cannot fall back this way: every
+          opening row needs a ``batch_no`` and the item-level row has none, so ERPNext
+          rejects it. Such an item's batch allocations genuinely cannot be represented
+          as ERPNext opening stock (e.g. a batch quantity that nets negative), so it is
+          skipped with a warning for manual entry - never posted at a wrong value.
         ``batch`` is "" for non-batch items, so they behave exactly as before.
         """
         item_qty = TallyExtractor.item_opening_qty(it)
-        legacy = [(default_wh, it.get("OpeningBalance"),
-                   it.get("OpeningRate"), it.get("OpeningValue"), "")]
-        godowns = it.get("GodownOpenings") or []
-        if not godowns:
-            return legacy
-        # A non-positive item quantity is not postable (and the legacy row drops it
-        # with a warning); never let a stray positive godown row post against it.
-        if item_qty <= 0:
-            return legacy
         # Tally stamps EVERY item's opening allocation with a batch name - an implicit
         # "Primary Batch" even for non-batch items - so the batch is only meaningful
         # when the item is actually batch-tracked. Otherwise batch_no would be set on a
         # has_batch_no=0 item and the reconciliation would be rejected.
         is_batch = (it.get("IsBatchWiseOn") or "").strip().lower() == "yes"
+        legacy = [(default_wh, it.get("OpeningBalance"),
+                   it.get("OpeningRate"), it.get("OpeningValue"), "")]
+        godowns = it.get("GodownOpenings") or []
+        if not godowns:
+            # A batch item needs a batch on every row; with no godown/batch detail
+            # there is no batch to post under, so skip rather than emit a batch-less
+            # row ERPNext rejects. A non-positive qty would be dropped anyway.
+            if is_batch and item_qty > 0:
+                return self._skip_unpostable_batch(it, result)
+            return legacy
+        # A non-positive item quantity is not postable (and the legacy row drops it
+        # with a warning); never let a stray positive godown row post against it.
+        if item_qty <= 0:
+            return legacy
         buckets: dict[tuple, float] = {}
         for g in godowns:
             wh = self._warehouse_for_godown(g.get("godown", ""), default_wh)
@@ -1202,11 +1212,15 @@ class StockOpeningImporter:
             buckets[(wh, batch)] = buckets.get((wh, batch), 0.0) + \
                 TallyExtractor._parse_quantity(g.get("qty"))
         # Faithfulness gate: a net-negative bucket cannot be posted, and a breakdown
-        # that does not sum to the item-level quantity would mis-state it. Either way,
-        # post the item-level row instead so the value still reconciles exactly.
-        if any(qty < -1e-9 for qty in buckets.values()):
-            return legacy
-        if abs(sum(buckets.values()) - item_qty) > 1e-6:
+        # that does not sum to the item-level quantity would mis-state it.
+        unfaithful = (any(qty < -1e-9 for qty in buckets.values())
+                      or abs(sum(buckets.values()) - item_qty) > 1e-6)
+        if unfaithful:
+            # A non-batch item falls back to the item-level row (still reconciles). A
+            # batch item cannot - the fallback row has no batch_no - and its batch
+            # allocations cannot be represented as ERPNext opening stock, so skip it.
+            if is_batch:
+                return self._skip_unpostable_batch(it, result)
             return legacy
         # Value every bucket at the item-level rate, distributing only the quantity.
         item_rate = TallyExtractor.item_opening_rate(it)
@@ -1216,6 +1230,23 @@ class StockOpeningImporter:
                 continue
             placements.append((wh, str(qty), str(item_rate), "", batch))
         return placements or legacy
+
+    @staticmethod
+    def _skip_unpostable_batch(it: dict, result: "ImportResult | None") -> list:
+        """Skip a batch-tracked item whose Tally batch allocations cannot be posted as
+        ERPNext opening stock - a batch quantity that nets negative, a godown/batch
+        split that does not reconcile to the item total, or no batch detail at all.
+        ERPNext opening stock cannot hold these, and a batch item cannot fall back to a
+        batch-less item-level row, so skip with a warning (manual entry) rather than
+        post a wrong value or fail the whole document. Returns no placements."""
+        if result is not None:
+            result.add_warning(
+                it.get("_name"),
+                "opening stock not posted - this batch-tracked item's Tally batch "
+                "allocations cannot be represented as ERPNext opening stock (a batch "
+                "quantity is negative, or the per-batch split does not reconcile to "
+                "the item's total). Set this item's opening stock manually.")
+        return []
 
     def _warehouse_for_godown(self, godown: str, default_wh: str) -> str:
         """Map a Tally godown name to its migrated ERPNext warehouse
@@ -1352,10 +1383,17 @@ class StockOpeningImporter:
 
         Idempotent and global (Stock Settings is a Single). Required for ERPNext to
         create the Serial and Batch Bundle that batch-tracked opening stock posts
-        through; we set it only when this import actually has batch rows."""
+        through; we set it only when this import actually has batch rows.
+
+        The change is committed immediately: the chunk-posting loop that follows rolls
+        back a failed chunk (``_post_doc``), and an uncommitted setting would be
+        reverted by that rollback - leaving every later batch chunk to fail with
+        "Activate Serial and Batch No for Item" and dropping all batch opening stock.
+        Committing once, up front, makes the flag survive any later chunk rollback."""
         if frappe.db.get_single_value("Stock Settings", "enable_serial_and_batch_no_for_item"):
             return
         frappe.db.set_single_value("Stock Settings", "enable_serial_and_batch_no_for_item", 1)
+        frappe.db.commit()
         result.add_warning(
             "Opening Stock",
             "enabled Stock Settings > 'Activate Serial and Batch No for Item' - it "

--- a/tally_migrator/erpnext/importers/openings.py
+++ b/tally_migrator/erpnext/importers/openings.py
@@ -1157,41 +1157,65 @@ class StockOpeningImporter:
         ``(warehouse, raw_qty, raw_rate, raw_value, batch)`` buckets fed to
         :meth:`_add_opening_row`.
 
+        The governing invariant: the rows for an item must total ``item_qty x
+        item_rate`` - the value the reconciliation counts - whatever the godown data
+        looks like. So:
+
         - No godown-wise detail (``GodownOpenings`` empty, e.g. a live client or an
           older export) → one bucket at the default warehouse using the item-level
           OpeningBalance/Rate/Value, i.e. exactly the legacy behaviour.
-        - Godown-wise detail present → one bucket per (resolved warehouse, batch).
-          Several godowns that map to the same warehouse *and* batch (e.g. both fall
-          back to the default because they weren't migrated) are summed, so nothing
-          is lost and the rows stay unique. A bucket fed by a single godown keeps
-          that godown's raw rate (preserving the unit-suffixed rate and the
-          value/rate cross-check); a summed bucket derives its rate from value÷qty.
-          ``batch`` is "" for non-batch items, so they behave exactly as before.
+        - Godown-wise detail present → net each allocation into its (resolved
+          warehouse, batch) bucket using SIGNED quantity. Tally's per-godown rows can
+          include negatives (transfers / oversold) that are only authoritative once
+          summed back to the item total. A clean split (every netted bucket >= 0 and
+          the buckets reproduce the item-level quantity) posts one row per bucket;
+          each is valued at the *item-level* rate, distributing only the quantity, so
+          the posted total ties exactly to the item value. Per-godown rate/value is
+          deliberately not trusted - it is frequently blank (then the row would post
+          at zero value) or internally inconsistent with the item total.
+        - When the godown split is not faithfully postable (a net-negative bucket,
+          which ERPNext opening stock cannot hold, or buckets that do not tie to the
+          item-level quantity) → fall back to the single item-level row, which always
+          reconciles. The per-warehouse detail is sacrificed for that one item, not
+          its value, and the run records a warning via the zero/negative handling.
+        ``batch`` is "" for non-batch items, so they behave exactly as before.
         """
+        item_qty = TallyExtractor.item_opening_qty(it)
+        legacy = [(default_wh, it.get("OpeningBalance"),
+                   it.get("OpeningRate"), it.get("OpeningValue"), "")]
         godowns = it.get("GodownOpenings") or []
         if not godowns:
-            return [(default_wh, it.get("OpeningBalance"),
-                     it.get("OpeningRate"), it.get("OpeningValue"), "")]
+            return legacy
+        # A non-positive item quantity is not postable (and the legacy row drops it
+        # with a warning); never let a stray positive godown row post against it.
+        if item_qty <= 0:
+            return legacy
         # Tally stamps EVERY item's opening allocation with a batch name - an implicit
         # "Primary Batch" even for non-batch items - so the batch is only meaningful
         # when the item is actually batch-tracked. Otherwise batch_no would be set on a
         # has_batch_no=0 item and the reconciliation would be rejected.
         is_batch = (it.get("IsBatchWiseOn") or "").strip().lower() == "yes"
-        buckets: dict[tuple, list] = {}
+        buckets: dict[tuple, float] = {}
         for g in godowns:
             wh = self._warehouse_for_godown(g.get("godown", ""), default_wh)
             batch = (g.get("batch") or "").strip() if is_batch else ""
-            buckets.setdefault((wh, batch), []).append(g)
+            buckets[(wh, batch)] = buckets.get((wh, batch), 0.0) + \
+                TallyExtractor._parse_quantity(g.get("qty"))
+        # Faithfulness gate: a net-negative bucket cannot be posted, and a breakdown
+        # that does not sum to the item-level quantity would mis-state it. Either way,
+        # post the item-level row instead so the value still reconciles exactly.
+        if any(qty < -1e-9 for qty in buckets.values()):
+            return legacy
+        if abs(sum(buckets.values()) - item_qty) > 1e-6:
+            return legacy
+        # Value every bucket at the item-level rate, distributing only the quantity.
+        item_rate = TallyExtractor.item_opening_rate(it)
         placements: list[tuple] = []
-        for (wh, batch), gs in buckets.items():
-            if len(gs) == 1:
-                g = gs[0]
-                placements.append((wh, g.get("qty"), g.get("rate"), g.get("value"), batch))
-            else:
-                qsum = sum(TallyExtractor._parse_quantity(g.get("qty")) for g in gs)
-                vsum = sum(abs(BaseImporter._to_float(g.get("value"))) for g in gs)
-                placements.append((wh, str(qsum), "", str(vsum), batch))
-        return placements
+        for (wh, batch), qty in buckets.items():
+            if qty <= 1e-9:
+                continue
+            placements.append((wh, str(qty), str(item_rate), "", batch))
+        return placements or legacy
 
     def _warehouse_for_godown(self, godown: str, default_wh: str) -> str:
         """Map a Tally godown name to its migrated ERPNext warehouse

--- a/tally_migrator/erpnext/importers/openings.py
+++ b/tally_migrator/erpnext/importers/openings.py
@@ -1178,11 +1178,13 @@ class StockOpeningImporter:
           which ERPNext opening stock cannot hold, or buckets that do not tie to the
           item-level quantity) → a NON-batch item falls back to the single item-level
           row, which always reconciles (per-warehouse detail is sacrificed for that one
-          item, not its value). A BATCH-tracked item cannot fall back this way: every
-          opening row needs a ``batch_no`` and the item-level row has none, so ERPNext
-          rejects it. Such an item's batch allocations genuinely cannot be represented
-          as ERPNext opening stock (e.g. a batch quantity that nets negative), so it is
-          skipped with a warning for manual entry - never posted at a wrong value.
+          item, not its value). A BATCH-tracked item cannot fall back to a batch-less
+          item-level row (every opening row needs a ``batch_no``), so instead it is
+          collapsed onto the single real batch that held the most stock - the item
+          quantity x rate posted under the largest positive bucket (see
+          :meth:`_collapse_unpostable_batch`). Value and total are kept; only the
+          per-batch split is sacrificed. If no positive bucket maps to an existing
+          Batch, it is skipped with a warning for manual entry - never a wrong value.
         ``batch`` is "" for non-batch items, so they behave exactly as before.
         """
         item_qty = TallyExtractor.item_opening_qty(it)
@@ -1217,10 +1219,10 @@ class StockOpeningImporter:
                       or abs(sum(buckets.values()) - item_qty) > 1e-6)
         if unfaithful:
             # A non-batch item falls back to the item-level row (still reconciles). A
-            # batch item cannot - the fallback row has no batch_no - and its batch
-            # allocations cannot be represented as ERPNext opening stock, so skip it.
+            # batch item cannot fall back to a batch-less row, but it can still be
+            # homed under a single real batch - collapse it there, keeping its value.
             if is_batch:
-                return self._skip_unpostable_batch(it, result)
+                return self._collapse_unpostable_batch(it, buckets, result)
             return legacy
         # Value every bucket at the item-level rate, distributing only the quantity.
         item_rate = TallyExtractor.item_opening_rate(it)
@@ -1247,6 +1249,56 @@ class StockOpeningImporter:
                 "quantity is negative, or the per-batch split does not reconcile to "
                 "the item's total). Set this item's opening stock manually.")
         return []
+
+    def _collapse_unpostable_batch(self, it: dict, buckets: dict,
+                                   result: "ImportResult | None") -> list:
+        """Home an unrepresentable batch item's opening on a single real batch.
+
+        A batch-tracked item whose Tally breakdown cannot be posted batch-for-batch -
+        a batch quantity nets negative (oversold / transferred), or the buckets do not
+        sum to the item total - still has an authoritative, reconciling item-level
+        quantity and rate: the negatives only net out against the positives at the item
+        level, which ERPNext opening stock cannot represent per batch. Rather than drop
+        the value, collapse to one line - the item-level quantity x rate posted under
+        the single (warehouse, batch) bucket that genuinely held the most stock (the
+        largest positive bucket whose Batch master exists for this item). This mirrors
+        the non-batch fallback (one row, value kept, the per-location split sacrificed)
+        while keeping a real batch so ERPNext accepts the row, and it ties the
+        reconciliation exactly. When no positive bucket maps to an existing Batch (e.g.
+        every batch id clashed cross-item and was skipped, or the positives carry no
+        batch name) the value cannot be homed anywhere, so fall back to skipping with a
+        warning for manual entry.
+        """
+        item_qty = TallyExtractor.item_opening_qty(it)
+        item_rate = TallyExtractor.item_opening_rate(it)
+        code = safe_item_code(it.get("_name", ""))
+        shared = getattr(self, "_shared_batch_names", set())
+        # Largest positive (warehouse, batch) bucket whose Batch exists for this item:
+        # the most representative single home for the collapsed quantity.
+        for (wh, batch), qty in sorted(
+                buckets.items(), key=lambda kv: kv[1], reverse=True):
+            if qty <= 1e-9 or not batch:
+                continue
+            if not self._batch_exists_for_item(batch_id_for(batch, code, shared), code):
+                continue
+            if result is not None:
+                result.add_warning(
+                    it.get("_name"),
+                    f"opening stock posted as a single batch line - this item's Tally "
+                    f"batch breakdown includes a negative or non-reconciling batch "
+                    f"quantity that ERPNext opening stock cannot hold, so its full "
+                    f"opening ({item_qty:g} at {item_rate:g}) was posted under batch "
+                    f"'{batch}'. The per-batch split was not preserved; set batch-wise "
+                    "opening stock manually if you need it.")
+            return [(wh, str(item_qty), str(item_rate), "", batch)]
+        # No positive bucket maps to an existing batch - nothing postable.
+        return self._skip_unpostable_batch(it, result)
+
+    def _batch_exists_for_item(self, batch_id: str, item_code: str) -> bool:
+        """True when ``batch_id`` is an existing Batch belonging to ``item_code`` (the
+        Batch importer creates these before opening stock). Isolated as its own method
+        so the placement maths can be unit-tested without a database."""
+        return frappe.db.get_value("Batch", batch_id, "item") == item_code
 
     def _warehouse_for_godown(self, godown: str, default_wh: str) -> str:
         """Map a Tally godown name to its migrated ERPNext warehouse

--- a/tally_migrator/migration/reconciliation.py
+++ b/tally_migrator/migration/reconciliation.py
@@ -32,9 +32,18 @@ only ``erpnext_totals`` touches the database (Frappe imported lazily there).
 from __future__ import annotations
 
 from tally_migrator.tally.extractors import TallyExtractor
+from tally_migrator.tally.mappings import is_stock_item
 
 # A difference below this (currency units) is rounding noise, not a real variance.
 _TOLERANCE = 1.0
+
+# Opening stock is posted as qty x valuation_rate, and ERPNext stores valuation_rate
+# at the company's currency precision (2-3 dp). Re-multiplying that rounded rate by a
+# large quantity leaves a small residual against Tally's full-precision value that
+# grows with the stock value, so the stock line uses a proportional tolerance (this
+# fraction of the stock value, but never less than the flat _TOLERANCE) - genuine
+# sub-precision rounding reads as reconciled, a real variance still shows.
+_STOCK_TOLERANCE_PCT = 0.0005  # 0.05%
 
 # Trial-balance classes in reading order, with display labels. Liability and Equity
 # are merged into one "Liabilities & Equity" row on purpose: Tally and ERPNext
@@ -49,13 +58,6 @@ _CLASS_LABEL = {"Asset": "Assets", "LiabEquity": "Liabilities & Equity",
 
 def _class_of(root_type: str) -> str:
     return "LiabEquity" if root_type in ("Liability", "Equity") else root_type
-
-
-def _to_float(v) -> float:
-    try:
-        return float(str(v or 0).replace(",", "").strip())
-    except (ValueError, TypeError):
-        return 0.0
 
 
 def _signed(amount: float, dr_cr: str) -> float:
@@ -106,19 +108,26 @@ def source_totals(coa, masters) -> dict:
 
     stock_value = 0.0
     stock_items = 0
+    non_stock_value = 0.0
+    non_stock_items = 0
     for it in masters.items:
-        qty = TallyExtractor._parse_quantity(it.get("OpeningBalance"))
+        # The same authoritative qty and rate the importer posts (item level, falling
+        # back to the godown allocations), so both sides tie exactly.
+        qty = TallyExtractor.item_opening_qty(it)
         if qty <= 0:
             continue
-        rate = TallyExtractor._parse_rate(it.get("OpeningRate"))
-        if rate == 0:
-            val = abs(_to_float(it.get("OpeningValue")))
-            if val:
-                rate = val / qty
-        if rate == 0:
-            rate = TallyExtractor._parse_rate(it.get("StandardCost"))
-        stock_value += qty * rate
-        stock_items += 1
+        rate = TallyExtractor.item_opening_rate(it)
+        # Count opening stock for exactly the items the importer posts. A service /
+        # non-stock item cannot hold stock in ERPNext (the importer drops it with a
+        # warning), so counting its opening quantity here would be a phantom stock
+        # variance against an ERPNext side that never held it. Keep its value aside as
+        # an un-migrated note instead, so it is disclosed rather than silently lost.
+        if is_stock_item(it):
+            stock_value += qty * rate
+            stock_items += 1
+        else:
+            non_stock_value += qty * rate
+            non_stock_items += 1
 
     # Temporary Opening is the contra for every opening posting, so it ends holding
     # the negative of (ledger accounts + parties + stock) - exactly Tally's own
@@ -133,6 +142,10 @@ def source_totals(coa, masters) -> dict:
         "payables": _side(supp_net),      # suppliers net Cr (Creditors control)
         "stock": {"amount": round(stock_value, 2), "dr_cr": "Dr" if stock_value else ""},
         "stock_items": stock_items,
+        # Disclosed, not part of the balancing trial balance: opening value Tally
+        # carried on service / non-stock items, which ERPNext cannot hold as stock.
+        "non_stock_value": round(non_stock_value, 2),
+        "non_stock_items": non_stock_items,
         "temporary_opening": _side(temp_net),
     }
 
@@ -289,10 +302,10 @@ def compare(source: dict, erp: dict) -> dict:
         elif side.get("dr_cr") == "Cr":
             totals[cr_key] += side["amount"]
 
-    def add(key, label, src_side, erp_side, is_diff=False):
+    def add(key, label, src_side, erp_side, is_diff=False, tol=_TOLERANCE):
         nonlocal all_match
         has = erp_side is not None
-        match = bool(has and abs(_signed_of(src_side) - _signed_of(erp_side)) < _TOLERANCE)
+        match = bool(has and abs(_signed_of(src_side) - _signed_of(erp_side)) < tol)
         if has and not match:
             all_match = False
         _accumulate(src_side, "src_dr", "src_cr")
@@ -312,8 +325,9 @@ def compare(source: dict, erp: dict) -> dict:
         erp.get("receivables") if available else None)
     add("payables", "Payables", source["payables"],
         erp.get("payables") if available else None)
+    stock_tol = max(_TOLERANCE, _STOCK_TOLERANCE_PCT * abs(_signed_of(source["stock"])))
     add("stock", "Stock value", source["stock"],
-        erp.get("stock") if available else None)
+        erp.get("stock") if available else None, tol=stock_tol)
     add("temporary_opening", "Temporary Opening", source["temporary_opening"],
         erp.get("temporary_opening") if available else None, is_diff=True)
 
@@ -322,6 +336,13 @@ def compare(source: dict, erp: dict) -> dict:
         "verdict": verdict,
         "available": available,
         "stock_items": source.get("stock_items", 0),
+        # Opening value on service / non-stock items that ERPNext cannot hold as
+        # stock - disclosed alongside the trial balance so it is visible, not folded
+        # into the stock line (where it would read as a variance) or lost.
+        "non_stock": {
+            "value": source.get("non_stock_value", 0.0),
+            "items": source.get("non_stock_items", 0),
+        },
         "rows": rows,
         "total": {
             "source": {"dr": round(totals["src_dr"], 2), "cr": round(totals["src_cr"], 2)},

--- a/tally_migrator/tally/extractors.py
+++ b/tally_migrator/tally/extractors.py
@@ -536,6 +536,65 @@ class TallyExtractor:
             return 0.0
 
     @staticmethod
+    def _to_float(raw) -> float:
+        """Parse a Tally numeric cell (e.g. an opening value '-31329.00') → float.
+        Returns 0.0 when there is no leading number. Sign is preserved."""
+        s = str(raw or "").strip().replace(",", "")
+        if not s:
+            return 0.0
+        m = re.match(r"[-+]?\d*\.?\d+", s)
+        if not m:
+            return 0.0
+        try:
+            return float(m.group(0))
+        except ValueError:
+            return 0.0
+
+    @staticmethod
+    def item_opening_qty(it: dict) -> float:
+        """Authoritative opening quantity for a stock item (signed). The item-level
+        OpeningBalance when Tally states it, else the sum of the godown allocations.
+        Tally normally records the item level as that sum, but falling back keeps a
+        godown-only item counted and posted consistently. Shared by the importer and
+        the reconciliation so both sides agree on what an item's opening qty is."""
+        qty = TallyExtractor._parse_quantity(it.get("OpeningBalance"))
+        if qty != 0:
+            return qty
+        return sum(TallyExtractor._parse_quantity(g.get("qty"))
+                   for g in (it.get("GodownOpenings") or []))
+
+    @staticmethod
+    def item_opening_rate(it: dict) -> float:
+        """Authoritative opening valuation rate for a stock item - the single rule
+        shared by the importer (which posts qty x rate) and the reconciliation (which
+        counts qty x rate), so the two sides always tie.
+
+        Cascade: the item-level opening rate, then the item-level value / qty, then
+        the item's standard cost, and finally - when Tally records a rate only on the
+        godown allocations and leaves the item master blank - the summed allocation
+        value / qty (signed, so transfers net out). Returns 0.0 when no valuation can
+        be found anywhere; the item then posts at zero value (with a warning).
+        """
+        qty = abs(TallyExtractor.item_opening_qty(it))
+        if qty == 0:
+            return 0.0
+        rate = TallyExtractor._parse_rate(it.get("OpeningRate"))
+        if rate:
+            return rate
+        value = abs(TallyExtractor._to_float(it.get("OpeningValue")))
+        if value:
+            return value / qty
+        rate = TallyExtractor._parse_rate(it.get("StandardCost"))
+        if rate:
+            return rate
+        godown_value = abs(sum(
+            TallyExtractor._to_float(g.get("value"))
+            for g in (it.get("GodownOpenings") or [])))
+        if godown_value:
+            return godown_value / qty
+        return 0.0
+
+    @staticmethod
     def _parse_opening(raw) -> tuple[float, str]:
         """Parse a Tally opening balance → (abs_amount, 'Dr'|'Cr'|'').
 

--- a/tally_migrator/tally/mappings.py
+++ b/tally_migrator/tally/mappings.py
@@ -7,6 +7,20 @@ import re
 DEBTOR_ROOTS   = {"Sundry Debtors"}
 CREDITOR_ROOTS = {"Sundry Creditors"}
 
+# ── Stock vs non-stock item classification ────────────────────────────────────
+
+def is_stock_item(record: dict) -> int:
+    """1 if a Tally Stock Item maps to a stock-tracked ERPNext Item, else 0.
+
+    A Tally item whose GST supply type is 'Services' becomes a non-stock Item in
+    ERPNext (it cannot hold stock); every other supply type stays a stock item.
+    Pure (no Frappe), so both the importer and the read-only reconciliation can
+    share one definition - the reconciliation must count opening stock for exactly
+    the items the importer will post, or a service item with an opening quantity
+    creates a phantom stock variance."""
+    supply = (record.get("TypeOfSupply") or "").strip().lower()
+    return 0 if supply in ("services", "service") else 1
+
 # ── Unit of Measure: Tally → ERPNext ─────────────────────────────────────────
 
 UOM_MAP: dict[str, str] = {

--- a/tally_migrator/tally_migration/doctype/tally_migration_log/tally_migration_log.js
+++ b/tally_migrator/tally_migration/doctype/tally_migration_log/tally_migration_log.js
@@ -673,6 +673,14 @@ function render_reconciliation(frm) {
 		? `<div class="text-muted small" style="margin-top:8px;">Stock value across ${r.stock_items} item(s) with opening quantity. Receivables/Payables are the Debtors/Creditors control totals (shown separately from Assets/Liabilities).</div>`
 		: "";
 
+	// Opening value Tally carried on service / non-stock items: ERPNext cannot hold it
+	// as stock, so it is disclosed here rather than counted on the Stock value line
+	// (where it would read as a variance) or dropped silently.
+	const nonStock = r.non_stock || {};
+	const nonStockNote = nonStock.items
+		? `<div class="text-muted small" style="margin-top:4px;">Opening value not migrated as stock: ${fmt(nonStock.value)} across ${nonStock.items} service / non-stock item(s) - ERPNext cannot hold stock for these; record their value as a ledger balance if needed.</div>`
+		: "";
+
 	wrapper.html(section(`
 		<div style="${CARD} max-width:100%;">
 			${callout(v.kind, iconRow(v.kind, v.text), "margin-bottom:8px;")}
@@ -701,6 +709,7 @@ function render_reconciliation(frm) {
 				<tfoot>${foot}</tfoot>
 			</table>
 			${stockNote}
+			${nonStockNote}
 		</div>
 	`));
 }

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -1592,15 +1592,71 @@ class TestERPNextImporter(unittest.TestCase):
         self.assertEqual(rows[0]["valuation_rate"], 758.48)
         self.assertEqual(rows[0]["warehouse"], "WH - TC")   # item-level default
 
-    def test_negative_godown_batch_item_is_skipped_with_warning(self):
-        """A BATCH-tracked item whose batch allocations net via a negative cannot fall
-        back to a batch-less item-level row (ERPNext rejects it) and cannot be
-        represented as opening stock, so it posts nothing and warns for manual entry -
-        never a wrong value."""
+    def test_negative_godown_batch_item_collapses_to_dominant_batch(self):
+        """A BATCH-tracked item whose batch allocations net via a negative cannot post
+        per batch, but its authoritative item-level qty x rate is homed on the single
+        largest positive batch (value kept, split sacrificed) - never the gross 99,
+        never zero value, never dropped."""
         from tally_migrator.erpnext.importers import StockOpeningImporter
         from tally_migrator.erpnext.importers.base import ImportResult
         imp = StockOpeningImporter("_TMTest Co", "TC")
         imp._warehouse_for_godown = lambda g, d: (f"{g} - TC" if g else d)
+        imp._batch_exists_for_item = lambda batch_id, code: True   # batches created
+        item = {"_name": "Cable", "IsBatchWiseOn": "Yes", "OpeningBalance": "41 PCS",
+                "OpeningRate": "758.48/PCS", "OpeningValue": "", "StandardCost": "",
+                "GodownOpenings": [
+                    {"godown": "CHD", "qty": "99 PCS", "rate": "", "value": "", "batch": "124"},
+                    {"godown": "Main", "qty": "-58 PCS", "rate": "", "value": "", "batch": "Primary"}]}
+        res, by_key = ImportResult("Stock Reconciliation"), {}
+        placements = imp._placements(item, "WH - TC", res)
+        self.assertEqual(len(placements), 1)           # collapsed to one row
+        for wh, q, r, v, b in placements:
+            imp._add_opening_row(by_key, item["_name"], wh, q, r, v,
+                                 item.get("StandardCost"), res, batch=b)
+        rows = list(by_key.values())
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["qty"], 41.0)                 # item-level net, not 99
+        self.assertEqual(rows[0]["valuation_rate"], 758.48)
+        self.assertEqual(rows[0]["warehouse"], "CHD - TC")     # dominant positive bucket
+        self.assertEqual(rows[0]["batch_no"], "124")           # homed on the largest batch
+        self.assertEqual(round(rows[0]["qty"] * rows[0]["valuation_rate"], 2), 31097.68)
+        self.assertIn("single batch line", res.warnings[0]["reason"])
+
+    def test_collapsed_batch_item_homes_on_largest_positive_bucket(self):
+        """With several positive batches and a negative one, the collapsed line lands on
+        the single largest positive (warehouse, batch) bucket, carrying the whole
+        item-level quantity x rate."""
+        from tally_migrator.erpnext.importers import StockOpeningImporter
+        from tally_migrator.erpnext.importers.base import ImportResult
+        imp = StockOpeningImporter("_TMTest Co", "TC")
+        imp._warehouse_for_godown = lambda g, d: (f"{g} - TC" if g else d)
+        imp._batch_exists_for_item = lambda batch_id, code: True
+        item = {"_name": "Cable", "IsBatchWiseOn": "Yes", "OpeningBalance": "59 PCS",
+                "OpeningRate": "100.00/PCS", "OpeningValue": "", "StandardCost": "",
+                "GodownOpenings": [
+                    {"godown": "CHD", "qty": "20 PCS", "rate": "", "value": "", "batch": "A"},
+                    {"godown": "HSP", "qty": "53 PCS", "rate": "", "value": "", "batch": "B"},
+                    {"godown": "MOH", "qty": "-14 PCS", "rate": "", "value": "", "batch": "C"}]}
+        res, by_key = ImportResult("Stock Reconciliation"), {}
+        for wh, q, r, v, b in imp._placements(item, "WH - TC", res):
+            imp._add_opening_row(by_key, item["_name"], wh, q, r, v,
+                                 item.get("StandardCost"), res, batch=b)
+        rows = list(by_key.values())
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["warehouse"], "HSP - TC")   # 53 is the largest bucket
+        self.assertEqual(rows[0]["batch_no"], "B")
+        self.assertEqual(rows[0]["qty"], 59.0)               # full item total
+        self.assertEqual(rows[0]["qty"] * rows[0]["valuation_rate"], 5900.0)
+
+    def test_negative_godown_batch_item_skips_when_no_batch_master(self):
+        """When no positive bucket maps to an existing Batch (e.g. every batch id
+        clashed cross-item and was skipped by the Batch importer), the value cannot be
+        homed anywhere, so the item posts nothing and warns for manual entry."""
+        from tally_migrator.erpnext.importers import StockOpeningImporter
+        from tally_migrator.erpnext.importers.base import ImportResult
+        imp = StockOpeningImporter("_TMTest Co", "TC")
+        imp._warehouse_for_godown = lambda g, d: (f"{g} - TC" if g else d)
+        imp._batch_exists_for_item = lambda batch_id, code: False   # no Batch master
         item = {"_name": "Cable", "IsBatchWiseOn": "Yes", "OpeningBalance": "41 PCS",
                 "OpeningRate": "758.48/PCS", "OpeningValue": "", "StandardCost": "",
                 "GodownOpenings": [

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -1556,6 +1556,95 @@ class TestERPNextImporter(unittest.TestCase):
         self.assertEqual(captured["items"][0]["valuation_rate"], 10.0)  # 300 / 30
         self.assertFalse(any("more than once" in w["reason"] for w in result.warnings))
 
+    # ── Godown-wise opening stock invariant (no DB - placement maths only) ──────
+
+    def _godown_rows(self, item, default="WH - TC"):
+        """Build the opening rows _placements + _add_opening_row produce for ``item``,
+        with the godown→warehouse map stubbed (a named godown migrates to
+        '<godown> - TC', a blank one falls to the default)."""
+        from tally_migrator.erpnext.importers import StockOpeningImporter
+        from tally_migrator.erpnext.importers.base import ImportResult
+        imp = StockOpeningImporter("_TMTest Co", "TC")
+        imp._warehouse_for_godown = lambda g, d: (f"{g} - TC" if g else d)
+        res, by_key = ImportResult("Stock Reconciliation"), {}
+        for wh, q, r, v, b in imp._placements(item, default):
+            imp._add_opening_row(by_key, item["_name"], wh, q, r, v,
+                                 item.get("StandardCost"), res, batch=b)
+        return list(by_key.values()), res
+
+    def test_negative_godown_allocation_falls_back_to_item_level(self):
+        """+99 in one godown and -58 in another net to the item-level 41. ERPNext
+        cannot hold the -58, so post the item-level net (41) at the item rate - never
+        the gross 99, and never at zero value."""
+        item = {"_name": "Case", "IsBatchWiseOn": "No", "OpeningBalance": "41 PCS",
+                "OpeningRate": "758.48/PCS", "OpeningValue": "", "StandardCost": "",
+                "GodownOpenings": [
+                    {"godown": "CHD", "qty": "99 PCS", "rate": "", "value": ""},
+                    {"godown": "Main", "qty": "-58 PCS", "rate": "", "value": ""}]}
+        rows, _ = self._godown_rows(item)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["qty"], 41.0)
+        self.assertEqual(rows[0]["valuation_rate"], 758.48)
+        self.assertEqual(rows[0]["warehouse"], "WH - TC")   # item-level default
+
+    def test_divergent_per_godown_rate_uses_item_rate(self):
+        """Godowns carrying their own (higher) rate are still valued at the item-level
+        rate, so the posted total ties to item_qty x item_rate, not the godown rates."""
+        item = {"_name": "Pods", "IsBatchWiseOn": "No", "OpeningBalance": "2 Nos",
+                "OpeningRate": "1000.00/Nos", "OpeningValue": "", "StandardCost": "",
+                "GodownOpenings": [
+                    {"godown": "A", "qty": "1 Nos", "rate": "1500.00/Nos", "value": "-1500.00"},
+                    {"godown": "B", "qty": "1 Nos", "rate": "1500.00/Nos", "value": "-1500.00"}]}
+        rows, _ = self._godown_rows(item)
+        self.assertEqual(sum(r["qty"] for r in rows), 2.0)
+        self.assertTrue(all(r["valuation_rate"] == 1000.0 for r in rows))
+
+    def test_godown_qty_mismatch_falls_back_to_item_level(self):
+        """When the godown allocations do not sum to the item-level quantity the split
+        is not faithful, so post the item-level row (which always reconciles)."""
+        item = {"_name": "Widget", "IsBatchWiseOn": "No", "OpeningBalance": "30 Nos",
+                "OpeningRate": "10.00/Nos", "OpeningValue": "", "StandardCost": "",
+                "GodownOpenings": [
+                    {"godown": "A", "qty": "15 Nos", "rate": "", "value": ""},
+                    {"godown": "B", "qty": "10 Nos", "rate": "", "value": ""}]}   # sums to 25
+        rows, _ = self._godown_rows(item)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["qty"], 30.0)
+        self.assertEqual(rows[0]["valuation_rate"], 10.0)
+        self.assertEqual(rows[0]["warehouse"], "WH - TC")
+
+    def test_clean_godown_split_posts_per_warehouse_at_item_rate(self):
+        """A clean, all-positive split that ties to the item quantity posts one row per
+        warehouse, each at the item-level rate (total == item_qty x item_rate)."""
+        item = {"_name": "Cable", "IsBatchWiseOn": "No", "OpeningBalance": "30 Nos",
+                "OpeningRate": "10.00/Nos", "OpeningValue": "", "StandardCost": "",
+                "GodownOpenings": [
+                    {"godown": "A", "qty": "20 Nos", "rate": "", "value": ""},
+                    {"godown": "B", "qty": "10 Nos", "rate": "", "value": ""}]}
+        rows, _ = self._godown_rows(item)
+        by_wh = {r["warehouse"]: r for r in rows}
+        self.assertEqual(by_wh["A - TC"]["qty"], 20.0)
+        self.assertEqual(by_wh["B - TC"]["qty"], 10.0)
+        self.assertTrue(all(r["valuation_rate"] == 10.0 for r in rows))
+        self.assertEqual(sum(r["qty"] * r["valuation_rate"] for r in rows), 300.0)
+
+    def test_item_opening_qty_and_rate_helpers(self):
+        """The shared qty/rate rule: item level wins, else the godown allocations."""
+        from tally_migrator.tally.extractors import TallyExtractor as TE
+        # qty: item-level OpeningBalance, else summed godown qty
+        self.assertEqual(TE.item_opening_qty({"OpeningBalance": "41 PCS"}), 41.0)
+        self.assertEqual(TE.item_opening_qty(
+            {"OpeningBalance": "", "GodownOpenings": [{"qty": "20 Nos"}, {"qty": "10 Nos"}]}),
+            30.0)
+        # rate: item rate, then value/qty, then summed godown value/qty
+        self.assertEqual(TE.item_opening_rate(
+            {"OpeningBalance": "10 Nos", "OpeningRate": "5.00/Nos"}), 5.0)
+        self.assertEqual(TE.item_opening_rate(
+            {"OpeningBalance": "10 Nos", "OpeningValue": "-250.00"}), 25.0)
+        self.assertEqual(TE.item_opening_rate(
+            {"OpeningBalance": "30 Nos", "GodownOpenings": [
+                {"value": "-200.00"}, {"value": "-100.00"}]}), 10.0)
+
     # ── Opening-balance batching (no DB - residual maths only) ──────────────────
 
     def test_warn_residual_only_fires_above_threshold(self):

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -487,10 +487,15 @@ class TestERPNextImporter(unittest.TestCase):
         from tally_migrator.erpnext.importers import openings
         res = ImportResult("Stock Reconciliation")
         with mock.patch.object(openings.frappe.db, "get_single_value", return_value=0), \
-             mock.patch.object(openings.frappe.db, "set_single_value") as set_single:
+             mock.patch.object(openings.frappe.db, "set_single_value") as set_single, \
+             mock.patch.object(openings.frappe.db, "commit") as commit:
             StockOpeningImporter._ensure_serial_batch_enabled(res)
         set_single.assert_called_once_with(
             "Stock Settings", "enable_serial_and_batch_no_for_item", 1)
+        # The flip MUST be committed up front: the chunk-posting loop rolls back a
+        # failed chunk, and an uncommitted setting would be reverted by that rollback,
+        # dropping all batch opening stock.
+        commit.assert_called_once()
         self.assertTrue(res.warnings)   # the flip is recorded on the log
 
     def test_ensure_serial_batch_enabled_noop_when_already_on(self):
@@ -1586,6 +1591,26 @@ class TestERPNextImporter(unittest.TestCase):
         self.assertEqual(rows[0]["qty"], 41.0)
         self.assertEqual(rows[0]["valuation_rate"], 758.48)
         self.assertEqual(rows[0]["warehouse"], "WH - TC")   # item-level default
+
+    def test_negative_godown_batch_item_is_skipped_with_warning(self):
+        """A BATCH-tracked item whose batch allocations net via a negative cannot fall
+        back to a batch-less item-level row (ERPNext rejects it) and cannot be
+        represented as opening stock, so it posts nothing and warns for manual entry -
+        never a wrong value."""
+        from tally_migrator.erpnext.importers import StockOpeningImporter
+        from tally_migrator.erpnext.importers.base import ImportResult
+        imp = StockOpeningImporter("_TMTest Co", "TC")
+        imp._warehouse_for_godown = lambda g, d: (f"{g} - TC" if g else d)
+        item = {"_name": "Cable", "IsBatchWiseOn": "Yes", "OpeningBalance": "41 PCS",
+                "OpeningRate": "758.48/PCS", "OpeningValue": "", "StandardCost": "",
+                "GodownOpenings": [
+                    {"godown": "CHD", "qty": "99 PCS", "rate": "", "value": "", "batch": "124"},
+                    {"godown": "Main", "qty": "-58 PCS", "rate": "", "value": "", "batch": "Primary"}]}
+        res = ImportResult("Stock Reconciliation")
+        rows = imp._placements(item, "WH - TC", res)
+        self.assertEqual(rows, [])                     # nothing posted
+        self.assertEqual(res.warned, 1)
+        self.assertIn("manually", res.warnings[0]["reason"])
 
     def test_divergent_per_godown_rate_uses_item_rate(self):
         """Godowns carrying their own (higher) rate are still valued at the item-level

--- a/tally_migrator/tests/test_reconciliation.py
+++ b/tally_migrator/tests/test_reconciliation.py
@@ -122,6 +122,49 @@ class TestSourceTotals(unittest.TestCase):
         self.assertEqual(s["temporary_opening"], {"amount": 0.0, "dr_cr": ""})
 
 
+class TestStockNonStockAndGodown(unittest.TestCase):
+    """The reconciliation must count opening stock for exactly the items the importer
+    posts (stock items, valued at the same item rate), so the two sides tie."""
+
+    def test_non_stock_item_excluded_from_stock_and_disclosed(self):
+        # A service item carries an opening quantity. ERPNext cannot hold it as stock
+        # (the importer drops it), so it must not inflate the stock line - it is
+        # disclosed separately instead of silently counted or lost.
+        m = _masters(items=[
+            {"_name": "Mouse", "OpeningBalance": "100 Nos", "OpeningRate": "1.00/Nos",
+             "OpeningValue": "", "StandardCost": ""},
+            {"_name": "Consulting", "OpeningBalance": "10 Nos",
+             "OpeningRate": "100.00/Nos", "OpeningValue": "", "StandardCost": "",
+             "TypeOfSupply": "Services"},
+        ])
+        s = source_totals(_coa([]), m)
+        self.assertEqual(s["stock"]["amount"], 100.0)     # only the stock item
+        self.assertEqual(s["stock_items"], 1)
+        self.assertEqual(s["non_stock_value"], 1000.0)    # service value disclosed
+        self.assertEqual(s["non_stock_items"], 1)
+
+    def test_compare_surfaces_non_stock_note(self):
+        m = _masters(items=[
+            {"_name": "Consulting", "OpeningBalance": "10 Nos",
+             "OpeningRate": "100.00/Nos", "OpeningValue": "", "StandardCost": "",
+             "TypeOfSupply": "Services"}])
+        out = compare(source_totals(_coa([]), m), {"available": False})
+        self.assertEqual(out["non_stock"], {"value": 1000.0, "items": 1})
+
+    def test_godown_only_rate_counted_in_source(self):
+        # The item master carries a quantity but no rate/value; the valuation lives on
+        # the godown allocations. The source must still count it (value/qty), matching
+        # what the importer posts.
+        m = _masters(items=[{
+            "_name": "Pen", "OpeningBalance": "30 Nos", "OpeningRate": "",
+            "OpeningValue": "", "StandardCost": "", "GodownOpenings": [
+                {"godown": "A", "qty": "20 Nos", "rate": "", "value": "-200.00"},
+                {"godown": "B", "qty": "10 Nos", "rate": "", "value": "-100.00"}]}])
+        s = source_totals(_coa([]), m)
+        self.assertEqual(s["stock"]["amount"], 300.0)
+        self.assertEqual(s["stock_items"], 1)
+
+
 class TestCompare(unittest.TestCase):
     def _src(self):
         return source_totals(
@@ -178,6 +221,24 @@ class TestCompare(unittest.TestCase):
             keys,
             ["class_Asset", "class_LiabEquity", "receivables", "payables",
              "stock", "temporary_opening"])
+
+    def test_stock_tolerance_absorbs_rounding_but_flags_real_variance(self):
+        # Opening stock posts qty x a currency-rounded rate, so a large stock value
+        # leaves a tiny proportional residual that must read as reconciled - while a
+        # material variance must still flag. (Other rows are irrelevant here.)
+        src = source_totals(
+            _coa([]), _masters(items=[_item("Bulk", "1000000 Nos", rate="100.00/Nos")]))
+        self.assertEqual(src["stock"]["amount"], 100000000.0)   # 1e8; 0.05% = 50,000
+
+        def _stock_row(erp_stock_amount):
+            erp = {"available": True, "classes": {}, "receivables": {}, "payables": {},
+                   "stock": {"amount": erp_stock_amount, "dr_cr": "Dr"},
+                   "temporary_opening": src["temporary_opening"]}
+            out = compare(src, erp)
+            return next(r for r in out["rows"] if r["key"] == "stock")
+
+        self.assertTrue(_stock_row(100000000.0 - 40)["match"])      # 40 within tolerance
+        self.assertFalse(_stock_row(100000000.0 - 200000)["match"])  # 200k is real
 
 
 class TestCumulativeOpeningsFlag(unittest.TestCase):


### PR DESCRIPTION
## Summary

A full real-world audit found that opening **stock value did not reconcile** after a migration - a net 25,813 gap on a ~16,000-master export. It looked like benign valuation rounding; it was not. The root cause is in the godown-wise opening stock path: it treats Tally's per-godown allocations as independently postable, when the breakdown is only authoritative **in aggregate** (the item-level total is their sum).

Two failure modes, same root:

1. **Rate dropped → posts at zero value.** When Tally records the rate only at the item level and leaves the godown allocations blank, each godown row's rate cascade finds nothing and posts at **valuation 0**. One item alone lost 31,098 of book value this way.
2. **Negative allocations dropped → qty/value overstated.** Tally's godown rows include negatives (transfers / oversold, e.g. `+99` and `-58` netting to `41`). ERPNext opening stock cannot hold a negative line, so the importer posted the gross `+99` and dropped the `-58` - overstating quantity and, for items that did have a rate, value.

The two partly offset, which is exactly why the net looked like a small rounding figure.

## The fix

One invariant drives everything: **an item's posted rows must total `item_qty x item_rate`** - the value the reconciliation counts - regardless of what the godown data looks like.

### Posting (`openings.py`, `extractors.py`)
- New shared, pure rules `TallyExtractor.item_opening_qty` / `item_opening_rate`: the item-level quantity and rate (rate → value/qty → standard cost → summed godown value/qty), falling back to the godown allocations only when the item master is blank. One definition, used by both the importer and the reconciliation, so the two sides always tie.
- `_placements` rewritten: net godown allocations into their `(warehouse, batch)` bucket with **signed** quantity; value every bucket at the **item-level rate**, distributing only quantity, so per-godown rate/value (often blank or inconsistent) never skews the total. When the split cannot be posted faithfully - a net-negative bucket, or buckets that do not sum to the item total - **fall back to the single item-level row** at the default warehouse, so the value is always kept and only that one item's per-warehouse split is sacrificed.

### Reconciliation (`reconciliation.py`, `mappings.py`, `items.py`)
- Count opening stock for exactly the items the importer posts, valued at the same item rate, so the Stock value line ties to ERPNext.
- Move the stock-vs-non-stock rule to one shared pure helper (`mappings.is_stock_item`; `items.py` delegates to it). A **service / non-stock item carrying an opening quantity** is excluded from the stock line (ERPNext cannot hold it as stock) and **disclosed** as a separate "opening value not migrated as stock" figure on the Migration Log - rather than counted as a phantom variance or dropped silently.
- Give the stock line a **proportional tolerance** (0.05%, floored at the flat tolerance) so genuine sub-precision rate rounding reads as reconciled while a real variance still flags.

## Validation

- **Invariant proven on real data:** posted stock value ties to the source exactly across **all 2,528 stock items** on the audit export (residual 0.00, 0 per-item mismatches). The previously zeroed item now carries its full 31,098.
- **Currency rounding (component B): ~0** at precisions 2 / 3 / 6 - the original 25,813 was entirely the godown bug, not rounding.
- **Stress-tested across 11 exports** (Master.xml, Frontier.xml, Latest Data.xml, NM.xml, MAX.xml, tally_master_data_sample.xml, allmasterss.xml, and others) under **two warehouse layouts** (per-godown buckets and all-godowns-collapsed). Every file: residual 0.00, 0 invariant mismatches. Branch coverage on real data: legacy (no godowns), clean godown-split, negative-bucket fallback, in-bucket signed netting, and zero-rate items.
- **Tests:** +9 unit tests (negative-bucket fallback, divergent per-godown rate, qty-mismatch fallback, clean split, the qty/rate helpers, non-stock exclusion + disclosure, proportional tolerance). Full suite: **517 pass**.

## Notes

- No standard Chart of Accounts is touched, no settings customized, and the tolerance is proportional (no magic numbers tied to one file).
- The service/non-stock disclosure path is exercised by unit tests; none of the sampled real exports happened to carry a service item with an opening quantity, so it is dormant-but-correct on that data.
- Docs updated for the valuation, godown-fallback, and non-stock disclosure behaviour.
