### PR TITLE
fix: reliable, fast migration revert (+ background-job cancel/submit, form refresh)

### DIFF
--- a/tally_migrator/erpnext/importers/openings.py
+++ b/tally_migrator/erpnext/importers/openings.py
@@ -1113,7 +1113,17 @@ class StockOpeningImporter:
                 "items": rows,
             })
             doc.insert(ignore_permissions=True)
-            doc.submit()
+            # Submit synchronously. ERPNext's StockReconciliation.submit() enqueues the
+            # submission as a BACKGROUND job when the entry has > 100 items, returning
+            # before the stock ledger is posted; the single migration worker is then busy
+            # until the run ends, so that queued submit only lands AFTER finalize and the
+            # trial balance / stock reads a chunk as absent. Chunks are capped at _CHUNK
+            # (100) today so submit() stays synchronous, but that is safe-by-coincidence:
+            # _submit() is exactly the path submit() takes for <=100-row entries, so we
+            # force the same synchronous posting regardless of chunk size (mirrors the
+            # Opening Entry above). Safe here because the migration runs off the web
+            # request, so there is no request-timeout reason to defer.
+            doc._submit()
             frappe.db.commit()
             result.add_created(doc.name)
             return True

--- a/tally_migrator/migration/rollback.py
+++ b/tally_migrator/migration/rollback.py
@@ -24,6 +24,8 @@ Supplier, UOM, Item Group) a migration creates. We reuse its safety helpers
 (:func:`_protected_doctypes`) but not its company-wide engine.
 """
 
+import contextlib
+
 import frappe
 from frappe import _
 from frappe.utils import get_link_to_form, now_datetime, time_diff_in_seconds
@@ -252,7 +254,8 @@ def _purge_party_links(party_type: str, party: str) -> list[dict]:
                                  {"parent": nm, "parenttype": linked_dt,
                                   "link_doctype": party_type, "link_name": party})
             else:
-                frappe.delete_doc(linked_dt, nm, ignore_permissions=True)
+                frappe.delete_doc(linked_dt, nm, ignore_permissions=True,
+                                  delete_permanently=True)
                 purged.append({"doctype": linked_dt, "name": nm})
     # A Bank Account created for the party (from Tally bank details) links it via its
     # own party_type/party fields and blocks the delete too. It belongs to exactly one
@@ -261,7 +264,8 @@ def _purge_party_links(party_type: str, party: str) -> list[dict]:
                              filters={"party_type": party_type, "party": party},
                              pluck="name"):
         if frappe.db.exists("Bank Account", nm):
-            frappe.delete_doc("Bank Account", nm, ignore_permissions=True)
+            frappe.delete_doc("Bank Account", nm, ignore_permissions=True,
+                              delete_permanently=True)
             purged.append({"doctype": "Bank Account", "name": nm})
     return purged
 
@@ -289,7 +293,27 @@ def _delete_one(row: dict, protected: set) -> str | None:
     try:
         doc = frappe.get_doc(doctype, name)
         if getattr(doc, "docstatus", 0) == 1:
-            doc.cancel()
+            # Clear any stale document lock before cancelling. A large doc whose cancel
+            # was previously routed to the background Submission Queue (see below) leaves a
+            # lock file that its never-run async job never releases; on a re-run that lock
+            # would raise "currently locked and queued" and wedge this record again. We own
+            # the teardown (single active revert) and are about to delete this doc, so
+            # clearing its lock is safe. Best-effort: no lock -> harmless no-op.
+            try:
+                doc.unlock()
+            except Exception:
+                pass
+            # Cancel synchronously. Some ERPNext doctypes route cancel() to a background
+            # Submission Queue when the document is large (e.g. a Journal Entry with more
+            # than 100 account rows - an opening-balance entry always is). In a background
+            # revert that path can't complete: it enqueues an async cancel and returns with
+            # the doc still submitted (so the delete below fails and the record is wrongly
+            # kept) or contends on the doc lock. Call the internal _cancel() - the exact
+            # action the queue would have run (frappe's queue_action maps "cancel" ->
+            # "_cancel"), still firing before_cancel/on_cancel via save - so cancellation
+            # always happens inline. Fall back to cancel() for anything without _cancel.
+            cancel_inline = getattr(doc, "_cancel", None) or doc.cancel
+            cancel_inline()
             for ledger in _LEDGER_DOCTYPES:
                 frappe.db.delete(ledger, {"voucher_no": name})
             # The opening Stock Reconciliation auto-creates a Serial and Batch Bundle
@@ -306,7 +330,8 @@ def _delete_one(row: dict, protected: set) -> str | None:
                         "Serial and Batch Bundle",
                         filters={"voucher_no": name}, pluck="name"):
                     frappe.delete_doc("Serial and Batch Bundle", bundle,
-                                      force=True, ignore_permissions=True)
+                                      force=True, ignore_permissions=True,
+                                      delete_permanently=True)
         # Clear ERPNext's derived side-effect rows for this master (Repost Item
         # Valuation, UOM Conversion Factor, GST UOM Map) before the delete, so they
         # don't block it. Scoped to this master's name, inside the savepoint, so a
@@ -331,7 +356,8 @@ def _delete_one(row: dict, protected: set) -> str | None:
         # links to the record (the run's own invoices/JE/stock recon are deleted
         # first), so the unforced delete still succeeds; only genuinely re-linked
         # records raise LinkExistsError, are caught, and are kept + reported.
-        frappe.delete_doc(doctype, name, ignore_permissions=True)
+        frappe.delete_doc(doctype, name, ignore_permissions=True,
+                          delete_permanently=True)
         return None
     except Exception as exc:
         _safe_savepoint_rollback(savepoint)
@@ -341,6 +367,78 @@ def _delete_one(row: dict, protected: set) -> str | None:
         return str(exc) or exc.__class__.__name__
     finally:
         _drop_queued_messages(msg_mark)
+
+
+@contextlib.contextmanager
+def _quiet_framework():
+    """Silence the per-record framework bookkeeping that dominates a large revert.
+
+    A revert of tens of thousands of documents spends almost all of its wall-clock
+    time not on the deletes themselves but on the side work each delete/cancel
+    triggers:
+
+    * a realtime ``list_update`` / ``doc_update`` event per document (and per Error
+      Log / Comment the cancel path writes); any desk client watching the revert then
+      re-runs its notification open-count aggregation - measured on a real run as the
+      bulk of the runtime (~14k aggregations over Error Log and other doctypes);
+    * an activity ``Comment`` feed row per delete (``insert_feed``);
+    * one enqueued ``delete_dynamic_links`` job per document, which also floods the
+      background queue (the earlier "Queue Overloaded" failure).
+
+    None of it is needed for an undo - we keep our own audit in the revert's
+    ``records`` table, and the site is not serving those list views mid-revert. We set
+    ``frappe.flags.in_import`` (which ``notify_update`` and ``insert_feed`` already
+    honour as "bulk data churn, do not emit") and run the dynamic-link cleanup inline
+    instead of enqueuing a job per record. Both are saved and restored, so normal
+    behaviour resumes the instant the revert finishes or raises. The flag only gates
+    validate/insert/naming and notification paths - never the cancel/delete logic this
+    revert relies on - so correctness is unchanged; it purely quietens the framework.
+    """
+    prev_in_import = frappe.flags.in_import
+    real_enqueue = frappe.enqueue
+
+    def _inline_enqueue(method=None, **kwargs):
+        name = method if isinstance(method, str) else getattr(method, "__name__", "")
+        if name.endswith("delete_dynamic_links"):
+            # Keep the cleanup, drop the per-record job: run it now, synchronously.
+            for k in ("queue", "timeout", "now", "enqueue_after_commit",
+                      "job_name", "at_front", "job_id"):
+                kwargs.pop(k, None)
+            return frappe.call(method, **kwargs)
+        return real_enqueue(method, **kwargs)
+
+    frappe.flags.in_import = True
+    frappe.enqueue = _inline_enqueue
+    try:
+        yield
+    finally:
+        frappe.flags.in_import = prev_in_import
+        frappe.enqueue = real_enqueue
+
+
+def _record_row(parent: str, idx: int, *, deleted: int, doctype: str,
+                name: str, entity: str, reason: str) -> None:
+    """Persist one revert audit row immediately, rather than buffering to the end.
+
+    Inserts a ``Tally Migration Revert Item`` child directly so a killed worker keeps
+    the audit for everything it had already deleted. The old path appended every row
+    to the parent in memory and wrote them all with a single ``revert.save()`` at the
+    very end: a job that hit the 60-minute timeout mid-run then persisted nothing and
+    reported 0 deleted though thousands were already gone. A direct child insert is
+    O(1) per row (``revert.save()`` would rewrite the whole child table each batch,
+    O(n^2)), and committing per batch bounds what a crash loses."""
+    frappe.get_doc({
+        "doctype": "Tally Migration Revert Item",
+        "parenttype": "Tally Migration Revert",
+        "parentfield": "records",
+        "parent": parent,
+        "idx": idx,
+        "deleted": deleted,
+        "reference_doctype": doctype,
+        "reference_name": name,
+        "entity": entity,
+        "reason": reason,
+    }).db_insert()
 
 
 @frappe.whitelist(methods=["POST"])
@@ -447,80 +545,82 @@ def run_revert(revert_name: str) -> None:
         rows = _deletion_order(frappe.parse_json(log.created_records or "{}"))
         protected = _protected_doctypes()
 
-        # Records absent before we start (manifest entries this run never actually
-        # created, or ones a user removed earlier) are reported honestly as "already
-        # absent" rather than counted among this undo's deletions. Snapshot now,
-        # before the loop, so a record that genuinely cascades with a parent we delete
-        # this run is NOT mistaken for one that was already gone.
-        pre_absent = {id(r) for r in rows
-                      if not frappe.db.exists(r["doctype"], r["name"])}
+        # Split off records already absent before we start (manifest entries this run
+        # never actually created, or ones removed earlier - including everything a
+        # prior, timed-out revert already deleted). Snapshot now, before the loop, so a
+        # record that genuinely cascades with a parent we delete this run is NOT
+        # mistaken for one that was already gone. Absent records are audited up front as
+        # "already absent" and kept out of the delete loop so they are not recounted as
+        # deletions; this is also what makes a re-run of a killed revert resumable.
+        pending, pre_absent = [], []
+        for r in rows:
+            (pre_absent if not frappe.db.exists(r["doctype"], r["name"]) else pending).append(r)
 
-        # Delete in dependency order, then retry whatever was kept. A record can be
-        # blocked on the first pass by a sibling removed later in the same run (a UOM
-        # still held by an Item deleted afterwards; a party still linked by a voucher
+        idx = 0
+        for r in pre_absent:
+            idx += 1
+            _record_row(revert.name, idx, deleted=0, doctype=r["doctype"],
+                        name=r["name"], entity=r["label"],
+                        reason=_("Already absent before this undo - not created by this "
+                                 "run, or removed earlier."))
+        frappe.db.commit()
+
+        # Delete in dependency order, retrying whatever was kept. A record can be
+        # blocked on one pass by a sibling removed later in the same run (a UOM still
+        # held by an Item deleted afterwards; a party still linked by a voucher
         # processed later). Repeat until a pass deletes nothing new, so only records
-        # genuinely re-linked by post-migration activity are left kept. Completed
-        # deletions are committed in batches (see _COMMIT_BATCH) to release locks and
-        # bound how much a crash can roll back.
-        done_ids: set[int] = set()
-        since_commit = 0
-        pending = list(rows)
-        while pending:
-            still, progressed = [], False
-            for row in pending:
-                reason = _delete_one(row, protected)
-                if reason:
-                    row["_reason"] = reason
-                    still.append(row)
-                else:
+        # genuinely re-linked by post-migration activity are left kept. Each deletion is
+        # audited and its batch committed as we go (see _record_row / _COMMIT_BATCH), so
+        # a killed worker leaves a truthful partial result and a re-run resumes from what
+        # is left. The loop runs inside _quiet_framework() so the per-record realtime /
+        # feed / backup / queue churn - not the deletes - stops dominating the runtime.
+        deleted = kept = since_commit = 0
+        with _quiet_framework():
+            while pending:
+                still, progressed = [], False
+                for row in pending:
+                    reason = _delete_one(row, protected)
+                    if reason:
+                        row["_reason"] = reason
+                        still.append(row)
+                        continue
                     progressed = True
-                    done_ids.add(id(row))
+                    idx += 1
+                    _record_row(revert.name, idx, deleted=1, doctype=row["doctype"],
+                                name=row["name"], entity=row["label"], reason="")
+                    deleted += 1
+                    # Party-attached business data (addresses, contacts, bank accounts)
+                    # removed alongside the party - audited so the trail shows them too.
+                    for p in row.get("_purged", []):
+                        idx += 1
+                        _record_row(revert.name, idx, deleted=1, doctype=p["doctype"],
+                                    name=p["name"],
+                                    entity=_("{0} (linked to {1})").format(
+                                        row["label"], row["name"]),
+                                    reason="")
+                        deleted += 1
                     since_commit += 1
                     if since_commit >= _COMMIT_BATCH:
-                        frappe.db.commit()
+                        revert.db_set("deleted_count", deleted,
+                                      update_modified=False, commit=True)
                         since_commit = 0
-            pending = still
-            if not progressed:
-                break
+                pending = still
+                if not progressed:
+                    break
         frappe.db.commit()  # flush the final, partial batch of deletions
 
-        deleted = kept = 0
-        for row in rows:
-            rid = id(row)
-            # Checked before done_ids: a record absent at the start also returns "no
-            # reason" from _delete_one (nothing to delete), so it lands in done_ids too -
-            # but it must be reported as already-absent, not counted as a deletion.
-            if rid in pre_absent:
-                revert.append("records", {
-                    "deleted": 0, "reference_doctype": row["doctype"],
-                    "reference_name": row["name"], "entity": row["label"],
-                    "reason": _("Already absent before this undo - not created by this "
-                                "run, or removed earlier.")})
-            elif rid in done_ids:
-                revert.append("records", {
-                    "deleted": 1, "reference_doctype": row["doctype"],
-                    "reference_name": row["name"], "entity": row["label"], "reason": ""})
-                deleted += 1
-                # Party-attached business data (addresses, contacts, bank accounts)
-                # removed alongside the party - listed so the audit shows them too.
-                for p in row.get("_purged", []):
-                    revert.append("records", {
-                        "deleted": 1, "reference_doctype": p["doctype"],
-                        "reference_name": p["name"],
-                        "entity": _("{0} (linked to {1})").format(row["label"], row["name"]),
-                        "reason": ""})
-                    deleted += 1
-            else:
-                revert.append("records", {
-                    "deleted": 0, "reference_doctype": row["doctype"],
-                    "reference_name": row["name"], "entity": row["label"],
-                    "reason": row.get("_reason", "")})
-                kept += 1
+        # Whatever is still pending after the loop is genuinely kept (re-linked by
+        # later activity, or a protected doctype); audit each with its reason.
+        for row in pending:
+            idx += 1
+            _record_row(revert.name, idx, deleted=0, doctype=row["doctype"],
+                        name=row["name"], entity=row["label"],
+                        reason=row.get("_reason", ""))
+            kept += 1
 
-        revert.deleted_count = deleted
-        revert.kept_count = kept
-        revert.status = "Completed with Errors" if kept else "Completed"
-        revert.save(ignore_permissions=True)
+        revert.db_set("deleted_count", deleted, update_modified=False)
+        revert.db_set("kept_count", kept, update_modified=False)
+        revert.db_set("status", "Completed with Errors" if kept else "Completed")
 
         # The one honest edit to the log: its status must tell the truth everywhere
         # (list view, form, filters). The import path never sets this value. A clean

--- a/tally_migrator/tally_migration/doctype/tally_migration_revert/tally_migration_revert.js
+++ b/tally_migrator/tally_migration/doctype/tally_migration_revert/tally_migration_revert.js
@@ -1,7 +1,9 @@
 // Tally Migration Revert is written by a background job (see
 // tally_migrator/migration/rollback.py: run_revert). While that job runs, the
-// form colours its status and live-reloads when the job publishes completion, so
-// the user can watch the undo finish without manually refreshing.
+// form colours its status and live-reloads when the job finishes, so the user can
+// watch the undo complete without manually refreshing.
+const TM_REVERT_TERMINAL = ["Completed", "Completed with Errors", "Failed"];
+
 frappe.ui.form.on("Tally Migration Revert", {
 	refresh(frm) {
 		const colour = {
@@ -14,15 +16,18 @@ frappe.ui.form.on("Tally Migration Revert", {
 		if (colour) {
 			frm.page.set_indicator(__(frm.doc.status), colour);
 		}
-		if (["Queued", "In Progress"].includes(frm.doc.status)) {
+		if (!TM_REVERT_TERMINAL.includes(frm.doc.status)) {
 			frm.dashboard.set_headline(
 				__("The undo is running in the background. This page will refresh when it finishes.")
 			);
+			tm_start_status_poll(frm);
+		} else {
+			tm_stop_status_poll(frm);
 		}
 	},
 
 	onload(frm) {
-		// Reload when the background job reports this revert is done.
+		// Fast path: reload the moment the background job reports this revert is done.
 		frappe.realtime.on("tally_revert_updated", (data) => {
 			if (data && data.revert === frm.doc.name) {
 				frm.reload_doc();
@@ -30,3 +35,35 @@ frappe.ui.form.on("Tally Migration Revert", {
 		});
 	},
 });
+
+// Reliable fallback: realtime is best-effort, so a page that missed the completion
+// event (a backgrounded tab, a socket reconnect, an incognito session) would otherwise
+// sit on "Queued" forever while the job has actually finished. Poll the status and
+// reload once it reaches a terminal state. Mirrors the wizard's step-5 poll fallback.
+function tm_start_status_poll(frm) {
+	tm_stop_status_poll(frm);
+	frm._tm_revert_poll = setInterval(() => {
+		// Self-terminate if the user navigated away (form DOM detached), so the poll
+		// never leaks past the page it belongs to.
+		if (!frm.page || !frm.page.wrapper || !document.body.contains(frm.page.wrapper[0])) {
+			tm_stop_status_poll(frm);
+			return;
+		}
+		frappe.db
+			.get_value("Tally Migration Revert", frm.doc.name, "status")
+			.then((r) => {
+				const status = r && r.message && r.message.status;
+				if (status && TM_REVERT_TERMINAL.includes(status)) {
+					tm_stop_status_poll(frm);
+					frm.reload_doc();
+				}
+			});
+	}, 5000);
+}
+
+function tm_stop_status_poll(frm) {
+	if (frm._tm_revert_poll) {
+		clearInterval(frm._tm_revert_poll);
+		frm._tm_revert_poll = null;
+	}
+}

--- a/tally_migrator/tests/test_critical_fixes.py
+++ b/tally_migrator/tests/test_critical_fixes.py
@@ -22,6 +22,7 @@ from tally_migrator.erpnext import importers
 from tally_migrator.erpnext.importers import (
     OpeningBalanceImporter,
     PartyOpeningImporter,
+    StockOpeningImporter,
     WarehouseImporter,
     StockGroupImporter,
     AccountImporter,
@@ -163,6 +164,39 @@ class TestOpeningEntrySubmitsSynchronously(unittest.TestCase):
         self.assertIn("_submit", calls)
         self.assertNotIn("submit", calls)        # never the background-gated path
         self.assertEqual(result.created_names, ["ACC-JV-0001"])
+
+
+class TestOpeningStockSubmitsSynchronously(unittest.TestCase):
+    """The opening Stock Reconciliation must post synchronously. ERPNext's
+    StockReconciliation.submit() enqueues a BACKGROUND job when the entry has > 100
+    items; that returns before the stock ledger is posted, so on a long single-worker
+    run the ledger lands only after the migration finalizes. _post_doc must therefore
+    call doc._submit() (the same synchronous path submit() takes for <=100 rows), never
+    the size-gated submit() - so it stays correct independent of the _CHUNK cap."""
+
+    def test_post_doc_calls_underlying_submit_not_gated_submit(self):
+        imp = StockOpeningImporter(company="_T Co", abbr="TC")
+        result = ImportResult("Opening Stock")
+        calls = []
+
+        class _FakeSR:
+            name = "MAT-SR-0001"
+            def insert(self, *a, **k):
+                calls.append("insert")
+            def submit(self):                 # the size-gated one - must NOT run
+                calls.append("submit")
+            def _submit(self):                # the synchronous one - must run
+                calls.append("_submit")
+
+        rows = [{"item_code": "Widget - TC", "qty": 5, "valuation_rate": 10}]
+        with mock.patch("frappe.get_doc", return_value=_FakeSR()), \
+                mock.patch("frappe.db.commit"):
+            ok = imp._post_doc(rows, "2026-01-01", result)
+
+        self.assertTrue(ok)
+        self.assertIn("_submit", calls)
+        self.assertNotIn("submit", calls)        # never the background-gated path
+        self.assertEqual(result.created_names, ["MAT-SR-0001"])
 
 
 class TestPLOpeningSkipped(unittest.TestCase):

--- a/tally_migrator/tests/test_rollback.py
+++ b/tally_migrator/tests/test_rollback.py
@@ -5,6 +5,7 @@ endpoint's guard rails (feature flag, company confirmation, already-reverted) ar
 tested with light mocking. The full live-DB delete happy-path is exercised by the
 integration suite, which has a real company to create and tear down.
 """
+import contextlib
 import unittest
 from unittest import mock
 
@@ -135,6 +136,37 @@ class TestDeleteOneSafety(unittest.TestCase):
         self.addCleanup(lambda: [p.stop() for p in patches])
         reason = rollback._delete_one({"doctype": "Item", "name": "Widget"}, set())
         self.assertIn("SI-9", reason)                          # kept + reported, not deleted
+
+    def test_submitted_doc_cancelled_synchronously_and_unlocked(self):
+        # A submitted doc must be cancelled via the synchronous _cancel(), NOT the
+        # size-gated cancel(): ERPNext routes a >100-row Journal Entry / Stock
+        # Reconciliation cancel to a background Submission Queue job that never runs in
+        # a revert, leaving the doc submitted so the delete fails and it is wrongly
+        # kept. Any stale lock (from a prior queued attempt) is cleared first.
+        calls = []
+        doc = mock.Mock(docstatus=1)
+        doc._cancel = lambda: calls.append("_cancel")
+        doc.cancel = lambda: calls.append("cancel")     # the gated path - must NOT run
+        doc.unlock = lambda: calls.append("unlock")
+        patches = [
+            mock.patch.object(rollback.frappe.db, "exists", return_value=True),
+            mock.patch.object(rollback.frappe.db, "savepoint", lambda *a, **k: None),
+            mock.patch.object(rollback.frappe.db, "rollback", lambda *a, **k: None),
+            mock.patch.object(rollback.frappe.db, "delete", lambda *a, **k: None),
+            mock.patch.object(rollback.frappe.db, "table_exists", return_value=False),
+            mock.patch.object(rollback.frappe, "get_all", return_value=[]),
+            mock.patch.object(rollback.frappe, "get_doc", return_value=doc),
+            mock.patch.object(rollback.frappe, "delete_doc", lambda *a, **k: None),
+            mock.patch.object(rollback.frappe, "local", mock.Mock(message_log=[])),
+        ]
+        for p in patches:
+            p.start()
+        self.addCleanup(lambda: [p.stop() for p in patches])
+        reason = rollback._delete_one(
+            {"doctype": "Journal Entry", "name": "ACC-JV-1"}, set())
+        self.assertIsNone(reason)                          # cancelled + deleted cleanly
+        # Stale lock cleared BEFORE cancel, and only the synchronous path was used.
+        self.assertEqual(calls, ["unlock", "_cancel"])
 
     def test_recon_bundle_force_deleted_before_voucher(self):
         # The opening Stock Reconciliation auto-creates a Serial and Batch Bundle per
@@ -328,6 +360,136 @@ class TestRevertGuards(unittest.TestCase):
             rollback.revert_migration("TML-1", "Frappe Tech")
         # The corpse was flagged Failed rather than blocking the new revert.
         self.assertEqual(set_calls.get("REV-OLD", {}).get("status"), "Failed")
+
+
+class TestQuietFramework(unittest.TestCase):
+    """_quiet_framework silences the per-record framework churn and always restores."""
+
+    def setUp(self):
+        # These tests mutate the process-global frappe.flags.in_import; capture and
+        # restore the real value so a leaked truthy flag can't skip _set_defaults in a
+        # later test (which would surface as an unrelated MandatoryError elsewhere).
+        orig = frappe.flags.in_import
+        self.addCleanup(lambda: setattr(frappe.flags, "in_import", orig))
+
+    def test_sets_and_restores_in_import(self):
+        frappe.flags.in_import = "sentinel"
+        real = rollback.frappe.enqueue
+        with rollback._quiet_framework():
+            self.assertTrue(frappe.flags.in_import)          # bulk-churn mode on
+            self.assertIsNot(rollback.frappe.enqueue, real)  # enqueue intercepted
+        self.assertEqual(frappe.flags.in_import, "sentinel")  # prior value restored
+        self.assertIs(rollback.frappe.enqueue, real)
+
+    def test_restores_even_on_exception(self):
+        frappe.flags.in_import = False
+        real = rollback.frappe.enqueue
+        with self.assertRaises(RuntimeError):
+            with rollback._quiet_framework():
+                raise RuntimeError("boom")
+        self.assertFalse(frappe.flags.in_import)             # not left stuck on
+        self.assertIs(rollback.frappe.enqueue, real)
+
+    def test_delete_dynamic_links_runs_inline_not_queued(self):
+        called = {}
+        with mock.patch.object(rollback.frappe, "call",
+                               side_effect=lambda m, **k: called.update(method=m, kwargs=k)), \
+             mock.patch.object(rollback.frappe, "enqueue") as real_enqueue:
+            with rollback._quiet_framework():
+                frappe.enqueue("frappe.model.delete_doc.delete_dynamic_links",
+                               doctype="Item", name="W", now=False,
+                               enqueue_after_commit=True)
+            # Cleanup ran inline (frappe.call), with the queue-only kwargs stripped, and
+            # was NOT pushed onto the background queue.
+            self.assertEqual(called["method"],
+                             "frappe.model.delete_doc.delete_dynamic_links")
+            self.assertEqual(called["kwargs"], {"doctype": "Item", "name": "W"})
+            real_enqueue.assert_not_called()
+
+    def test_other_enqueue_calls_are_delegated(self):
+        with mock.patch.object(rollback.frappe, "enqueue") as real_enqueue:
+            with rollback._quiet_framework():
+                frappe.enqueue("some.other.repost", foo=1)
+            real_enqueue.assert_called_once_with("some.other.repost", foo=1)
+
+
+class TestRecordRow(unittest.TestCase):
+    """_record_row inserts a child audit row directly so a killed job keeps its trail."""
+
+    def test_inserts_child_directly(self):
+        captured, doc = {}, mock.Mock()
+        with mock.patch.object(rollback.frappe, "get_doc",
+                               side_effect=lambda d: captured.update(d) or doc):
+            rollback._record_row("REV-1", 3, deleted=1, doctype="Item",
+                                 name="W", entity="Items", reason="")
+        self.assertEqual(captured["doctype"], "Tally Migration Revert Item")
+        self.assertEqual(captured["parenttype"], "Tally Migration Revert")
+        self.assertEqual(captured["parentfield"], "records")
+        self.assertEqual((captured["parent"], captured["idx"]), ("REV-1", 3))
+        self.assertEqual(captured["deleted"], 1)
+        doc.db_insert.assert_called_once()   # direct insert, no O(n^2) parent save
+
+
+class TestRunRevertPersistence(unittest.TestCase):
+    """run_revert must audit each deletion as it happens (inside _quiet_framework),
+    delete permanently (no Deleted Document backup), and set truthful terminal state."""
+
+    def test_deletions_recorded_incrementally_with_status(self):
+        revert = mock.Mock(name="revert")
+        revert.name, revert.migration_log = "REV-1", "TML-1"
+        log = mock.Mock()
+        log.created_records = ('{"Items": [{"name": "W1", "doctype": "Item"}, '
+                               '{"name": "W2", "doctype": "Item"}]}')
+
+        def gd(dt, *a, **k):
+            return revert if dt == "Tally Migration Revert" else log
+
+        recorded, quiet = [], {"entered": False}
+
+        @contextlib.contextmanager
+        def fake_quiet():
+            quiet["entered"] = True
+            yield
+
+        with mock.patch.object(rollback.frappe, "get_doc", side_effect=gd), \
+             mock.patch.object(rollback, "_protected_doctypes", return_value=set()), \
+             mock.patch.object(rollback.frappe.db, "exists", return_value=True), \
+             mock.patch.object(rollback.frappe.db, "commit", lambda *a, **k: None), \
+             mock.patch.object(rollback.frappe.db, "get_value", return_value="user@x"), \
+             mock.patch.object(rollback.frappe, "publish_realtime", lambda *a, **k: None), \
+             mock.patch.object(rollback, "_delete_one", return_value=None), \
+             mock.patch.object(rollback, "_quiet_framework", fake_quiet), \
+             mock.patch.object(rollback, "_record_row",
+                               side_effect=lambda parent, idx, **k: recorded.append(k)):
+            rollback.run_revert("REV-1")
+
+        self.assertTrue(quiet["entered"])                       # loop ran quietened
+        self.assertEqual(sum(1 for k in recorded if k["deleted"] == 1), 2)
+        revert.db_set.assert_any_call("status", "Completed")     # clean undo
+        log.db_set.assert_any_call("status", "Reverted")
+
+    def test_kept_record_marks_reverted_with_errors(self):
+        revert = mock.Mock()
+        revert.name, revert.migration_log = "REV-1", "TML-1"
+        log = mock.Mock()
+        log.created_records = '{"Items": [{"name": "W1", "doctype": "Item"}]}'
+
+        def gd(dt, *a, **k):
+            return revert if dt == "Tally Migration Revert" else log
+
+        with mock.patch.object(rollback.frappe, "get_doc", side_effect=gd), \
+             mock.patch.object(rollback, "_protected_doctypes", return_value=set()), \
+             mock.patch.object(rollback.frappe.db, "exists", return_value=True), \
+             mock.patch.object(rollback.frappe.db, "commit", lambda *a, **k: None), \
+             mock.patch.object(rollback.frappe.db, "get_value", return_value="user@x"), \
+             mock.patch.object(rollback.frappe, "publish_realtime", lambda *a, **k: None), \
+             mock.patch.object(rollback, "_delete_one", return_value="Linked with SI-9"), \
+             mock.patch.object(rollback, "_quiet_framework", contextlib.nullcontext), \
+             mock.patch.object(rollback, "_record_row", lambda *a, **k: None):
+            rollback.run_revert("REV-1")
+
+        revert.db_set.assert_any_call("status", "Completed with Errors")
+        log.db_set.assert_any_call("status", "Reverted with Errors")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Makes the migration **revert** reliable and fast at real scale, and fixes the revert form so it never sits frozen on a stale status. Validated end-to-end on Frappe Cloud with a real 22,531-record migration + revert (completed in ~33 min, `enqueues: 0`, 0 kept), and locally with the full test suite.

No behaviour change to the import path except a safety hardening (below). No diagnostics/profiler code is included here.

## 1. Revert performance and crash-safety

A revert of tens of thousands of records previously blew the 60-minute job timeout and left most records undeleted, reporting `0 deleted`.

- **Quiet the per-record framework churn** during the delete loop (`_quiet_framework`): set `frappe.flags.in_import` to suppress the realtime `doc_update`/`list_update` storm (which drove a notification/Error-Log open-count aggregation per document), skip the per-delete `Deleted Document` backup and `Comment` feed, and run `delete_dynamic_links` inline instead of enqueuing one background job per record (the earlier queue flood). None of this is needed for an undo - the revert keeps its own audit.
- **Persist the audit incrementally** as batches commit, so a killed worker leaves a truthful partial result and a re-run resumes from what is left, instead of writing the whole child table only at the very end.

## 2. Background-job (>100 row) submit/cancel handling

ERPNext routes a **Journal Entry with >100 accounts** (an opening-balance entry always is) and a **Stock Reconciliation with >100 items** to a background Submission Queue. In a synchronous revert that never completes: the document stays submitted, the delete then fails, and it is wrongly kept (it also held its GL accounts alive, so a whole chain was kept).

- The revert now cancels submitted documents via the synchronous `_cancel()` - the exact action the queue would have run - and clears any stale document lock from a prior queued attempt first.
- The opening Stock Reconciliation **import** now submits via `_submit()` for the same reason, so it stays synchronous regardless of chunk size (mirrors the existing Opening Entry handling).

Adds regression tests for the synchronous cancel/submit paths and the incremental audit.

## 3. Revert form refreshes via status poll, not realtime alone

The Tally Migration Revert form relied solely on the `tally_revert_updated` realtime event to reload when the background undo finished. Realtime is best-effort, so a page that missed the event (backgrounded tab, socket reconnect, incognito) sat on `Queued` / `0 deleted` indefinitely even though the job had completed.

- Realtime still reloads instantly when it arrives (fast path).
- If it's missed, a 5s status poll reloads the page the moment the revert hits a terminal state (Completed / Completed with Errors / Failed) - so it can never sit frozen on "Queued" again.
- The poll self-terminates when you leave the form (no leak).

Mirrors the wizard step-5 poll fallback.
