### PR TITLE
fix: keep address naming-series in step on PIN retry; allow "New Item" items

### DIFF
--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -770,6 +770,10 @@ Migrator handles a real-world wrinkle in Tally data.
   ERPNext item code (codes are truncated to 140 characters and "/" becomes "-"). The
   first wins; the second is skipped with a warning naming both, so you can rename one
   in Tally. The pre-flight flags this too.
+- **Reserved item name.** ERPNext refuses to save any record literally named "New
+  Item" (it reserves that for a blank, unsaved item), so a Tally item with that exact
+  name is imported with a slightly adjusted code ("Item - New Item") while keeping its
+  original name. Nothing for you to do.
 - **Unit resolution.** An item's Tally base unit maps to an ERPNext UOM: your chosen
   mapping first, then the built-in unit map, then the Tally unit's own name if a UOM
   by that name exists, and only "Nos" as a last resort.

--- a/tally_migrator/erpnext/importers/party.py
+++ b/tally_migrator/erpnext/importers/party.py
@@ -488,6 +488,19 @@ class PartyImporter(BaseImporter):
             if addr.pincode and ("not associated with" in msg or "postal code" in msg):
                 try:
                     addr.pincode = ""
+                    # Force the name to be re-derived on this second attempt. The first
+                    # insert already ran autoname - which, for a colliding address title,
+                    # bumps a "<title>-<type>-.#" series counter (make_autoname) - then
+                    # failed, and atomic()'s savepoint rolled the counter back. But the
+                    # doc kept the name it claimed (flags.name_set short-circuits
+                    # re-naming in Document.set_new_name), so reusing it would commit a
+                    # name one ahead of the now-rolled-back counter, leaving the series
+                    # permanently behind. The NEXT same-titled address then regenerates
+                    # this number and hits a duplicate-key error (the address is lost).
+                    # Clearing name + name_set makes the retry re-run autoname, bumping
+                    # the counter back in step with what actually commits.
+                    addr.name = None
+                    addr.flags.name_set = False
                     with atomic():
                         addr.insert(ignore_permissions=True)
                     # Drop the failed attempt's queued "Invalid Postal Code" message -

--- a/tally_migrator/naming.py
+++ b/tally_migrator/naming.py
@@ -11,7 +11,19 @@ from collections import defaultdict
 
 def safe_item_code(name: str) -> str:
     """ERPNext item_code caps at 140 chars and dislikes '/'."""
-    return (name or "")[:140].replace("/", "-").strip()
+    code = (name or "")[:140].replace("/", "-").strip()
+    # Frappe reserves the literal string "New {Doctype}" for the unsaved-document
+    # placeholder and refuses to save a real record under it - validate_name raises
+    # NameError for any name starting with "New Item" (frappe/model/naming.py). Items
+    # are named by item_code, so a Tally item literally called "New Item" is unsavable
+    # as-is. Disambiguate just enough to clear the reserved prefix. This is the single
+    # Tally-name -> item_code mapping every consumer shares (the Item itself AND every
+    # batch / BOM / price / opening-stock reference to it), so the links stay
+    # consistent and a re-run still matches. The original label is kept as item_name.
+    # Matches frappe's own case-sensitive check, so only names it would reject change.
+    if code.startswith("New Item"):
+        code = f"Item - {code}"[:140]
+    return code
 
 
 def company_scoped(base: str, abbr: str) -> str:

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -952,17 +952,29 @@ class TestERPNextImporter(unittest.TestCase):
         """India Compliance rejects a pincode whose digits don't match the state. The
         importer must keep the address (dropping just the PIN) instead of losing it -
         and never crash. Regression for the PIN/state warning aborting the migration."""
+        import types
         from unittest import mock
         from tally_migrator.erpnext.importers import CustomerImporter, ImportResult
 
         class FakeAddr:
             def __init__(self):
                 self.links = []
+                # A real frappe doc always carries these; the retry re-derives the name
+                # by clearing them so autoname runs again (see _save_address).
+                self.flags = types.SimpleNamespace(name_set=False)
+                self.name = None
+                self.name_set_at_retry = None
             def append(self, t, r):
                 self.links.append(r)
             def insert(self, **k):
                 if getattr(self, "pincode", ""):   # IC rejects the bad PIN
+                    # Mimic frappe: autoname claims a name and marks it set, then the
+                    # DB insert raises on the pincode/state mismatch.
+                    self.name = "X-Billing"
+                    self.flags.name_set = True
                     raise Exception("Postal Code 166982 is not associated with Kerala")
+                # Retry path: record what the importer left for re-derivation.
+                self.name_set_at_retry = (self.name, self.flags.name_set)
                 self.inserted = True
 
         fake = FakeAddr()
@@ -978,6 +990,10 @@ class TestERPNextImporter(unittest.TestCase):
 
         self.assertTrue(getattr(fake, "inserted", False))   # address still created
         self.assertEqual(fake.pincode, "")                  # only the PIN was dropped
+        # The retry cleared the claimed name + name_set so autoname re-runs and the
+        # naming-series counter is bumped back in step (no duplicate-key on the next
+        # same-titled address).
+        self.assertEqual(fake.name_set_at_retry, (None, False))
         self.assertEqual(len(result.errors), 0)             # no hard failure
         self.assertTrue(any("without its PIN" in w["reason"] for w in result.warnings))
 

--- a/tally_migrator/tests/test_naming.py
+++ b/tally_migrator/tests/test_naming.py
@@ -1,0 +1,44 @@
+"""Pure unit tests for the shared Tally-name -> ERPNext-code transforms.
+
+No frappe needed, so these run under ``make test-pure`` and ``make test-bench``.
+"""
+import unittest
+
+from tally_migrator.naming import safe_item_code
+
+
+class TestSafeItemCode(unittest.TestCase):
+    def test_reserved_new_item_prefix_is_disambiguated(self):
+        # Frappe reserves "New Item" (and any "New Item..." prefix) for the unsaved-
+        # document placeholder and raises NameError on save, so the code must not
+        # start with it.
+        self.assertFalse(safe_item_code("New Item").startswith("New Item"))
+        self.assertEqual(safe_item_code("New Item"), "Item - New Item")
+        self.assertFalse(safe_item_code("New Item 2").startswith("New Item"))
+        self.assertFalse(safe_item_code("New Items").startswith("New Item"))
+
+    def test_disambiguation_is_idempotent(self):
+        # Running an already-safe code back through must not double-prefix it, so a
+        # re-run still matches the existing item.
+        self.assertEqual(safe_item_code("Item - New Item"), "Item - New Item")
+
+    def test_only_the_case_frappe_rejects_changes(self):
+        # Frappe's reserved check is case-sensitive; other casings are valid names and
+        # must be left untouched (changing them would needlessly alter item codes).
+        self.assertEqual(safe_item_code("new item"), "new item")
+        self.assertEqual(safe_item_code("NEW ITEM"), "NEW ITEM")
+
+    def test_normal_codes_unchanged(self):
+        self.assertEqual(safe_item_code("Widget"), "Widget")
+        self.assertEqual(safe_item_code("A/B"), "A-B")
+        self.assertEqual(safe_item_code("  Spaced  "), "Spaced")
+        self.assertEqual(safe_item_code(""), "")
+        self.assertEqual(safe_item_code(None), "")
+
+    def test_result_never_exceeds_140_chars(self):
+        self.assertEqual(len(safe_item_code("x" * 200)), 140)
+        self.assertLessEqual(len(safe_item_code("New Item " + "y" * 200)), 140)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tally_migrator/tests/test_party_address_naming.py
+++ b/tally_migrator/tests/test_party_address_naming.py
@@ -1,0 +1,86 @@
+"""The address PIN-salvage retry must re-derive the name, not reuse it.
+
+Run via ``bench run-tests`` (imports ``tally_migrator.erpnext.importers.party``,
+which imports ``frappe``); the DB is fully mocked, so no site is touched.
+
+Why this matters: when an address insert fails on a pincode/state mismatch, the
+importer drops the PIN and retries. The first (failed) attempt already ran autoname,
+which - for a colliding address title - bumps a ``<title>-<type>-.#`` naming-series
+counter, and then rolled back with its savepoint. But the doc kept the name it
+claimed, because ``Document.set_new_name`` short-circuits while ``flags.name_set`` is
+True. Reusing that name commits a value one ahead of the rolled-back counter, leaving
+the series permanently behind - so the NEXT same-titled address regenerates the same
+number and hits a duplicate-key error (the address is lost). The retry must therefore
+clear ``name`` + ``name_set`` so autoname runs again and the counter stays in step.
+"""
+import contextlib
+import types
+import unittest
+from unittest import mock
+
+from tally_migrator.erpnext.importers import party
+from tally_migrator.erpnext.importers.base import ImportResult
+
+
+@contextlib.contextmanager
+def _noop_atomic():
+    yield
+
+
+class _FakeAddr:
+    """Stand-in for a frappe Address doc that fails its first insert on the pincode."""
+
+    def __init__(self):
+        self.flags = types.SimpleNamespace(name_set=False)
+        self.name = None
+        self.pincode = ""
+        self.inserts = 0
+        # (name, name_set) observed at the start of each insert attempt.
+        self.states_at_insert = []
+
+    def append(self, *args, **kwargs):
+        pass
+
+    def insert(self, **kwargs):
+        self.inserts += 1
+        self.states_at_insert.append((self.name, self.flags.name_set))
+        if self.inserts == 1:
+            # frappe's set_new_name claims a name and marks it set; then the DB insert
+            # rejects the pincode/state mismatch.
+            self.name = "Manpreet Singh-Billing-13"
+            self.flags.name_set = True
+            raise Exception("Postal Code 110001 is not associated with Punjab")
+        # Second attempt: a re-derived name commits cleanly.
+        self.name = "Manpreet Singh-Billing-13"
+
+
+class TestAddressRetryRederivesName(unittest.TestCase):
+    def test_pin_retry_clears_name_so_autoname_reruns(self):
+        addr = _FakeAddr()
+        imp = party.PartyImporter.__new__(party.PartyImporter)  # skip __init__/frappe
+        result = ImportResult("Supplier")
+        data = {"Address": "123 Street", "PinCode": "110001",
+                "CountryName": "India", "MailingName": "Manpreet Singh"}
+
+        with mock.patch.object(party, "frappe") as fr, \
+                mock.patch.object(party, "atomic", _noop_atomic), \
+                mock.patch.object(party, "validate_email_address", return_value=""), \
+                mock.patch.object(party, "validate_gstin", return_value=(False, "")), \
+                mock.patch.object(party, "_address_requires_state", return_value=True), \
+                mock.patch.object(party.PartyImporter, "_resolve_state",
+                                  return_value="Punjab"):
+            fr.new_doc.return_value = addr
+            name = imp._save_address("Manpreet Singh", "Supplier", data, result)
+
+        # It retried exactly once after the postal-code failure.
+        self.assertEqual(addr.inserts, 2)
+        # The crux: at the retry, name was cleared and name_set reset, so autoname
+        # re-runs and the series counter is bumped back in step with what commits.
+        self.assertEqual(addr.states_at_insert[1], (None, False))
+        # The salvaged address is kept and its name returned (not a hard drop).
+        self.assertEqual(name, "Manpreet Singh-Billing-13")
+        self.assertTrue(any("without its PIN" in w["reason"] for w in result.warnings))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two masters-side edge cases found on a real 13k-supplier import, both verified fixed end-to-end on that file: the run goes from "Completed with Errors" to "Completed", ~88 dropped supplier addresses are recovered, and the single hard item failure is gone. Books still reconcile and the GL balances to the paisa.

## 1. Duplicate-key address losses (~88 suppliers)

ERPNext names a colliding Address via a `<title>-<type>-.#` naming-series counter. On the pincode/state salvage retry, `_save_address` reused the doc's already-claimed name (`Document.set_new_name` short-circuits while `flags.name_set` is True), but `atomic()`'s savepoint had rolled the counter back when the first insert failed. The retry then committed a name one ahead of the counter, leaving the series permanently behind - so the next address with the same (case-insensitive) title regenerated that number and hit an `IntegrityError`, dropping the address.

Fix: clear `name` + `name_set` before the retry so autoname re-runs and the counter stays in step with what commits. Confirmed on the live DB (committed max `-13`, `tabSeries.current` was `12`).

## 2. Reserved "New Item" name (1 item)

Frappe refuses to save any record named `New <Doctype>` (`validate_name` raises `NameError` - it reserves that for the unsaved-doc placeholder). A Tally item literally called "New Item" is named by its `item_code`, so it hard-failed.

Fix: guard the reserved prefix in `safe_item_code`, the single Tally-name -> item_code mapping every consumer shares (the Item and all its batch/BOM/price/opening-stock references), so the item lands as `Item - New Item` with every reference consistent and a re-run still matches. `item_name` keeps the original label. Case-sensitive, matching frappe's own check, so only names it would reject change.

## Tests
- New `test_naming` (reserved-name guard, idempotency, case-sensitivity, 140-char cap).
- New `test_party_address_naming` (the retry re-derivation contract).
- `test_importer`'s address-salvage fake updated to model `flags`/`name`.
- Full suite green (526).

## Verification
Re-ran the full 13k-supplier file after the fix: status `Completed`, 0 hard failures, 0 duplicate-address `IntegrityError`s (was 26 rows / ~89 suppliers), items 2,632 -> 2,633, supplier address drops 6,737 -> 6,649. Reconciliation `reconciled`; GL Dr = Cr.

## Docs
One bullet added to the Items edge-cases section.