### PR TITLE
perf: skip ERPNext's internal-supplier uniqueness scan for external suppliers

### DIFF
--- a/tally_migrator/erpnext/importers/party.py
+++ b/tally_migrator/erpnext/importers/party.py
@@ -232,6 +232,58 @@ def _link_title_lightweight():
             mod.set_link_title = fn
 
 
+# ── Skip ERPNext's internal-supplier uniqueness scan for external suppliers ──────
+# ERPNext's Supplier.validate_internal_supplier runs a uniqueness scan of `tabSupplier`
+# on EVERY supplier save. Unlike Customer.validate_internal_customer - which returns
+# early for a non-internal customer - the Supplier version is missing that early return
+# (erpnext/buying/doctype/supplier/supplier.py), so the scan fires once per supplier
+# regardless. On a real book it is the single largest cost of the party phase: an
+# `is_internal_supplier=1` filter the growing table isn't indexed for, degrading toward
+# O(n^2) - measured ~106s (28% of the phase) for 13k suppliers on Frappe Cloud.
+#
+# A migrated supplier is never internal (the importer sets neither is_internal_supplier
+# nor represents_company), so that scan can only ever return nothing for our data. We
+# swap in exactly the behaviour Customer already has - clear represents_company for a
+# non-internal party and skip the scan - and DELEGATE to the original for a genuine
+# internal supplier, so the uniqueness guarantee is fully preserved and we track any
+# future ERPNext revision of that path instead of forking its query. Data-neutral and
+# no GST/compliance surface (neither field relates to India Compliance). Customer needs
+# no patch - it already returns early.
+def _make_fast_validate_internal_supplier(original):
+    """Build a drop-in for ``Supplier.validate_internal_supplier`` that short-circuits
+    the uniqueness scan for a non-internal supplier and delegates to ``original`` for a
+    genuine internal one. Mirrors ``Customer.validate_internal_customer`` exactly."""
+    def _fast_validate_internal_supplier(self):
+        if not self.is_internal_supplier:
+            self.represents_company = ""
+            return
+        return original(self)
+    return _fast_validate_internal_supplier
+
+
+@contextlib.contextmanager
+def _internal_supplier_scan_skipped():
+    """Skip ERPNext's per-supplier internal-uniqueness scan for external suppliers for
+    the party phase, then restore it. No-op-safe: if ERPNext or the method is absent
+    (e.g. renamed upstream) leave it untouched and yield unchanged - the migration still
+    runs, just without this saving. Restored in ``finally``; process-local, serialised
+    by the single-active-run guard (same contract as the suspensions above)."""
+    try:
+        from erpnext.buying.doctype.supplier.supplier import Supplier
+    except Exception:
+        yield
+        return
+    original = getattr(Supplier, "validate_internal_supplier", None)
+    if original is None:
+        yield
+        return
+    Supplier.validate_internal_supplier = _make_fast_validate_internal_supplier(original)
+    try:
+        yield
+    finally:
+        Supplier.validate_internal_supplier = original
+
+
 # ── Party importers (Customer / Supplier) ──────────────────────────────────────
 
 class PartyImporter(BaseImporter):
@@ -255,10 +307,12 @@ class PartyImporter(BaseImporter):
         gravatar network lookup, the Google-Contacts sync and Call-Log linking hooks,
         and the full-doc load in ``set_link_title`` (all data-irrelevant per-record cost
         of the phase; see ``_gravatar_lookup_suspended`` /
-        ``_party_side_effect_hooks_suspended`` / ``_link_title_lightweight``).
-        Everything else is the standard template."""
+        ``_party_side_effect_hooks_suspended`` / ``_link_title_lightweight``) - and with
+        ERPNext's per-supplier internal-uniqueness scan skipped for external suppliers
+        (see ``_internal_supplier_scan_skipped``). Everything else is the standard
+        template."""
         with _gravatar_lookup_suspended(), _party_side_effect_hooks_suspended(), \
-                _link_title_lightweight():
+                _link_title_lightweight(), _internal_supplier_scan_skipped():
             return super().run(records, on_progress=on_progress)
 
     def before_run(self, records: list[dict], result: "ImportResult") -> None:

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -172,6 +172,52 @@ class TestERPNextImporter(unittest.TestCase):
         self.assertIs(am.set_link_title, before_a)
         self.assertIs(cm.set_link_title, before_c)
 
+    def test_fast_internal_supplier_skips_scan_for_external_supplier(self):
+        """A non-internal supplier must clear represents_company and NOT run the
+        uniqueness scan (the original is never called) - the exact behaviour Customer
+        already has, and the whole point of the optimisation."""
+        from types import SimpleNamespace
+        from tally_migrator.erpnext.importers.party import (
+            _make_fast_validate_internal_supplier)
+
+        called = {"n": 0}
+        fast = _make_fast_validate_internal_supplier(lambda self: called.__setitem__("n", called["n"] + 1))
+        doc = SimpleNamespace(is_internal_supplier=0, represents_company="ACME")
+        fast(doc)
+        self.assertEqual(called["n"], 0)          # scan skipped
+        self.assertEqual(doc.represents_company, "")   # normalised like Customer does
+
+    def test_fast_internal_supplier_delegates_for_internal_supplier(self):
+        """A genuine internal supplier must still run ERPNext's real uniqueness check -
+        the optimisation only short-circuits the non-internal case, so the guarantee is
+        fully preserved."""
+        from types import SimpleNamespace
+        from tally_migrator.erpnext.importers.party import (
+            _make_fast_validate_internal_supplier)
+
+        seen = {}
+        fast = _make_fast_validate_internal_supplier(
+            lambda self: seen.setdefault("self", self))
+        doc = SimpleNamespace(is_internal_supplier=1, represents_company="ACME")
+        fast(doc)
+        self.assertIs(seen.get("self"), doc)      # original delegated to, unchanged
+        self.assertEqual(doc.represents_company, "ACME")   # left intact for internal
+
+    def test_internal_supplier_scan_context_patches_and_restores(self):
+        """The context manager repoints Supplier.validate_internal_supplier for its
+        duration and restores the original. Also asserts the method still exists on
+        ERPNext's Supplier - so this test fails loudly if a future ERPNext renames or
+        removes it (the no-op-safe guard would otherwise hide that silently)."""
+        from erpnext.buying.doctype.supplier.supplier import Supplier
+        from tally_migrator.erpnext.importers.party import (
+            _internal_supplier_scan_skipped)
+
+        original = Supplier.validate_internal_supplier      # fails here if renamed
+        self.assertTrue(callable(original))
+        with _internal_supplier_scan_skipped():
+            self.assertIsNot(Supplier.validate_internal_supplier, original)
+        self.assertIs(Supplier.validate_internal_supplier, original)
+
     def test_party_import_does_not_fire_contact_integration_hooks(self):
         """A normal Contact insert fires the Google-Contacts/Call-Log hooks; importing
         a party that creates a Contact must not (they are suspended), while the Contact


### PR DESCRIPTION
ERPNext's Supplier.validate_internal_supplier runs a uniqueness scan of tabSupplier on every supplier save (it is missing the early return that Customer.validate_internal_customer has). On a real book that is the single largest cost of the party phase - measured ~106s / 28% for 13k suppliers on Frappe Cloud, an is_internal filter degrading toward O(n^2). Migrated suppliers are never internal, so the scan can only ever return nothing for our data.

Scoped patch for the party phase: mirror Customer's early return for a non-internal supplier and delegate to the original for a genuine internal one (uniqueness fully preserved). Validated 9/9 on a real erpnext+india_compliance site, and Cloud-confirmed: Suppliers phase 380s -> 264s, 0 scan queries, books reconciled.