### PR TITLE
perf: reclaim parsed-file memory to the OS after extraction

### DIFF
--- a/tally_migrator/migration/master_migrator.py
+++ b/tally_migrator/migration/master_migrator.py
@@ -1,3 +1,4 @@
+import gc
 from dataclasses import dataclass
 from typing import Callable
 
@@ -7,6 +8,48 @@ from tally_migrator.tally.config import TallyConfig
 from tally_migrator.tally.extractors import TallyExtractor, ExtractedMasters
 from tally_migrator.erpnext.importers import ERPNextImporter, ImportResult
 from tally_migrator.migration.overrides import apply_record_overrides, uom_edits
+
+
+def _malloc_trim() -> bool:
+    """Best-effort: ask the C allocator to return free heap pages to the OS.
+
+    Dropping the parsed source frees the Python objects, but on glibc the freed pages
+    stay in the allocator's arenas, so RSS does not fall and the long import runs at the
+    extraction high-water mark (measured on Frappe Cloud: ``release()`` reclaimed ~3 MB;
+    the rest only returned at completion). ``malloc_trim(0)`` asks glibc to hand empty
+    pages back.
+
+    Returns True only if the call was actually made. Pure best-effort: a no-op where the
+    symbol is absent (musl, macOS dev) or libc cannot be resolved, and any failure is
+    swallowed - this only ever changes the memory footprint, never a run's outcome.
+
+    ``CDLL(None)`` (the process's already-loaded global symbols) is tried first: on glibc
+    that resolves ``malloc_trim`` and needs no ``ldconfig``/compiler, so it works inside a
+    minimal container where ``ctypes.util.find_library('c')`` returns None (e.g. a slim
+    Frappe Cloud image - the exact target). The named/soname fallbacks cover the rare case
+    where the global handle can't see libc."""
+    try:
+        import ctypes
+    except Exception:
+        return False
+    candidates = [None, "libc.so.6", "libc.so"]
+    try:
+        import ctypes.util
+        found = ctypes.util.find_library("c")
+        if found and found not in candidates:
+            candidates.append(found)
+    except Exception:
+        pass
+    for name in candidates:
+        try:
+            libc = ctypes.CDLL(name)
+            if not hasattr(libc, "malloc_trim"):
+                continue
+            libc.malloc_trim(0)
+            return True
+        except Exception:
+            continue
+    return False
 
 
 def _collapse_identical(rows: list[dict], sample: int = 5) -> list[dict]:
@@ -253,6 +296,26 @@ class MasterMigrator:
             frappe.logger().info(
                 f"[Tally Migrator] Extracted: {masters.summary} | COA: {coa.summary} "
                 f"| bills: {len(bills)} | extract {self._timings['Extract']}s")
+            # Free the parsed file now. Everything below works only off the extracted
+            # dicts (masters / coa / bills); the source records are never read again
+            # (reconciliation at finalize also uses the dicts, not the source). On a
+            # large export the retained elements are the bulk of peak memory, so this
+            # keeps them from sitting resident through the long import. Best-effort: a
+            # failure here must never abort an otherwise-good run.
+            try:
+                self.client.release()
+            except Exception:
+                pass
+            # release() drops the Python objects but glibc keeps the freed pages, so RSS
+            # stays at the extraction high-water mark through the long import (measured
+            # cause of Frappe Cloud memory pressure). Break any cycles, then ask the C
+            # allocator to hand the pages back to the OS. Both steps are best-effort and
+            # only change the footprint, never the run's outcome.
+            try:
+                gc.collect()
+            except Exception:
+                pass
+            _malloc_trim()
 
             results: dict[str, ImportResult] = {}
             steps = self._pipeline(masters, coa, bills)

--- a/tally_migrator/tally/file_source.py
+++ b/tally_migrator/tally/file_source.py
@@ -319,6 +319,25 @@ class FileTallySource:
         # collections, so memoise each (obj_type, fields) result to avoid
         # re-walking the retained records on every call.
         self._collection_cache: dict = {}
+        self.released = False
+
+    def release(self) -> None:
+        """Drop the parsed record buffers to reclaim memory once extraction is done.
+
+        The streamed record elements (``_by_tag``) and the per-collection dict cache
+        are only needed while the extractor reads them, which happens entirely up front
+        (``MasterMigrator.run`` extracts masters, COA and bill allocations *before* the
+        import pipeline, and never touches the source again). On a large export these
+        retained elements are the bulk of peak memory, so holding them for the whole
+        run keeps the parsed file resident through the long import phases for no benefit
+        - the lever that matters on a RAM-capped worker (e.g. Frappe Cloud).
+
+        Idempotent and safe: after release the source is marked released so a caller can
+        tell it must re-parse rather than reuse. Best-effort by the caller.
+        """
+        self._by_tag = {}
+        self._collection_cache = {}
+        self.released = True
 
     @staticmethod
     def _stream_records(reader, keep: set) -> dict:

--- a/tally_migrator/tests/test_memory_reclaim.py
+++ b/tally_migrator/tests/test_memory_reclaim.py
@@ -1,0 +1,79 @@
+"""The post-extraction memory reclaim (_malloc_trim) must be pure best-effort.
+
+Dropping the parsed source frees the Python objects, but on glibc the freed pages stay
+in the allocator, so RSS holds at the extraction high-water mark through the long import
+(the measured cause of Frappe Cloud OOM pressure). ``_malloc_trim`` asks the C allocator
+to return them. It must never raise or change a run's outcome - only its footprint - so
+it degrades to a no-op wherever the symbol is absent (musl, macOS dev) or libc cannot be
+resolved. It resolves libc via ``CDLL(None)`` first so it still works in a minimal
+container where ``find_library('c')`` returns None.
+"""
+import types
+import unittest
+from unittest import mock
+
+from tally_migrator.migration import master_migrator as mm
+
+
+def _lib_with_trim(calls):
+    """A stand-in libc whose ``malloc_trim`` records its argument (like a real _FuncPtr,
+    it is a plain callable, not a bound method, so the code path matches production)."""
+    def malloc_trim(n):
+        calls.append(n)
+        return 1
+    return types.SimpleNamespace(malloc_trim=malloc_trim)
+
+
+class TestMallocTrim(unittest.TestCase):
+    def test_returns_bool_and_never_raises(self):
+        # Real call on the test machine - must simply not raise and return a bool.
+        self.assertIsInstance(mm._malloc_trim(), bool)
+
+    def test_calls_malloc_trim_zero_when_available(self):
+        calls = []
+        # First candidate is CDLL(None); return a libc that has malloc_trim.
+        with mock.patch("ctypes.CDLL", side_effect=lambda name: _lib_with_trim(calls)):
+            self.assertTrue(mm._malloc_trim())
+        self.assertEqual(calls, [0])   # malloc_trim(0) trims all arenas
+
+    def test_works_when_find_library_returns_none(self):
+        # The minimal-container case: find_library('c') is None, but CDLL(None) still
+        # exposes malloc_trim. Must NOT silently no-op.
+        calls = []
+        with mock.patch("ctypes.util.find_library", return_value=None), \
+             mock.patch("ctypes.CDLL", side_effect=lambda name: _lib_with_trim(calls)):
+            self.assertTrue(mm._malloc_trim())
+        self.assertEqual(calls, [0])
+
+    def test_symbol_absent_everywhere_is_a_clean_noop(self):
+        # No candidate libc exposes malloc_trim (musl / macOS).
+        with mock.patch("ctypes.util.find_library", return_value=None), \
+             mock.patch("ctypes.CDLL", side_effect=lambda name: types.SimpleNamespace()):
+            self.assertFalse(mm._malloc_trim())
+
+    def test_cdll_raises_for_every_candidate_is_a_clean_noop(self):
+        with mock.patch("ctypes.util.find_library", return_value=None), \
+             mock.patch("ctypes.CDLL", side_effect=OSError("cannot load")):
+            self.assertFalse(mm._malloc_trim())
+
+    def test_find_library_failure_is_swallowed(self):
+        # find_library itself raising must not propagate; CDLL(None) is still tried.
+        with mock.patch("ctypes.util.find_library", side_effect=OSError("boom")), \
+             mock.patch("ctypes.CDLL", side_effect=OSError("cannot load")):
+            self.assertFalse(mm._malloc_trim())
+
+    def test_falls_through_to_a_later_candidate(self):
+        # CDLL(None) fails to load, but a named soname works - the loop must keep going.
+        calls = []
+        def cdll(name):
+            if name is None:
+                raise OSError("no global handle")
+            return _lib_with_trim(calls)
+        with mock.patch("ctypes.util.find_library", return_value=None), \
+             mock.patch("ctypes.CDLL", side_effect=cdll):
+            self.assertTrue(mm._malloc_trim())
+        self.assertEqual(calls, [0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Frees the parsed masters buffers as soon as extraction finishes, then returns the pages to the OS.

## What
- `FileTallySource.release()` drops the retained record elements (`_by_tag`) and the collection cache once extraction is done.
- `MasterMigrator.run()` calls `release()` + `gc.collect()` + `malloc_trim()` right after extraction, before the import pipeline.

## Why
On a large export the streamed record elements are the bulk of peak memory, and they are only read up front (masters, COA, bill allocations); the source is never touched again. Previously they sat resident through the entire import. `release()` frees the Python objects, but glibc keeps the freed pages in its arenas, so RSS stays pinned at the extraction high-water mark. `malloc_trim(0)` hands them back.

## Measured (Frappe Cloud, ~13k suppliers)
- `release()` alone reclaimed ~3 MB; the rest only came back at completion.
- With the trim: RSS drops ~400 MB immediately after extraction (~1467 -> ~1065 MB) and stays down for the whole import. No `memory_pressure` finding, all records created, no new errors.

## Safety
All three steps are best-effort and only change the memory footprint, never a run outcome: each degrades to a no-op on any failure. `malloc_trim` resolves libc via `CDLL(None)` so it works in a minimal container where `find_library("c")` returns None, and is a clean no-op on musl / macOS.

## Tests
`tally_migrator/tests/test_memory_reclaim.py` (7 tests) covers the resolver fallbacks and the never-raises contract; `release()` verified idempotent. No behavior change, so no docs affected.