### PR TITLE
fix: live 'x of N' progress for opening-stock, Batches, Prices, Accounts, BOMs

### DIFF
--- a/tally_migrator/erpnext/importers/accounts.py
+++ b/tally_migrator/erpnext/importers/accounts.py
@@ -57,13 +57,16 @@ class AccountImporter:
         # (see _build_redirects). Empty until run() builds it.
         self._redirect: dict[str, str] = {}
 
-    def run(self, accounts: list) -> ImportResult:
+    def run(self, accounts: list, on_progress=None) -> ImportResult:
         result = ImportResult(self.doctype)
         ordered = self._ordered(self._select(accounts))
         # Decide up front which Tally groups collide with an existing account we must
         # leave intact, so child parent-resolution can re-home them (order-independent).
         self._build_redirects(ordered, result)
-        for node in ordered:
+        total = len(ordered)
+        for idx, node in enumerate(ordered, 1):
+            if on_progress:
+                on_progress(idx, total)
             parent = self._resolve_parent(node)
             if not parent:
                 result.add_error(node.name, "could not resolve a parent account")

--- a/tally_migrator/erpnext/importers/batch.py
+++ b/tally_migrator/erpnext/importers/batch.py
@@ -32,12 +32,17 @@ class BatchImporter:
         self.company = company
         self.abbr = abbr
 
-    def run(self, items: list[dict]) -> ImportResult:
+    def run(self, items: list[dict], on_progress=None) -> ImportResult:
         result = ImportResult(self.doctype)
         # Names reused across items would collide on ERPNext's global batch id, so
         # those get scoped per item - by the same rule the opening-stock importer uses.
         shared = shared_batch_names(items)
-        for it in items:
+        total = len(items)
+        for idx, it in enumerate(items, 1):
+            # Tick per item so this long phase (one Batch insert + commit per batch
+            # row) shows a live "x of N" instead of a frozen static message.
+            if on_progress:
+                on_progress(idx, total)
             # Tally stamps every item's opening with an implicit "Primary Batch", so
             # only genuinely batch-tracked items (ISBATCHWISEON=Yes) get Batch masters -
             # otherwise we'd create a batch for every non-batch item too.

--- a/tally_migrator/erpnext/importers/bom.py
+++ b/tally_migrator/erpnext/importers/bom.py
@@ -26,9 +26,12 @@ class BomImporter:
         self.currency = frappe.get_cached_value(
             "Company", company, "default_currency") or "INR"
 
-    def run(self, items: list[dict]) -> ImportResult:
+    def run(self, items: list[dict], on_progress=None) -> ImportResult:
         result = ImportResult(self.doctype)
-        for it in items:
+        total = len(items)
+        for idx, it in enumerate(items, 1):
+            if on_progress:
+                on_progress(idx, total)
             boms = it.get("Boms") or []
             if not boms:
                 continue

--- a/tally_migrator/erpnext/importers/openings.py
+++ b/tally_migrator/erpnext/importers/openings.py
@@ -1015,7 +1015,7 @@ class StockOpeningImporter:
     # failure's blast radius, and bounds the per-document memory/transaction size.
     _CHUNK = 100
 
-    def run(self, items: list, posting_date: str) -> ImportResult:
+    def run(self, items: list, posting_date: str, on_progress=None) -> ImportResult:
         result = ImportResult(self.doctype)
         warehouse = self._default_warehouse()
         if not warehouse:
@@ -1078,6 +1078,8 @@ class StockOpeningImporter:
         # Memoise the per-item Accounting Dimension lookup ERPNext repeats on every
         # GL/SLE posting (a company-wide constant) - the dominant avoidable round-trip
         # cost of this phase, especially on Frappe Cloud. See _accounting_dimensions_cached.
+        total = len(pending)
+        done = 0
         with _accounting_dimensions_cached():
             for i in range(0, len(pending), self._CHUNK):
                 chunk = pending[i:i + self._CHUNK]
@@ -1087,6 +1089,12 @@ class StockOpeningImporter:
                     # their opening stock. A 1-row doc also submits synchronously.
                     for row in chunk:
                         self._post_doc([row], posting_date, result, isolate=True)
+                # Opening stock posts ~100 rows per submit over a long, DB-heavy phase;
+                # tick the "x of N" count per chunk so the bar keeps moving instead of
+                # sitting frozen on a single static message for minutes.
+                done += len(chunk)
+                if on_progress:
+                    on_progress(done, total)
         return result
 
     def _post_doc(self, rows: list, posting_date: str, result: ImportResult,

--- a/tally_migrator/erpnext/importers/orchestrator.py
+++ b/tally_migrator/erpnext/importers/orchestrator.py
@@ -115,7 +115,8 @@ class ERPNextImporter:
                     "finishes to fill any gaps.")
                 return result
             return StockOpeningImporter(self.company, self.abbr).run(
-                items, self._opening_date(posting_date))
+                items, self._opening_date(posting_date),
+                on_progress=self.on_progress)
 
     def import_stock_groups(self, groups: list[dict]) -> ImportResult:
         return StockGroupImporter(self.company, self.abbr).run(groups)

--- a/tally_migrator/erpnext/importers/orchestrator.py
+++ b/tally_migrator/erpnext/importers/orchestrator.py
@@ -62,7 +62,8 @@ class ERPNextImporter:
         self.on_progress = None
 
     def import_accounts(self, accounts: list) -> ImportResult:
-        return AccountImporter(self.company, self.abbr, mode=self._coa_mode).run(accounts)
+        return AccountImporter(self.company, self.abbr, mode=self._coa_mode).run(
+            accounts, on_progress=self.on_progress)
 
     def import_cost_centres(self, centres: list) -> ImportResult:
         return CostCentreImporter(self.company, self.abbr).run(centres)
@@ -125,13 +126,16 @@ class ERPNextImporter:
         return UnitImporter(self.company, self.abbr).run(units)
 
     def import_prices(self, items: list[dict]) -> ImportResult:
-        return PriceImporter(self.company, self.abbr).run(items)
+        return PriceImporter(self.company, self.abbr).run(
+            items, on_progress=self.on_progress)
 
     def import_boms(self, items: list[dict]) -> ImportResult:
-        return BomImporter(self.company, self.abbr).run(items)
+        return BomImporter(self.company, self.abbr).run(
+            items, on_progress=self.on_progress)
 
     def import_batches(self, items: list[dict]) -> ImportResult:
-        return BatchImporter(self.company, self.abbr).run(items)
+        return BatchImporter(self.company, self.abbr).run(
+            items, on_progress=self.on_progress)
 
     def import_warehouses(self, warehouses: list[dict]) -> ImportResult:
         return WarehouseImporter(self.company, self.abbr).run(

--- a/tally_migrator/erpnext/importers/prices.py
+++ b/tally_migrator/erpnext/importers/prices.py
@@ -30,9 +30,12 @@ class PriceImporter:
     # List named "MRP" with one Item Price per item - mirroring how price levels map.
     MRP_PRICE_LIST = "MRP"
 
-    def run(self, items: list[dict]) -> ImportResult:
+    def run(self, items: list[dict], on_progress=None) -> ImportResult:
         result = ImportResult(self.doctype)
-        for it in items:
+        total = len(items)
+        for idx, it in enumerate(items, 1):
+            if on_progress:
+                on_progress(idx, total)
             for lv in (it.get("PriceLevels") or []):
                 self._import_level(result, it.get("_name", ""), lv)
             self._import_mrp(result, it.get("_name", ""), it.get("Mrp"))

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -1367,6 +1367,28 @@ class TestERPNextImporter(unittest.TestCase):
         # 250 rows -> chunks of 100, 100, 50 -> cumulative counts against a fixed total.
         self.assertEqual(ticks, [(100, 250), (200, 250), (250, 250)])
 
+    def test_batch_importer_reports_progress_per_item(self):
+        """Batches is a multi-second phase (one Batch insert + commit per row) that used
+        to sit frozen. It must tick on_progress with 'x of N' per item - verified via the
+        non-batch skip path so no DB is needed (the tick precedes any item work)."""
+        from tally_migrator.erpnext.importers.batch import BatchImporter
+        imp = BatchImporter("_TMTest Co", "TC")
+        # Items without IsBatchWiseOn=Yes are skipped, but must still advance the bar.
+        items = [{"_name": f"I{i}"} for i in range(3)]
+        ticks = []
+        imp.run(items, on_progress=lambda done, total: ticks.append((done, total)))
+        self.assertEqual(ticks, [(1, 3), (2, 3), (3, 3)])
+
+    def test_price_importer_reports_progress_per_item(self):
+        """Prices ticks 'x of N' per item (checked via items with no price levels/MRP,
+        which the importer skips without touching the DB)."""
+        from tally_migrator.erpnext.importers.prices import PriceImporter
+        imp = PriceImporter("_TMTest Co", "TC")
+        items = [{"_name": f"I{i}"} for i in range(3)]
+        ticks = []
+        imp.run(items, on_progress=lambda done, total: ticks.append((done, total)))
+        self.assertEqual(ticks, [(1, 3), (2, 3), (3, 3)])
+
     def test_default_warehouse_skips_other_company_global_default(self):
         """Stock Settings' default_warehouse is global. On a multi-company site it
         can point at another company's warehouse; using it makes the Opening Stock

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -1337,6 +1337,36 @@ class TestERPNextImporter(unittest.TestCase):
         self.assertEqual(result.skipped, 1)
         self.assertIn("already posted", result.warnings[-1]["reason"])
 
+    def test_opening_stock_reports_progress_per_chunk(self):
+        """The opening-stock phase posts ~100 rows per submit over a long, DB-heavy
+        run. It must tick on_progress with a cumulative "done of total" per chunk so
+        the bar keeps moving instead of sitting frozen on one static message."""
+        from tally_migrator.erpnext.importers import StockOpeningImporter
+
+        imp = StockOpeningImporter("_TMTest Co", "TC")
+        imp._default_warehouse = lambda: "Stores - TC"
+        imp._posted_keys = lambda: set()
+        imp._drop_non_stock_rows = lambda rows, items, result: rows
+        # Each item contributes exactly one row, without touching frappe.
+        imp._placements = lambda it, wh, result: [(wh, 1.0, 10.0, 10.0, None)]
+
+        def add_row(by_key, name, wh, q, r, v, sc, result, batch=None):
+            by_key[(name, wh)] = {"item_code": name, "warehouse": wh}
+        imp._add_opening_row = add_row
+
+        def post_doc(chunk, date, result, isolate=False):
+            for row in chunk:
+                result.add_created(f"SR-{row['item_code']}")
+            return True
+        imp._post_doc = post_doc
+
+        ticks = []
+        items = [{"_name": f"I{i}"} for i in range(250)]
+        imp.run(items, "2024-04-01",
+                on_progress=lambda done, total: ticks.append((done, total)))
+        # 250 rows -> chunks of 100, 100, 50 -> cumulative counts against a fixed total.
+        self.assertEqual(ticks, [(100, 250), (200, 250), (250, 250)])
+
     def test_default_warehouse_skips_other_company_global_default(self):
         """Stock Settings' default_warehouse is global. On a multi-company site it
         can point at another company's warehouse; using it makes the Opening Stock


### PR DESCRIPTION
Several importers ran their own per-item loops but never forwarded the progress callback, so each sat frozen on a static 'Importing N ...' message (most visibly opening stock and Batches). Thread on_progress through each and tick per item, reusing the throttled step callback. Scoped to phases with a real per-record loop - sub-second masters and the aggregate Opening Balances phase are left untouched. Cloud-confirmed the bars now tick.