### PR TITLE
build: declare Frappe Cloud version compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,9 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 include = ["tally_migrator*"]
+
+# Frappe Cloud reads this to validate version compatibility during installs,
+# updates, and branch changes. Use version ranges, not hard pins.
+[tool.bench.frappe-dependencies]
+frappe = ">=15.0.0,<17.0.0"
+erpnext = ">=15.0.0,<17.0.0"


### PR DESCRIPTION
Add `[tool.bench.frappe-dependencies]` to `pyproject.toml` so Frappe Cloud can validate app compatibility during installs, updates, and branch changes.

Without this section, a non-version-named branch (e.g. `fc/e2e-profiler`) fails FC branch-change validation with:

> Invalid version format for app 'Tally Migrator'. Please use NPM-style semver ranges.

Declares support for Frappe/ERPNext 15 and 16.

Ref: https://docs.frappe.io/cloud/custom-apps/app-versioning/versioning