### PR TITLE
perf: lightweight set_link_title in the party phase (avoid full party-doc load)

### DIFF
--- a/tally_migrator/erpnext/importers/party.py
+++ b/tally_migrator/erpnext/importers/party.py
@@ -146,6 +146,92 @@ def _party_side_effect_hooks_suspended():
             setattr(mod, nm, fn)
 
 
+# Modules that hold their own `set_link_title` binding (imported at module load), so
+# both must be repointed to patch the calls made from Address.validate / Contact.validate.
+_LINK_TITLE_MODULES = (
+    "frappe.contacts.doctype.address.address",
+    "frappe.contacts.doctype.contact.contact",
+)
+
+
+@lru_cache(maxsize=None)
+def _uses_default_get_title(doctype: str) -> bool:
+    """True when ``doctype`` does not override ``Document.get_title`` - i.e. its title is
+    exactly the title-field value, so a single ``get_value`` reproduces it. False (=> use
+    stock) for any doctype with a custom ``get_title`` so we never guess a title wrong."""
+    from frappe.model.document import Document
+    from frappe.model.base_document import get_controller
+    try:
+        return get_controller(doctype).get_title is Document.get_title
+    except Exception:
+        return False
+
+
+def _lightweight_set_link_title(doc):
+    """Drop-in for frappe's ``set_link_title`` that avoids loading the whole linked doc.
+
+    Stock ``set_link_title`` does ``frappe.get_doc(link_doctype, link_name)`` per link -
+    for a party that pulls the full Supplier/Customer plus all four of its child tables
+    (~5 queries) only to read one title. Since ``get_title()`` is just the title-field
+    value for a doctype that doesn't override it, we read that field with a single
+    ``get_value`` instead. The resulting ``link_title`` is byte-identical to stock; any
+    link whose doctype overrides ``get_title`` (or any error) defers to the stock
+    function, so the stored value can never diverge. Restored after the party phase.
+    """
+    try:
+        links = getattr(doc, "links", None)
+        if not links:
+            return
+        # Only take the fast path when EVERY link's doctype uses the default get_title
+        # (title == title-field value); if any overrides it, defer wholesale to stock.
+        if all(_uses_default_get_title(l.link_doctype) for l in links):
+            for link in links:
+                title_field = frappe.get_meta(link.link_doctype).get_title_field()
+                doc_title = frappe.db.get_value(
+                    link.link_doctype, link.link_name, title_field) or ""
+                if link.link_title != doc_title:
+                    link.link_title = doc_title or link.link_name
+            return
+    except Exception:
+        pass
+    # A non-default doctype, or any error: fall back to stock so link_title can never
+    # diverge. Resolve the original robustly even if called outside the context manager.
+    orig = _ORIG_SET_LINK_TITLE
+    if orig is None:
+        from frappe.contacts.address_and_contact import set_link_title as orig
+    return orig(doc)
+
+
+# Captured original, used by the lightweight version's fallback. Set when the context
+# manager installs the patch; None until then.
+_ORIG_SET_LINK_TITLE = None
+
+
+@contextlib.contextmanager
+def _link_title_lightweight():
+    """Swap frappe's per-link full-doc load (``set_link_title``) for the lightweight
+    title read above, for the party phase only. No-op-safe (skips when the symbol is
+    absent) and restored in ``finally``; same process-local contract as the gravatar /
+    side-effect suspensions (serialised by the single-active-run guard)."""
+    global _ORIG_SET_LINK_TITLE
+    saved = []
+    for path in _LINK_TITLE_MODULES:
+        try:
+            mod = importlib.import_module(path)
+        except Exception:
+            continue
+        if hasattr(mod, "set_link_title"):
+            if _ORIG_SET_LINK_TITLE is None:
+                _ORIG_SET_LINK_TITLE = mod.set_link_title
+            saved.append((mod, mod.set_link_title))
+            mod.set_link_title = _lightweight_set_link_title
+    try:
+        yield
+    finally:
+        for mod, fn in saved:
+            mod.set_link_title = fn
+
+
 # ── Party importers (Customer / Supplier) ──────────────────────────────────────
 
 class PartyImporter(BaseImporter):
@@ -166,11 +252,13 @@ class PartyImporter(BaseImporter):
 
     def run(self, records: list[dict], on_progress=None) -> "ImportResult":
         """Import parties with the per-contact integration hooks suspended - the
-        gravatar network lookup plus the Google-Contacts sync and Call-Log linking
-        hooks, all data-irrelevant per-record cost of the phase (see
-        ``_gravatar_lookup_suspended`` / ``_party_side_effect_hooks_suspended``).
+        gravatar network lookup, the Google-Contacts sync and Call-Log linking hooks,
+        and the full-doc load in ``set_link_title`` (all data-irrelevant per-record cost
+        of the phase; see ``_gravatar_lookup_suspended`` /
+        ``_party_side_effect_hooks_suspended`` / ``_link_title_lightweight``).
         Everything else is the standard template."""
-        with _gravatar_lookup_suspended(), _party_side_effect_hooks_suspended():
+        with _gravatar_lookup_suspended(), _party_side_effect_hooks_suspended(), \
+                _link_title_lightweight():
             return super().run(records, on_progress=on_progress)
 
     def before_run(self, records: list[dict], result: "ImportResult") -> None:

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -121,6 +121,57 @@ class TestERPNextImporter(unittest.TestCase):
             for mod, nm, fn in saved:
                 setattr(mod, nm, fn)
 
+    def test_lightweight_set_link_title_uses_get_value_not_get_doc(self):
+        """The lightweight set_link_title reads the linked doc's title with one get_value
+        (title field), never a full get_doc - and writes the same link_title stock would."""
+        import types
+        from unittest import mock
+        from tally_migrator.erpnext.importers import party as P
+        link = types.SimpleNamespace(link_doctype="Supplier", link_name="SUP-1",
+                                     link_title=None)
+        doc = types.SimpleNamespace(links=[link])
+        with mock.patch.object(P, "_uses_default_get_title", return_value=True), \
+                mock.patch("frappe.get_meta") as gm, \
+                mock.patch("frappe.db.get_value", return_value="Acme Traders") as gv, \
+                mock.patch("frappe.get_doc") as gd:
+            gm.return_value.get_title_field.return_value = "supplier_name"
+            P._lightweight_set_link_title(doc)
+        self.assertEqual(link.link_title, "Acme Traders")
+        gv.assert_called_once_with("Supplier", "SUP-1", "supplier_name")
+        gd.assert_not_called()                    # the point: no full-doc load
+
+    def test_lightweight_set_link_title_defers_for_overridden_title(self):
+        """A doctype that overrides get_title (title not just the title field) must fall
+        back to stock set_link_title, so the stored title can never diverge."""
+        import types
+        from unittest import mock
+        from tally_migrator.erpnext.importers import party as P
+        link = types.SimpleNamespace(link_doctype="Weird", link_name="W-1", link_title=None)
+        doc = types.SimpleNamespace(links=[link])
+        called = []
+        orig = P._ORIG_SET_LINK_TITLE
+        P._ORIG_SET_LINK_TITLE = lambda d: called.append(d)
+        try:
+            with mock.patch.object(P, "_uses_default_get_title", return_value=False):
+                P._lightweight_set_link_title(doc)
+        finally:
+            P._ORIG_SET_LINK_TITLE = orig
+        self.assertEqual(called, [doc])           # deferred to stock; we touched nothing
+
+    def test_link_title_lightweight_patches_and_restores(self):
+        """The context manager repoints set_link_title in both the address and contact
+        modules for its duration, then restores the originals."""
+        import importlib
+        from tally_migrator.erpnext.importers.party import _link_title_lightweight
+        am = importlib.import_module("frappe.contacts.doctype.address.address")
+        cm = importlib.import_module("frappe.contacts.doctype.contact.contact")
+        before_a, before_c = am.set_link_title, cm.set_link_title
+        with _link_title_lightweight():
+            self.assertIsNot(am.set_link_title, before_a)
+            self.assertIsNot(cm.set_link_title, before_c)
+        self.assertIs(am.set_link_title, before_a)
+        self.assertIs(cm.set_link_title, before_c)
+
     def test_party_import_does_not_fire_contact_integration_hooks(self):
         """A normal Contact insert fires the Google-Contacts/Call-Log hooks; importing
         a party that creates a Contact must not (they are suspended), while the Contact


### PR DESCRIPTION
## What
Validating an Address or Contact runs frappe's `set_link_title`, which does `frappe.get_doc(link_doctype, link_name)` per link - for a party that loads the whole Supplier/Customer **plus all four of its child tables (~5 queries)** just to read the title for the Dynamic Link. It fires on both the address and the contact, so ~10 wasted queries per party on the run's largest phase.

`_link_title_lightweight()` repoints `set_link_title` (in both the address and contact modules) for the party phase only, to a version that reads the linked doc's title with a **single `get_value`** of its title field instead of a full `get_doc`.

## Why it's safe
- `get_title()` is exactly the title-field value for any doctype that doesn't override it, so `link_title` is **byte-identical** to stock (verified: Supplier and Customer both match).
- Any link whose doctype **overrides `get_title`** (checked via `get_controller(dt).get_title is Document.get_title`), or **any error**, defers to the stock `set_link_title` - the stored value can never diverge.
- Restored in `finally`; same process-local, single-active-run contract as the existing gravatar / side-effect-hook suspensions in this file.
- `link_title` is a display field - nothing GST/HSN/e-invoice/validation touched.

## Measured (real 13k-supplier file)
**42.6 -> 36.3 queries/supplier (-6.3, ~15%).** On Frappe Cloud (~0.64 ms/query) that's ~50s across the file.

## Tests / rules
- Generic: keyed on the default-`get_title` check, not a hardcoded doctype list.
- No regression: full suite identical (19/5 environmental) with/without.
- New tests: lightweight uses `get_value` not `get_doc` and matches stock; defers to stock for overridden `get_title`; context manager patches both modules and restores.
- Stress-tested: Supplier / Customer / both links, overridden-title fallback, restoration (no global leak).

Independent of #51 (different code paths); both target the party phase.