### PR TITLE
fix: preserve party contacts and addresses on dirty phone / GSTIN data

### DIFF
--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -721,12 +721,24 @@ Migrator handles a real-world wrinkle in Tally data.
   matches a standard type (Billing, Shipping, Office, and so on), otherwise it is
   typed "Other" with the label preserved in the title.
 - **Each address needs a state.** ERPNext (with India Compliance) requires a state on
-  an Indian address. For each address, the app uses the most precise signal it has:
-  the address's own state, then the state derived from its own PIN code, then the
-  party's state. So a party with a valid address rarely loses it for a missing state.
+  an Indian address. For each address, the app uses the most reliable signal it has:
+  a valid GSTIN's own state code, then the address's ledger state, then the state
+  derived from its PIN code, then the party's state. So a party with a valid address
+  rarely loses it for a missing state.
+- **GSTIN wins when it disagrees with the state.** India Compliance rejects an address
+  whose state does not match its GSTIN. When Tally's ledger state contradicts a valid
+  GSTIN, the app trusts the GSTIN (its first two digits are the GST state) and sets the
+  address state to match, keeping both the address and the GSTIN, and warns you to
+  verify. Previously such a mismatch lost the whole address.
 - **Multiple phone numbers and contacts.** Tally's extra named contacts are each
   imported as their own ERPNext Contact, linked to the party. The number Tally marks
   as the WhatsApp default is set as the primary mobile.
+- **Bad phone numbers.** Tally often holds a company name, a placeholder, or a stray
+  text-guard character in a phone field, which ERPNext would reject - failing the whole
+  Contact or Address (and losing its email and name too). The app keeps a valid number
+  as-is (including international numbers ERPNext accepts), salvages one that only carries
+  invisible or wrapper characters, and otherwise drops just the phone with a warning -
+  never guessing a number from text. The contact's email and name are kept either way.
 - **The primary address and contact are linked.** ERPNext does not automatically mark
   a party's primary address or contact when they are created separately, so the app
   sets them explicitly. Without this, migrated parties would show no primary address
@@ -916,7 +928,7 @@ These appear on the Check step and in the log's data-quality section.
 | **Invalid GSTIN** | Error | The GST number fails its format or checksum | Correct the GSTIN in Tally (or in the inline editor), or clear it to migrate the party as Unregistered |
 | **Item code collision** | Error | Two Tally items reduce to the same ERPNext item code after truncation and "/" replacement | Rename one item in Tally; ERPNext item codes must be unique |
 | **Imports without a GST state** | Warning | An Indian party has no state, and none could be derived from a GSTIN | Add a state so its GST invoices compute CGST/SGST vs IGST correctly, or leave it; the party still imports |
-| **GSTIN and state to verify** | Warning | The GSTIN's state code maps to a different state than the ledger state | Check it; the wrong state flips CGST/SGST vs IGST |
+| **GSTIN and state to verify** | Warning | The GSTIN's state code maps to a different state than the ledger state | On import the app trusts the GSTIN and sets the address state to match it (keeping the address); verify which is correct, as the wrong state flips CGST/SGST vs IGST |
 | **PIN and state to verify** | Warning | The PIN code's region does not match the state | Check it; the PIN or the state may be a typo |
 | **Imports without the email** | Warning | The email is not a valid address; the party's contact would lose it | Fix or clear the email; the party imports with its other contact details either way |
 | **Imports without HSN** | Warning | An item has no HSN/SAC code | Add an HSN when ready; needed only for GST-compliant invoices |

--- a/tally_migrator/erpnext/importers/party.py
+++ b/tally_migrator/erpnext/importers/party.py
@@ -3,12 +3,13 @@
 import contextlib
 import importlib
 import re
+import unicodedata
 from collections import Counter
 from dataclasses import dataclass, field
 from functools import lru_cache
 
 import frappe
-from frappe.utils import validate_email_address
+from frappe.utils import validate_email_address, validate_phone_number
 
 from tally_migrator.tally.mappings import (
     UOM_MAP,
@@ -36,6 +37,57 @@ from .banks import _ensure_bank, _insert_bank_account
 # Mirrored here so an invalid Tally INCOMETAXNumber can be dropped before it reaches
 # IC's validation and blocks the party - see PartyImporter._valid_pan.
 _PAN_NUMBER = re.compile(r"^[A-Z]{5}[0-9]{4}[A-Z]$")
+
+# The characters ERPNext's phone validator accepts (frappe.utils.validate_phone_number
+# / PHONE_NUMBER_PATTERN). Used only to peel wrapper cruft off the ENDS of a value
+# ERPNext already rejected - internal characters are never touched, so a real number is
+# never fabricated from alphanumeric junk.
+_PHONE_ALLOWED = frozenset("0123456789 +_-,.*#()")
+
+
+def _clean_phone(raw) -> str:
+    """A phone string ERPNext will store, or "" when it cannot be salvaged without
+    guessing.
+
+    Verbatim-if-valid: a value ERPNext already accepts is returned byte-for-byte, so
+    good data (including any international number ERPNext accepts) is never altered.
+    Only a value ERPNext would reject enters the salvage path, which:
+
+      * removes invisible control/format characters (Unicode Cc/Cf - e.g. Tally's
+        trailing bidi mark on "6005-593802\\u202c"), and
+      * peels leading/trailing characters outside the accepted set (e.g. an Excel/Tally
+        text-guard apostrophe on "'628065239").
+
+    Internal characters are never removed or reordered, so alphanumeric junk
+    ("NOBLE INFOMATIQUE", "98abc76") can never be turned into a number - it is dropped.
+    The validation is ERPNext's own ``validate_phone_number``, so this is never stricter
+    or looser than what ERPNext would have accepted."""
+    if raw in (None, ""):
+        return ""
+    s = str(raw)
+    if validate_phone_number(s):
+        return s  # ERPNext accepts it - store exactly as given, never touch valid data
+    # Salvage path - reached only for values ERPNext rejects.
+    s = "".join(ch for ch in s if unicodedata.category(ch) not in ("Cc", "Cf"))
+    while s and s[0] not in _PHONE_ALLOWED:
+        s = s[1:]
+    while s and s[-1] not in _PHONE_ALLOWED:
+        s = s[:-1]
+    return s if (s and validate_phone_number(s)) else ""
+
+
+@lru_cache(maxsize=1)
+def _state_by_gst_number() -> dict:
+    """Inverse of India Compliance's ``STATE_NUMBERS`` (GST state code -> canonical
+    state name), so a state derived from a GSTIN is guaranteed to be a name IC accepts
+    and whose number IC maps back to the same code. Empty when IC is absent (no GST
+    validation runs then), so callers fall back to prior behaviour. Cached: the map is
+    a static constant."""
+    try:
+        from india_compliance.gst_india.constants import STATE_NUMBERS
+    except Exception:
+        return {}
+    return {num: state for state, num in STATE_NUMBERS.items()}
 
 
 @lru_cache(maxsize=1)
@@ -543,8 +595,12 @@ class PartyImporter(BaseImporter):
         ERPNext Contact linked to the party, with the WhatsApp-default number marked
         the primary mobile. Non-fatal per contact."""
         for c in data.get("_extra_contacts") or []:
-            phone = (c.get("phone") or "").strip()
+            raw_phone = (c.get("phone") or "").strip()
+            phone = _clean_phone(raw_phone)
             if not phone:
+                if raw_phone:
+                    result.add_warning(
+                        link_name, "additional contact skipped - not a valid phone number")
                 continue
             try:
                 with atomic():
@@ -654,18 +710,27 @@ class PartyImporter(BaseImporter):
             addr.state = state
             addr.country = country
             addr.pincode = data.get("PinCode") or ""
-            addr.phone = data.get("LedgerPhone") or data.get("LedgerMobile") or ""
+            # Tally holds plenty of junk in the phone field (a company name, a
+            # placeholder like "XXXXXXXXXX", a stray text-guard apostrophe). A phone
+            # ERPNext rejects would fail the WHOLE address, so validate/salvage it and
+            # drop just the field when it cannot be salvaged - the address still imports.
+            raw_phone = (data.get("LedgerPhone") or data.get("LedgerMobile") or "").strip()
+            addr.phone = _clean_phone(raw_phone)
+            if raw_phone and not addr.phone:
+                result.add_warning(
+                    link_name, "phone number not set on the address - not a valid "
+                    "phone number")
             # A malformed email (Tally holds plenty: "NA", "n/a", "x@") makes ERPNext
             # reject the whole address. Run it through the same validator ERPNext uses
             # and drop just the bad email, so the address still imports.
             addr.email_id = validate_email_address(
                 (data.get("LedgerEmail") or "").strip(), throw=False)
-            # Only set a structurally valid GSTIN: India Compliance validates the
-            # address GSTIN and rejects the whole address on a malformed one, which
-            # would lose the address entirely. A bad GSTIN is already flagged by the
-            # pre-flight; here we drop just the field and keep the address.
+            # Only set a structurally valid GSTIN, and on an IC site only when its state
+            # code matches the address state (else IC rejects the whole address) - see
+            # _address_gstin. A bad or state-mismatched GSTIN is dropped, keeping the
+            # address; the pre-flight already flags GSTIN problems.
             gstin = (data.get("GSTRegistrationNumber") or "").strip().upper()
-            addr.gstin = gstin if (gstin and validate_gstin(gstin)[0]) else ""
+            addr.gstin = self._address_gstin(gstin, state, country, link_name, result)
             addr.append("links", {"link_doctype": link_type, "link_name": link_name})
             # Remember the message-queue length so that, if the insert fails on a
             # pincode/state mismatch, we can drop India Compliance's own "Invalid
@@ -728,18 +793,61 @@ class PartyImporter(BaseImporter):
             result.add_warning(link_name, f"address not created: {exc}")
             return ""
 
+    def _address_gstin(self, gstin: str, state: str, country: str,
+                       link_name: str, result: "ImportResult") -> str:
+        """The GSTIN to store on the address, or "" to drop it (keeping the address).
+
+        Keeps the existing rule (a structurally valid GSTIN only) and, on an India
+        Compliance site for an Indian address, additionally keeps it only when its state
+        code matches the address state IC will validate against - otherwise IC rejects
+        the whole address ("First 2 digits of GSTIN should match ..."). Because
+        _resolve_state derives the state from the GSTIN whenever IC can represent its
+        code, that check passes for every ordinary GSTIN; it drops only a valid GSTIN
+        whose code IC cannot represent (e.g. a pre-2020 union-territory code), with a
+        warning, so the address itself still imports. Non-IC or non-India addresses are
+        returned unchanged - IC does not cross-check them."""
+        if not (gstin and validate_gstin(gstin)[0]):
+            return ""
+        ic_states = _state_by_gst_number()
+        if not ic_states or country != "India":
+            return gstin  # IC absent or foreign address: no state<->GSTIN cross-check
+        if ic_states.get(gstin[:2]) == state:
+            return gstin
+        result.add_warning(
+            link_name, "GSTIN not set on the address - its state code has no matching "
+            "GST state in India Compliance (verify the GSTIN in ERPNext)")
+        return ""
+
     def _resolve_state(self, data: dict) -> str:
-        """The party's ERPNext state, most-reliable signal first: Tally's ledger
-        state, else a structurally valid GSTIN's state code, else derived from the
-        party's PIN code (India Compliance's pincode<->state map). Tally does not
-        mandate a ledger state so most exports omit it, but a PIN is common and
-        yields an IC-valid state - so the address is kept rather than dropped on
-        India Compliance's missing-state rule."""
+        """The party's ERPNext state, most-reliable signal first: a structurally valid
+        GSTIN's state code (authoritative, and mapped through India Compliance's own
+        state<->number table so it round-trips through IC's validation), else Tally's
+        ledger state, else derived from the party's PIN code (IC's pincode<->state map).
+        Tally does not mandate a ledger state so most exports omit it, but a GSTIN or a
+        PIN is common and yields an IC-valid state - so the address is kept rather than
+        dropped on India Compliance's missing-state rule."""
+        # A structurally valid GSTIN is the authoritative source of the party's GST
+        # state: its first two digits ARE the state's GST number, and India Compliance
+        # rejects the address unless the state and the GSTIN agree. So when a valid
+        # GSTIN is present, derive the state from it - using IC's own state<->number map
+        # so the name is guaranteed to round-trip through IC's validation - in preference
+        # to Tally's free-text ledger state, which is frequently blank or contradicts the
+        # GSTIN (the contradiction is exactly what used to lose the whole address).
+        gstin = (data.get("GSTRegistrationNumber") or "").strip().upper()
+        gstin_valid = bool(gstin and validate_gstin(gstin)[0])
+        ic_states = _state_by_gst_number()  # {} when India Compliance is not installed
+        if gstin_valid and ic_states:
+            ic_state = ic_states.get(gstin[:2], "")
+            if ic_state:
+                return ic_state
         state = TALLY_STATE_MAP.get((data.get("LedgerState") or "").strip(), "")
         if state:
             return state
-        gstin = (data.get("GSTRegistrationNumber") or "").strip().upper()
-        if gstin and validate_gstin(gstin)[0]:
+        # Without IC there is no canonical map, so fall back to the migrator's own
+        # GSTIN->state table. Only used when IC is absent (and therefore not validating):
+        # a few of its union-territory names differ from IC's, so on an IC site the code
+        # above already handled the GSTIN and this is deliberately skipped.
+        if gstin_valid and not ic_states:
             derived = GSTIN_STATE_CODES.get(gstin[:2], "")
             if derived:
                 return derived
@@ -756,8 +864,17 @@ class PartyImporter(BaseImporter):
         Address fields and be lost entirely when the party has no street address.
         Non-fatal: a failure is recorded as a warning so the dropped contact is
         visible in the migration log rather than lost silently."""
-        phone = (data.get("LedgerPhone") or "").strip()
-        mobile = (data.get("LedgerMobile") or "").strip()
+        # Validate/salvage phone and mobile the same way (a junk phone would otherwise
+        # reject the whole Contact and lose its email and name too). Drop just the bad
+        # field, keeping the rest of the contact. Warn so the drop shows.
+        raw_phone = (data.get("LedgerPhone") or "").strip()
+        raw_mobile = (data.get("LedgerMobile") or "").strip()
+        phone = _clean_phone(raw_phone)
+        mobile = _clean_phone(raw_mobile)
+        if raw_mobile and not mobile:
+            result.add_warning(link_name, "contact mobile number skipped - not a valid phone number")
+        if raw_phone and not phone:
+            result.add_warning(link_name, "contact phone number skipped - not a valid phone number")
         # Validate emails up front (the same validator ERPNext's Contact uses) and
         # drop a malformed one - Tally holds plenty ("NA", "n/a", "x@") and a single
         # bad email would otherwise reject the whole contact. Warn so the drop shows.

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -338,16 +338,25 @@ class TestERPNextImporter(unittest.TestCase):
 
     # ── Step 1: recover address/contact drops (no-state, bad email) ────────────
 
-    def test_resolve_state_prefers_ledger_then_gstin_then_pin(self):
-        """State resolves most-reliable first: Tally ledger state, else GSTIN state
-        code, else derived from the PIN. Tally rarely sets a ledger state, so the
-        PIN fallback is what keeps most addresses out of the missing-state drop."""
+    def test_resolve_state_prefers_gstin_then_ledger_then_pin(self):
+        """State resolves most-reliable first: a valid GSTIN's state code (authoritative -
+        it IS the GST state, and India Compliance rejects the address unless the state
+        matches it), else Tally's ledger state, else derived from the PIN. Preferring the
+        GSTIN is what stops a GSTIN that contradicts Tally's ledger state from losing the
+        whole address."""
         from tally_migrator.erpnext.importers import CustomerImporter
         imp = CustomerImporter("_TMTest Co", "TC")
-        # ledger state wins over everything
+        # a valid GSTIN wins over a conflicting ledger state (27 -> Maharashtra), so the
+        # state agrees with the GSTIN we attach and IC accepts the address
         self.assertEqual(imp._resolve_state(
             {"LedgerState": "Karnataka", "GSTRegistrationNumber": "27AAACT2727Q1ZW",
-             "PinCode": "600001"}), "Karnataka")
+             "PinCode": "600001"}), "Maharashtra")
+        # a structurally invalid GSTIN is ignored -> ledger state is used
+        self.assertEqual(imp._resolve_state(
+            {"LedgerState": "Karnataka", "GSTRegistrationNumber": "GARBAGE"}), "Karnataka")
+        # no GSTIN -> ledger state
+        self.assertEqual(imp._resolve_state(
+            {"LedgerState": "Karnataka", "PinCode": "600001"}), "Karnataka")
         # no ledger state -> GSTIN's state code (27 -> Maharashtra) beats the PIN
         self.assertEqual(imp._resolve_state(
             {"GSTRegistrationNumber": "27AAACT2727Q1ZW", "PinCode": "600001"}),

--- a/tally_migrator/tests/test_party_hygiene.py
+++ b/tally_migrator/tests/test_party_hygiene.py
@@ -1,0 +1,263 @@
+"""Party data-hygiene: phone salvage and GSTIN<->state authority.
+
+Two related fixes, both following the importer's established "validate the dirty field,
+drop just that field, keep the record" pattern (as it already does for email, GSTIN and
+PIN):
+
+  * ``_clean_phone`` - a phone ERPNext rejects used to fail the WHOLE Contact/Address,
+    silently losing the party's email and name too. Now a bad phone is salvaged or
+    dropped, keeping the rest. Verbatim-if-valid, so good data (including international
+    numbers ERPNext accepts) is never altered, and junk is never turned into a number.
+  * ``_address_gstin`` / ``_resolve_state`` - a structurally valid GSTIN whose state code
+    contradicts Tally's ledger state used to fail the whole address on India Compliance's
+    "First 2 digits of GSTIN should match ..." rule. The GSTIN is now authoritative (its
+    code IS the GST state), derived through IC's own state<->number map so it round-trips
+    through IC's validation.
+
+Frappe-tier (imports ``tally_migrator.erpnext.importers.party`` -> ``frappe``). The DB is
+mocked, so no site is touched; ``validate_phone_number`` / ``validate_gstin`` and (when
+installed) India Compliance's ``STATE_NUMBERS`` are exercised for real.
+"""
+import contextlib
+import types
+import unittest
+from unittest import mock
+
+from tally_migrator.erpnext.importers import party
+from tally_migrator.erpnext.importers.base import ImportResult
+
+
+@contextlib.contextmanager
+def _noop_atomic():
+    yield
+
+
+class TestCleanPhone(unittest.TestCase):
+    """`_clean_phone` against ERPNext's real validator (frappe.utils.validate_phone_number)."""
+
+    def test_valid_numbers_pass_through_verbatim(self):
+        # No-override guarantee: anything ERPNext accepts is returned byte-for-byte.
+        for good in [
+            "9876543210",
+            "+91 98765 43210",
+            "98765-43210",
+            "(011) 2345-6789",
+            "+1 415 555 2671",       # US - the validator is not India-specific
+            "+44 20 7946 0958",      # UK
+            "+971 4 123 4567",       # UAE
+        ]:
+            self.assertEqual(party._clean_phone(good), good, f"altered a valid number: {good!r}")
+
+    def test_whitespace_wrapped_valid_number_is_untouched(self):
+        # ERPNext accepts it (its validator strips only for the check, then stores raw),
+        # so we must return it exactly - not a trimmed version.
+        self.assertEqual(party._clean_phone("  9876543210  "), "  9876543210  ")
+
+    def test_integer_input_is_stringified(self):
+        self.assertEqual(party._clean_phone(9876543210), "9876543210")
+
+    def test_empty_and_none(self):
+        self.assertEqual(party._clean_phone(""), "")
+        self.assertEqual(party._clean_phone(None), "")
+        self.assertEqual(party._clean_phone("   "), "")
+
+    def test_salvages_trailing_invisible_char(self):
+        # Tally's trailing bidi mark (U+202C) - stripped, number kept.
+        self.assertEqual(party._clean_phone("6005-593802‬"), "6005-593802")
+
+    def test_salvages_leading_text_guard_apostrophe(self):
+        # Excel/Tally text guard - peeled off the end, number kept (Tier 2).
+        self.assertEqual(party._clean_phone("'628065239"), "628065239")
+        self.assertEqual(party._clean_phone('"9876543210"'), "9876543210")
+
+    def test_drops_names_and_placeholders_never_fabricates(self):
+        # A name / placeholder is not a number - dropped, never mined for digits.
+        # (Note: "-" or "()" ARE accepted by ERPNext's lenient validator, so _clean_phone
+        # stores them verbatim - being stricter than ERPNext would be its own override.)
+        for junk in ["NOBLE INFOMATIQUE", "Balvinder Pa", "XXXXXXXXXX", "n/a", "abc"]:
+            self.assertEqual(party._clean_phone(junk), "", f"fabricated from junk: {junk!r}")
+
+    def test_internal_junk_is_never_mined(self):
+        # Letters BETWEEN digits can't be peeled (only the ends are), so an alphanumeric
+        # value is dropped whole - "98abc76" never becomes "9876".
+        self.assertEqual(party._clean_phone("98abc76"), "")
+        self.assertEqual(party._clean_phone("011-2345 Ph 98765"), "")  # two labelled bits -> drop
+
+    def test_leading_label_is_peeled_to_the_number(self):
+        # A label prefix is wrapper cruft on the end, so it peels off and the contiguous
+        # number is recovered (same class as the apostrophe case). The number is never
+        # fabricated - it appears verbatim and contiguous in the input.
+        self.assertEqual(party._clean_phone("Ph: 98765"), " 98765")
+
+    def test_drops_overlong_number(self):
+        # ERPNext caps at 20 chars; a 23-digit value fails there too, so we drop it
+        # (never silently truncate).
+        self.assertEqual(party._clean_phone("1" * 23), "")
+
+
+class TestStateByGstNumber(unittest.TestCase):
+    """`_state_by_gst_number` must be the exact inverse of IC's STATE_NUMBERS so any
+    state we derive from a GSTIN round-trips through IC's own validation."""
+
+    def setUp(self):
+        try:
+            from india_compliance.gst_india.constants import STATE_NUMBERS  # noqa: F401
+        except Exception:
+            self.skipTest("India Compliance not installed")
+        self.STATE_NUMBERS = STATE_NUMBERS
+
+    def test_known_codes_map_to_ic_canonical_names(self):
+        inv = party._state_by_gst_number()
+        self.assertEqual(inv.get("04"), "Chandigarh")
+        self.assertEqual(inv.get("27"), "Maharashtra")
+        self.assertEqual(inv.get("03"), "Punjab")
+
+    def test_is_exact_inverse_roundtrip(self):
+        # For every code we resolve, IC maps the resulting state back to that same code -
+        # so IC's "state number must match gstin[:2]" check can never reject it.
+        inv = party._state_by_gst_number()
+        self.assertTrue(inv, "inverse map unexpectedly empty on an IC site")
+        for code, state in inv.items():
+            self.assertEqual(self.STATE_NUMBERS[state], code)
+
+    def test_legacy_daman_code_25_absent(self):
+        # Post-2020 merger: IC has no code 25 - so a legacy 25-GSTIN is not representable
+        # and must be handled by dropping the GSTIN, not by inventing a state.
+        self.assertEqual(party._state_by_gst_number().get("25", ""), "")
+
+
+class TestAddressGstin(unittest.TestCase):
+    """`_address_gstin` - keep a GSTIN only when IC will accept it against the state."""
+
+    # A real, checksum-valid GSTIN for Chandigarh (state code 04).
+    GSTIN_04 = "04AABCU9603R1ZV"
+
+    def setUp(self):
+        self.result = ImportResult("Address")
+        self._self = types.SimpleNamespace()   # _address_gstin uses no instance state
+
+    def _call(self, gstin, state, country="India"):
+        return party.PartyImporter._address_gstin(
+            self._self, gstin, state, country, "ACME", self.result)
+
+    def test_structurally_invalid_gstin_dropped(self):
+        self.assertEqual(self._call("NOTAGSTIN", "Chandigarh"), "")
+        self.assertEqual(self.result.warnings, [])   # invalid GSTIN is silent here (pre-flight owns it)
+
+    def test_valid_gstin_matching_state_kept(self):
+        if not party._state_by_gst_number():
+            self.skipTest("India Compliance not installed")
+        self.assertEqual(self._call(self.GSTIN_04, "Chandigarh"), self.GSTIN_04)
+        self.assertEqual(self.result.warnings, [])
+
+    def test_valid_gstin_mismatched_state_dropped_with_warning(self):
+        if not party._state_by_gst_number():
+            self.skipTest("India Compliance not installed")
+        # GSTIN says 04 (Chandigarh) but the address state is Punjab -> IC would reject the
+        # whole address; we keep the address and drop the GSTIN, with a visible warning.
+        self.assertEqual(self._call(self.GSTIN_04, "Punjab"), "")
+        self.assertTrue(any("GSTIN not set" in w["reason"] for w in self.result.warnings))
+
+    def test_non_india_address_keeps_gstin_untouched(self):
+        # IC does not cross-check a foreign address, so prior behaviour is preserved.
+        self.assertEqual(self._call(self.GSTIN_04, "", country="United States"), self.GSTIN_04)
+        self.assertEqual(self.result.warnings, [])
+
+    def test_ic_absent_keeps_valid_gstin(self):
+        with mock.patch.object(party, "_state_by_gst_number", return_value={}):
+            self.assertEqual(self._call(self.GSTIN_04, "Anything"), self.GSTIN_04)
+        self.assertEqual(self.result.warnings, [])
+
+
+class TestResolveStateGstinAuthority(unittest.TestCase):
+    """`_resolve_state` prefers a valid GSTIN's (IC-canonical) state over the ledger."""
+
+    def setUp(self):
+        if not party._state_by_gst_number():
+            self.skipTest("India Compliance not installed")
+        self._self = types.SimpleNamespace(
+            _state_from_pincode=lambda pin: "")
+
+    def _resolve(self, data):
+        return party.PartyImporter._resolve_state(self._self, data)
+
+    def test_gstin_wins_over_conflicting_ledger_state(self):
+        # Ledger says Punjab, GSTIN says 04 (Chandigarh) -> Chandigarh, so it matches the
+        # GSTIN we will attach and IC accepts the address.
+        state = self._resolve({"GSTRegistrationNumber": "04AABCU9603R1ZV",
+                               "LedgerState": "Punjab"})
+        self.assertEqual(state, "Chandigarh")
+
+    def test_ledger_used_when_no_gstin(self):
+        state = self._resolve({"LedgerState": "Maharashtra"})
+        self.assertEqual(state, "Maharashtra")
+
+    def test_invalid_gstin_falls_back_to_ledger(self):
+        state = self._resolve({"GSTRegistrationNumber": "GARBAGE",
+                               "LedgerState": "Maharashtra"})
+        self.assertEqual(state, "Maharashtra")
+
+
+class TestSaveContactRecoversRest(unittest.TestCase):
+    """The key win: a junk phone must no longer cost the party its email and name."""
+
+    def _run_save_contact(self, data):
+        result = ImportResult("Contact")
+        made = {}
+
+        class _FakeContact:
+            def __init__(self):
+                self.name = "CONTACT-0001"
+                self.first_name = ""
+                self.email_ids = []
+                self.phone_nos = []
+                self.links = []
+                made["doc"] = self
+
+            def append(self, table, row):
+                getattr(self, table).append(row)
+
+            def insert(self, **kw):
+                made["inserted"] = True
+
+        with mock.patch.object(party.frappe, "new_doc", side_effect=lambda *a, **k: _FakeContact()), \
+             mock.patch.object(party, "atomic", _noop_atomic):
+            name = party.PartyImporter._save_contact(
+                types.SimpleNamespace(), "ACME", "Supplier", data, result)
+        return name, made, result
+
+    def test_junk_phone_keeps_email_and_name(self):
+        name, made, result = self._run_save_contact({
+            "LedgerContact": "Priya",
+            "LedgerPhone": "NOBLE INFOMATIQUE",     # junk
+            "LedgerEmail": "priya@acme.example",
+        })
+        self.assertEqual(name, "CONTACT-0001")            # contact WAS created
+        doc = made["doc"]
+        self.assertEqual(doc.first_name, "Priya")         # name kept
+        self.assertEqual([e["email_id"] for e in doc.email_ids], ["priya@acme.example"])
+        self.assertEqual(doc.phone_nos, [])               # junk phone dropped, not stored
+        self.assertTrue(any("phone number skipped" in w["reason"] for w in result.warnings))
+
+    def test_valid_mobile_and_junk_phone_keeps_mobile(self):
+        name, made, result = self._run_save_contact({
+            "LedgerContact": "Sales",
+            "LedgerMobile": "9876543210",
+            "LedgerPhone": "call us",               # junk
+        })
+        doc = made["doc"]
+        self.assertEqual([p["phone"] for p in doc.phone_nos], ["9876543210"])
+        self.assertEqual(doc.phone_nos[0]["is_primary_mobile_no"], 1)
+        self.assertTrue(any("phone number skipped" in w["reason"] for w in result.warnings))
+
+    def test_no_contact_when_nothing_valid_remains(self):
+        name, made, result = self._run_save_contact({
+            "LedgerContact": "Ghost",
+            "LedgerPhone": "XXXXXXXXXX",             # junk, and no email/mobile
+        })
+        self.assertEqual(name, "")                        # nothing to create
+        self.assertNotIn("doc", made)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Tally phone fields often hold a name, placeholder, or stray text-guard character that ERPNext rejects, which failed the whole Contact or Address and silently lost the party's email and name too. A structurally valid GSTIN whose state code contradicted Tally's ledger state was likewise rejected by India Compliance, losing the whole address.

## Fixes
- **Phone:** keep a valid number verbatim (including international numbers ERPNext accepts), salvage one carrying only invisible/wrapper characters, else drop just the phone with a warning - never guessing digits from text.
- **GSTIN-state:** treat a valid GSTIN's state code as authoritative (derived through India Compliance's own state<->number map so it round-trips through IC's validation), keeping both the address and the GSTIN. A legacy/unrepresentable code drops just the GSTIN, keeping the address.

## Impact (measured on a 13k-party export)
- Error Log entries: **61 -> 1** (all 41 phone + 19 GSTIN-state errors eliminated; the 1 remaining is an unrelated name-length case).
- Recovered ~45 addresses/contacts; every GSTIN address is IC-consistent (1209/1209).
- No runtime or memory cost (validation-only).

## Tests
- New `test_party_hygiene.py` (24 tests); updated the `_resolve_state` contract test to GSTIN-first.
- Full suite green (622 tests).