### PR TITLE
fix: Step-4 advance preview matches what the importer posts

### DIFF
--- a/tally_migrator/migration/account_mapping.py
+++ b/tally_migrator/migration/account_mapping.py
@@ -105,11 +105,18 @@ def _signed(amount: float, dr_cr: str) -> float:
 
 
 def _classify_party(party_type: str, signed: float, is_advance: bool) -> str:
-    """Mirror of PartyOpeningImporter._classify: an outstanding invoice (party's
-    natural side, not flagged advance) vs an advance/credit. Customer natural side
-    = Dr (signed > 0); Supplier = Cr (signed < 0); Tally's ISADVANCE forces advance."""
-    if is_advance:
-        return "advance"
+    """Mirror of PartyOpeningImporter._classify: an outstanding invoice (the party's
+    natural side) vs an advance/credit (the opposite side). Customer natural side =
+    Dr (signed > 0); Supplier = Cr (signed < 0).
+
+    Tally's ``is_advance`` is deliberately NOT used to force 'advance' - the flag is
+    kept in the signature (callers pass the real value) but ignored, so this preview
+    counts exactly what the importer posts. A genuine advance already sits on the
+    opposite side; some exports also tag a NATURAL-side bill ISADVANCE, and the
+    importer posts that as an outstanding invoice (routing by side keeps every bill's
+    GL effect equal to Tally's). Forcing those to 'advance' here over-counted advances
+    on the Step-4 screen versus what actually migrated. See
+    ``PartyOpeningImporter._classify`` for the full rationale and the matching tests."""
     on_natural_side = (signed > 0) if party_type == "Customer" else (signed < 0)
     return "invoice" if on_natural_side else "advance"
 
@@ -123,8 +130,9 @@ def _party_openings(masters, bills) -> dict:
 
       * **invoices**   - outstanding bills on the party's natural side -> one
         opening Sales/Purchase Invoice each.
-      * **advances**   - ISADVANCE bills (or bills on the opposite side) -> one
-        opening Payment Entry each.
+      * **advances**   - bills on the side opposite the party's natural side -> one
+        opening Payment Entry each. (Tally's ISADVANCE flag is not used to force this:
+        the importer routes purely by side, so the preview matches it.)
       * **on_account** - parties whose bills did not add up to the ledger opening;
         the gap posts as one 'On Account' opening (a mismatch worth reviewing).
       * **lump**       - parties with an opening but no bill detail -> a single

--- a/tally_migrator/tests/test_account_mapping.py
+++ b/tally_migrator/tests/test_account_mapping.py
@@ -116,6 +116,35 @@ class TestAccountMapping(unittest.TestCase):
         # No bill detail in this fixture, so it posts a single lump opening document.
         self.assertEqual(acme["documents"], 1)
 
+    def test_natural_side_advance_flagged_bill_counts_as_invoice(self):
+        # Regression: a bill on the party's NATURAL side that Tally also tags
+        # ISADVANCE must be previewed as an outstanding invoice, NOT an advance -
+        # that is exactly what PartyOpeningImporter._classify posts (it routes by side
+        # and ignores ISADVANCE). The Step-4 screen must report what migrates, so its
+        # advance/invoice split has to match the importer. The old preview forced
+        # ISADVANCE to 'advance' and over-counted advances versus what actually posted.
+        from tally_migrator.tally.file_source import FileTallySource
+
+        xml = (
+            '<ENVELOPE><BODY><IMPORTDATA><REQUESTDATA>'
+            '<TALLYMESSAGE><GROUP NAME="Sundry Debtors"><NAME>Sundry Debtors</NAME>'
+            '<PARENT>Primary</PARENT></GROUP></TALLYMESSAGE>'
+            '<TALLYMESSAGE><LEDGER NAME="Acme Corp"><NAME>Acme Corp</NAME>'
+            '<PARENT>Sundry Debtors</PARENT><OPENINGBALANCE>-5000.00</OPENINGBALANCE>'
+            '<BILLALLOCATIONS.LIST><NAME>INV-1</NAME><BILLDATE>20260401</BILLDATE>'
+            '<ISADVANCE>Yes</ISADVANCE><OPENINGBALANCE>-5000.00</OPENINGBALANCE>'
+            '</BILLALLOCATIONS.LIST>'
+            '</LEDGER></TALLYMESSAGE>'
+            '</REQUESTDATA></IMPORTDATA></BODY></ENVELOPE>'
+        )
+        p = account_mapping(FileTallySource(xml))["party_openings"]
+        self.assertEqual(p["invoices"], 1)     # the natural-side bill -> invoice
+        self.assertEqual(p["advances"], 0)     # NOT forced to an advance by ISADVANCE
+        row = next(r for r in p["parties_list"] if r["name"] == "Acme Corp")
+        self.assertEqual(row["invoices"], 1)
+        self.assertEqual(row["advances"], 0)
+        self.assertEqual(row["documents"], 1)  # net ties to ledger, so no extra plug
+
     def test_balanced_book_reads_clean(self):
         ledgers = [
             _l("HDFC Bank", "Bank Accounts", "50000.00 Dr"),

--- a/tally_migrator/tests/test_critical_fixes.py
+++ b/tally_migrator/tests/test_critical_fixes.py
@@ -488,6 +488,21 @@ class TestPartyOpeningClassification(unittest.TestCase):
         self.assertEqual(PartyOpeningImporter._signed(100.0, "Dr"), 100.0)
         self.assertEqual(PartyOpeningImporter._signed(100.0, "Cr"), -100.0)
 
+    def test_preview_classifier_matches_importer(self):
+        # The Step-4 preview keeps its own copy of this routing
+        # (account_mapping._classify_party) so it can run pure, with no Frappe. The two
+        # diverged once - the preview forced ISADVANCE to an advance while the importer
+        # ignored it - so the screen over-counted advances versus what actually posted.
+        # Lock them together across the full input matrix so they can never drift again.
+        from tally_migrator.migration.account_mapping import _classify_party
+        for party_type in ("Customer", "Supplier"):
+            for signed in (5000.0, -5000.0, 0.0):
+                for is_advance in (True, False):
+                    self.assertEqual(
+                        _classify_party(party_type, signed, is_advance),
+                        PartyOpeningImporter._classify(party_type, signed, is_advance),
+                        msg=f"{party_type} signed={signed} is_advance={is_advance}")
+
 
 class TestPartyOpeningOrchestration(unittest.TestCase):
     """_process routes bills, reconciles to the ledger opening, and plugs the gap.


### PR DESCRIPTION
## Problem
The Step-4 "Review accounts" preview classified a bill tagged Tally ISADVANCE as an *advance*, but the importer (`PartyOpeningImporter._classify`) deliberately ignores ISADVANCE and routes purely by ledger side. So a bill on the party's **natural side** that Tally also tagged ISADVANCE was counted as an advance on screen while it actually posted as an outstanding **invoice** - the preview overstated the advance count versus what migrated.

GL postings were always correct; only the preview's invoice/advance split was wrong.

## Fix
Drop the `is_advance` branch in `account_mapping._classify_party` so the preview routes by side, identical to the importer. The flag stays in the signature (callers pass the real value) but is ignored.

## Tests
- **Preview regression** (`test_account_mapping`): a natural-side ISADVANCE bill now counts as an invoice, not an advance.
- **Anti-drift guard** (`test_critical_fixes`): `_classify_party` is locked equal to `PartyOpeningImporter._classify` across the full party/sign/flag matrix, so the two copies (the preview keeps its own to stay Frappe-free) can never silently diverge again.

Independent of the opening-stock work: touches only `account_mapping.py` and two test files.