### PR TITLE
fix: suspend India Compliance GSTIN portal-autofill during the party phase

### DIFF
--- a/tally_migrator/erpnext/importers/party.py
+++ b/tally_migrator/erpnext/importers/party.py
@@ -104,13 +104,28 @@ _SUSPENDED_PARTY_HOOKS = (
     # per contact. A cosmetic telephony convenience, re-derivable; irrelevant here.
     ("erpnext.telephony.doctype.call_log.call_log",
      ("link_existing_conversations",)),
+    # India Compliance GSTIN autofill: when GST Settings has the API + autofill on,
+    # validating a party with a GSTIN calls the GST portal to fetch its registered
+    # name/category (and enqueues request-log jobs). IC already skips this under
+    # `frappe.flags.in_import`, which the migrator deliberately does NOT set (it would
+    # also skip default population + link validation). Left active it fires once per
+    # party: on a 13k-supplier book that is 13k GST-portal fetches whose log jobs
+    # saturate the background queue ("Too many queued background jobs"), stalling the
+    # run near the end of the party phase. Patched to return None so the gate
+    # (`is_autofill_party_info_enabled()`) reads falsy - exactly as if autofill were
+    # off - and IC falls back to the offline `guess_gst_category`. The party still
+    # imports with its GSTIN; the user can refresh portal info later if they want it.
+    ("india_compliance.gst_india.overrides.party",
+     ("is_autofill_party_info_enabled",)),
 )
 
 
 @contextlib.contextmanager
 def _party_side_effect_hooks_suspended():
-    """Neutralise the per-contact Google-Contacts sync and Call-Log linking hooks for
-    the duration of the party phase, then restore them. No-op-safe: a module or symbol
+    """Neutralise per-party external side-effects for the duration of the party phase,
+    then restore them: the Google-Contacts sync, Call-Log linking, and India
+    Compliance's per-party GST-portal autofill (see the table above). No-op-safe: a
+    module or symbol
     that is not installed is skipped, leaving Frappe/ERPNext untouched. Migrations are
     serialised by the single-active-run guard, so the process-local patch can never
     bleed into a concurrent migration (same contract as _gravatar_lookup_suspended)."""


### PR DESCRIPTION
## Problem
On a large masters import against a site with India Compliance's **live** GST API (GST Settings: `enable_api` + `autofill_party_info`, sandbox off), the run stalls near the end of the supplier phase (~12k of 13k, ~79%) and never finishes.

Diagnosed from a live run: memory was flat (~1.1 GB, under its extraction peak) and the worker stayed alive - **not** an out-of-memory issue. The Error Log showed the real cause:
> `Failed to Fetch GSTIN Info → Too many queued background jobs`

Validating each party with a GSTIN calls the GST portal (`fetch_or_guess_gst_category → _get_gstin_info`) and enqueues request-log jobs. Across 13k suppliers this saturates the background-job queue; every subsequent party then blocks/retries on the full queue, crawling to a near-halt.

It does not reproduce on a sandbox/offline site, where the production API is disabled so the autofill gate is already off.

## Fix
India Compliance already skips this autofill under `frappe.flags.in_import`, which the migrator deliberately does not set (it would also skip default population and link validation). So the autofill fired once per party.

Add IC's gate `is_autofill_party_info_enabled` (its sole call site, in `gst_india.overrides.party`) to the migrator's existing `_SUSPENDED_PARTY_HOOKS` table. Patched to return `None` for the party phase, the gate reads falsy - exactly as if autofill were off - so IC falls back to the offline `guess_gst_category` and makes no GST-portal call or job. Parties still import with their GSTIN; portal info can be refreshed later.

Same process-local, restore-in-`finally` mechanism already used for the Google-Contacts and Call-Log suspensions (serialised by the single-active-run guard; no-op when IC is absent).

## Scope / validation
- `is_autofill_party_info_enabled` has exactly one call site; every party doctype (Customer/Supplier/Address) routes through it; the suspension wraps `PartyImporter.run`, covering both party phases plus their address/contact `after_insert`. No other phase creates parties.
- Verified the gate reads falsy inside the suspension and is restored after.
- Full suite shows no new failures.

Note: a memory-instrumentation branch (what surfaced this) is kept separate for diagnostics.