### PR TITLE
Reliability: hang guard + auto-resume, trustworthy Step 3, faster party/account import

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ options in step 1:
   the link", then in the upload dialog choose **Link** and paste the link; the app
   downloads it server-side. A zipped XML on Drive works too.
 
+The uncompressed file is held to a **1 GB** limit by default (the same ceiling for a
+zip's contents and a Drive download). An administrator can raise it with the
+`tally_migrator_max_upload_mb` site-config setting, in megabytes.
+
 ---
 
 ## Installation

--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -225,9 +225,7 @@ but a Masters XML compresses by roughly 90%, so a big export has two easy routes
 
 - **Upload a zip.** Zip the `Master.xml` and choose the `.zip` - the app unpacks it
   automatically and reads the XML inside. The zip must contain exactly one `.xml`
-  file and must not be password-protected. (The uncompressed XML is still held to
-  the same size limit, so a zip cannot be used to slip an over-limit file past the
-  cap.)
+  file and must not be password-protected.
 - **Import from a Google Drive link.** In the upload dialog, choose the **Link**
   option and paste the share link to your file. In Drive, the file must be shared as
   **Anyone with the link** - otherwise Google returns a sign-in page instead of the
@@ -235,6 +233,12 @@ but a Masters XML compresses by roughly 90%, so a big export has two easy routes
   the server, so nothing has to pass through your browser. A zipped XML on Drive
   works the same way. Only Google Drive links are accepted; any other link is
   rejected.
+
+The uncompressed file is held to a size limit - **1 GB by default** - and the same
+ceiling applies to a plain upload, a zip's contents, and a Drive download, so a zip
+can never be used to slip an over-limit file past the cap. If your export is larger,
+an administrator can raise it with the `tally_migrator_max_upload_mb` site-config
+setting (the value is in megabytes, for example `2048` for 2 GB).
 
 This preview is your first and best check that you exported the right thing. Read
 the counts carefully.
@@ -301,7 +305,11 @@ right here, in place, without touching Tally.
 > _Screenshot placeholder: step 3 with the data-quality cards and an expanded issue group._
 
 The check has several parts. Any of them can appear; a clean file shows a simple
-**"Nothing to resolve"** message and you continue straight away.
+**"Nothing to resolve"** message and you continue straight away. For a large file the
+check runs in the background, showing **"Checking your file..."** while it works. If
+the check itself cannot finish (for example the file is too large to scan in time),
+it tells you so plainly and asks you to try again - it never shows a false
+all-clear, so an empty result is never mistaken for a clean file.
 
 #### Data-quality report
 

--- a/tally_migrator/api.py
+++ b/tally_migrator/api.py
@@ -421,7 +421,7 @@ _SOURCE_CACHE_MAX = 4
 # raise it, and a memory-constrained one can lower it, via site config
 # (``tally_migrator_max_upload_mb``). Note this also bounds the uncompressed size
 # of a zipped upload (the zip-bomb guard), so both paths share one ceiling.
-_DEFAULT_MAX_UPLOAD_MB = 512
+_DEFAULT_MAX_UPLOAD_MB = 1024
 
 # A run above this *upload size* is handed to a background job instead of blocking
 # the web request. We decide on the file's size (cheap metadata), not a record count,
@@ -822,19 +822,38 @@ def _download_drive_file(file_id: str) -> bytes:
     return raw
 
 
+def _configured_max_upload_mb() -> int:
+    """The configured single-import size ceiling in MB, coerced to a positive int.
+
+    ``tally_migrator_max_upload_mb`` can arrive as a *string* - ``bench set-config``
+    stores a bare value as JSON text unless ``-p`` is passed - so we coerce here.
+    Without this, ``max_mb * 1024 * 1024`` would build a giant string (``str * int``)
+    and the later ``size > ceiling`` comparison raises ``TypeError: '>' not supported
+    between instances of 'int' and 'str'``, turning a raised limit into a 500 on every
+    upload. A missing or non-numeric value falls back to the default rather than
+    failing the upload."""
+    raw = frappe.conf.get("tally_migrator_max_upload_mb")
+    if raw in (None, ""):
+        return _DEFAULT_MAX_UPLOAD_MB
+    try:
+        mb = int(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_UPLOAD_MB
+    return mb if mb > 0 else _DEFAULT_MAX_UPLOAD_MB
+
+
 def _max_upload_bytes() -> int:
     """The single-import size ceiling in bytes (site-config overridable).
 
     Applied to a raw upload, to a Drive download, and - as the zip-bomb guard -
     to the *uncompressed* size of a zipped XML, so every ingestion path is held
     to the same limit."""
-    max_mb = frappe.conf.get("tally_migrator_max_upload_mb") or _DEFAULT_MAX_UPLOAD_MB
-    return max_mb * 1024 * 1024
+    return _configured_max_upload_mb() * 1024 * 1024
 
 
 def _assert_within_size_limit(num_bytes: int) -> None:
     """Reject an oversized upload before parsing, with an actionable message."""
-    max_mb = frappe.conf.get("tally_migrator_max_upload_mb") or _DEFAULT_MAX_UPLOAD_MB
+    max_mb = _configured_max_upload_mb()
     if num_bytes > _max_upload_bytes():
         frappe.throw(
             frappe._(

--- a/tally_migrator/api.py
+++ b/tally_migrator/api.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import re
 import threading
@@ -99,6 +100,55 @@ def validate_masters_data(file_url: str, record_overrides: str = "", erpnext_com
     the same rules. The uploaded file itself is never modified.
     """
     frappe.only_for(ALLOWED_ROLES)
+    file_doc = _resolve_file_doc(file_url)
+    _assert_file_access(file_doc)
+    # Small file: compute inline (fast, no timeout risk). Any failure is reported
+    # honestly as 'failed' - the wizard blocks - never as a silent empty 'clean'.
+    if not _should_run_async(file_doc):
+        try:
+            return {"status": "ready", **_compute_preflight(
+                file_url, record_overrides, erpnext_company, posting_date)}
+        except Exception as exc:
+            frappe.log_error(f"preflight (inline) failed: {exc}", "Tally Migrator")
+            return {"status": "failed", "error": _preflight_error_message(exc)}
+
+    # Large file: the scan (parse + extract + validate + coverage + mapping) can exceed
+    # the web request timeout, so compute it once in a background job and cache the
+    # result in Redis (shared across workers, so a cold worker never re-parses). The
+    # wizard polls this endpoint until 'ready' or 'failed'.
+    key = _preflight_key(file_doc, record_overrides, erpnext_company, posting_date)
+    cached = frappe.cache().get_value(key)
+    if cached:
+        return cached
+    # Mark running first so concurrent polls don't each enqueue, then enqueue.
+    frappe.cache().set_value(key, {"status": "running"}, expires_in_sec=_PREFLIGHT_TTL)
+    frappe.enqueue(
+        "tally_migrator.api._run_preflight_job", queue="short", timeout=30 * 60,
+        key=key, file_url=file_url, record_overrides=record_overrides,
+        erpnext_company=erpnext_company, posting_date=posting_date)
+    return {"status": "running"}
+
+
+# Seconds a computed preflight result stays cached (keyed by file version + edits +
+# company + date + user), long enough to cover a wizard session's polling and review.
+_PREFLIGHT_TTL = 3600
+
+
+def _preflight_key(file_doc, record_overrides, erpnext_company, posting_date) -> str:
+    """Redis key for a preflight result, unique to the file version, the user's inline
+    edits, the target company/date, and the user - so an edit ('Re-check') or a new
+    upload never serves a stale result, and one user's scan can't leak to another."""
+    h = hashlib.sha1(
+        f"{file_doc.name}|{file_doc.modified}|{record_overrides}|{erpnext_company}"
+        f"|{posting_date}|{frappe.session.user}".encode()).hexdigest()
+    return f"tally_preflight:{h}"
+
+
+def _compute_preflight(file_url, record_overrides, erpnext_company, posting_date) -> dict:
+    """The full read-only pre-flight scan - data-quality + UOM + coverage + account
+    mapping + readiness - from a single parse. Writes nothing. Folding the UOM scan in
+    here means the wizard gets everything from one parse and one call (previously two
+    parallel calls, each re-parsing on a cold worker)."""
     overrides = json.loads(record_overrides) if record_overrides else {}
     _, source = _source_from_file(file_url)
     extractor = TallyExtractor(source)
@@ -113,7 +163,36 @@ def validate_masters_data(file_url: str, record_overrides: str = "", erpnext_com
     payload["account_mapping"] = account_mapping(source)
     if erpnext_company:
         payload["readiness"] = check_readiness(erpnext_company, posting_date)
+    items = source.get_collection("Stock Item", ITEM_FIELDS, ITEM_TAGS)
+    resolver = UomResolver(
+        u["name"] for u in frappe.get_all("UOM", fields=["name"], limit_page_length=0))
+    payload["uom_issues"] = resolver.issues_for(r.get("BaseUnits") for r in items)
+    payload["all_uoms"] = resolver.existing_sorted
     return payload
+
+
+def _run_preflight_job(key, file_url, record_overrides, erpnext_company, posting_date):
+    """Background worker: compute the pre-flight scan once and cache the result (or a
+    failure), so the polling wizard picks it up. Off the web request, so a large file's
+    scan can't time the request out."""
+    try:
+        payload = _compute_preflight(file_url, record_overrides, erpnext_company, posting_date)
+        frappe.cache().set_value(
+            key, {"status": "ready", **payload}, expires_in_sec=_PREFLIGHT_TTL)
+    except Exception as exc:
+        frappe.log_error(f"preflight job failed: {exc}", "Tally Migrator")
+        # Cache the failure (short TTL) so the wizard shows 'couldn't validate' instead
+        # of polling forever, and a retry can recompute soon.
+        frappe.cache().set_value(
+            key, {"status": "failed", "error": _preflight_error_message(exc)},
+            expires_in_sec=120)
+        raise
+
+
+def _preflight_error_message(exc) -> str:
+    """A short, user-facing reason the scan failed - no stack or internals."""
+    msg = str(exc).strip()
+    return msg[:200] if msg else "the file could not be read or validated"
 
 
 @frappe.whitelist(methods=["POST"])

--- a/tally_migrator/api.py
+++ b/tally_migrator/api.py
@@ -120,10 +120,15 @@ def validate_masters_data(file_url: str, record_overrides: str = "", erpnext_com
     cached = frappe.cache().get_value(key)
     if cached:
         return cached
-    # Mark running first so concurrent polls don't each enqueue, then enqueue.
+    # Mark running first so concurrent polls don't each enqueue, then enqueue. On the
+    # 'default' queue, not 'short': this parse can run for minutes on a large book (that
+    # is why it is async at all), and the short queue is meant for sub-second tasks -
+    # parking a long parse there would starve it. deduplicate + a key-derived job_id
+    # closes the small window where two near-simultaneous first polls could both enqueue.
     frappe.cache().set_value(key, {"status": "running"}, expires_in_sec=_PREFLIGHT_TTL)
     frappe.enqueue(
-        "tally_migrator.api._run_preflight_job", queue="short", timeout=30 * 60,
+        "tally_migrator.api._run_preflight_job", queue="default", timeout=30 * 60,
+        job_id=f"preflight::{key}", deduplicate=True,
         key=key, file_url=file_url, record_overrides=record_overrides,
         erpnext_company=erpnext_company, posting_date=posting_date)
     return {"status": "running"}

--- a/tally_migrator/erpnext/importers/accounts.py
+++ b/tally_migrator/erpnext/importers/accounts.py
@@ -100,7 +100,13 @@ class AccountImporter:
         structure (frappe's stock ``rebuild_tree``), replacing the per-insert
         renumbering deferred via ``ignore_update_nsm``. Idempotent, so it is safe on a
         re-run / resume. Non-fatal: a failure is recorded so a numbering problem is
-        visible rather than leaving a silently broken tree."""
+        visible rather than leaving a silently broken tree.
+
+        Note: ``rebuild_tree`` is site-wide - it renumbers Accounts for *every* company,
+        not only this run's. That is by design (we use the stock routine rather than fork
+        a company-scoped one): it only rewrites the opaque lft/rgt ordering numbers, the
+        tree *structure* is preserved, and it writes with ``update_modified=False`` so
+        other companies' rows are not otherwise touched."""
         try:
             from frappe.utils.nestedset import rebuild_tree
             rebuild_tree(self.doctype)

--- a/tally_migrator/erpnext/importers/accounts.py
+++ b/tally_migrator/erpnext/importers/accounts.py
@@ -64,15 +64,51 @@ class AccountImporter:
         # leave intact, so child parent-resolution can re-home them (order-independent).
         self._build_redirects(ordered, result)
         total = len(ordered)
-        for idx, node in enumerate(ordered, 1):
-            if on_progress:
-                on_progress(idx, total)
-            parent = self._resolve_parent(node)
-            if not parent:
-                result.add_error(node.name, "could not resolve a parent account")
-                continue
-            self._upsert(result, node, parent)
+        # Defer the nested-set (lft/rgt) maintenance that ERPNext's Account.on_update
+        # runs on EVERY insert - the "UPDATE tabAccount SET rgt=rgt+2 WHERE rgt>=x"
+        # shuffle that grows O(n^2) with the chart and dominated this phase on a real
+        # book (60% of the phase in SQL, 14,788 queries). Account.on_update honours
+        # frappe.local.flags.ignore_update_nsm (a first-class ERPNext hook - NOT a
+        # monkeypatch); with it set, each insert skips per-record tree renumbering and
+        # we rebuild the whole tree ONCE at the end in a single O(n) pass. The full
+        # Account.validate still runs on every insert (it reads the parent's is_group,
+        # never lft/rgt), so validation is unchanged - only the numbering is batched.
+        prior_nsm = frappe.local.flags.ignore_update_nsm
+        frappe.local.flags.ignore_update_nsm = True
+        try:
+            for idx, node in enumerate(ordered, 1):
+                if on_progress:
+                    on_progress(idx, total)
+                parent = self._resolve_parent(node)
+                if not parent:
+                    result.add_error(node.name, "could not resolve a parent account")
+                    continue
+                self._upsert(result, node, parent)
+        finally:
+            frappe.local.flags.ignore_update_nsm = prior_nsm
+            # Rebuild in finally so the committed accounts always end with a valid tree
+            # even if the loop raised or the per-record hang-guard killed the worker
+            # mid-phase: a resume re-enters run(), skips the existing accounts, and this
+            # rebuild still fires (self-healing). Only when the phase had accounts to
+            # place, so an empty/party-only run does no needless work.
+            if ordered:
+                self._rebuild_account_tree(result)
         return result
+
+    def _rebuild_account_tree(self, result: ImportResult) -> None:
+        """Recompute every Account's lft/rgt in one pass from the parent_account
+        structure (frappe's stock ``rebuild_tree``), replacing the per-insert
+        renumbering deferred via ``ignore_update_nsm``. Idempotent, so it is safe on a
+        re-run / resume. Non-fatal: a failure is recorded so a numbering problem is
+        visible rather than leaving a silently broken tree."""
+        try:
+            from frappe.utils.nestedset import rebuild_tree
+            rebuild_tree(self.doctype)
+            frappe.db.commit()
+        except Exception as exc:
+            frappe.db.rollback()
+            frappe.log_error("Tally Migrator", f"Account tree rebuild failed: {exc}")
+            result.add_error("(account tree rebuild)", exc)
 
     # ── Selection + ordering ─────────────────────────────────────────────────
     def _select(self, accounts: list) -> list:

--- a/tally_migrator/erpnext/importers/base.py
+++ b/tally_migrator/erpnext/importers/base.py
@@ -22,6 +22,7 @@ from tally_migrator.tally.mappings import (
     gst_category_from_type,
 )
 from tally_migrator.naming import safe_item_code, company_scoped
+from tally_migrator.migration import record_guard
 from tally_migrator.tally.extractors import TallyExtractor
 from tally_migrator.validation.engine import (
     infer_gst_category, validate_gstin, GSTIN_STATE_CODES,
@@ -179,16 +180,31 @@ class BaseImporter:
         total = len(records)
         pending = 0   # newly-written records not yet committed
         for done, record in enumerate(self.iter_records(records), 1):
-            name, created = self._upsert(result, self.build_doc(record))
-            # after_insert (e.g. address creation) must run ONLY for newly
-            # created records - otherwise a re-run duplicates side effects for
-            # records that were skipped because they already exist.
-            if name and created:
-                self.after_insert(name, record, result)
-                pending += 1
-                if pending >= self._COMMIT_BATCH_SIZE:
-                    frappe.db.commit()
-                    pending = 0
+            ident = self._record_ident(record)
+            # A record that hung twice before is left out so the migration can finish,
+            # rather than dying on it again. Recorded as a failure (not a silent drop)
+            # so the loss is visible and auditable (see record_guard / resume).
+            if record_guard.should_skip(self.doctype, ident):
+                result.add_error(
+                    ident, "left out because it repeatedly stalled the migration "
+                    "(timed out twice) - see the hang log; re-import this record on its own")
+                if on_progress:
+                    on_progress(done, total)
+                continue
+            # Time-box the whole record body (build + insert + side effects). On a hang
+            # the worker is dumped and killed; the batch commit below runs only after the
+            # guard is disarmed, so a commit is never interrupted.
+            with record_guard.guard(self.doctype, ident):
+                name, created = self._upsert(result, self.build_doc(record))
+                # after_insert (e.g. address creation) must run ONLY for newly
+                # created records - otherwise a re-run duplicates side effects for
+                # records that were skipped because they already exist.
+                if name and created:
+                    self.after_insert(name, record, result)
+                    pending += 1
+            if pending >= self._COMMIT_BATCH_SIZE:
+                frappe.db.commit()
+                pending = 0
             if on_progress:
                 on_progress(done, total)
         # Flush the final partial batch (and make every phase end on a clean commit,
@@ -367,6 +383,15 @@ class BaseImporter:
         failure, or ``None`` to record the failure as-is. The warning is logged only
         when the retry succeeds. Default: no recovery."""
         return None
+
+    # ── Hang-guard identity ────────────────────────────────────────────────────
+    def _record_ident(self, record: dict) -> str:
+        """A stable, human-readable identity for one source record - used by the hang
+        guard to mark the in-flight record and to recognise a confirmed-hung one on
+        resume. Stable across runs because it derives from the source data (re-parsed
+        identically), never from DB state. Overridable; defaults to the Tally ledger
+        name, which every masters record carries."""
+        return str(record.get("name") or record.get(self.key_field) or "")
 
     # ── Utilities ─────────────────────────────────────────────────────────────
     @staticmethod

--- a/tally_migrator/erpnext/importers/openings.py
+++ b/tally_migrator/erpnext/importers/openings.py
@@ -26,6 +26,7 @@ from tally_migrator.validation.engine import (
     infer_gst_category, validate_gstin, GSTIN_STATE_CODES,
 )
 from .base import BaseImporter, ImportResult
+from tally_migrator.migration import record_guard
 from .items import ItemImporter
 
 # ── Concurrency guard for opening entries ─────────────────────────────────────
@@ -477,7 +478,13 @@ class PartyOpeningImporter:
         if not parties:
             return
         key_field = self._PARTY_KEY_FIELD[party_type]
-        for record in parties:
+        # Time-box each party's opening so one party can't freeze the whole phase; a
+        # party that hung twice is left out (logged), the resume steps past it.
+        for record in record_guard.guarded_records(
+                f"Opening:{party_type}", parties, lambda r: r["_name"],
+                on_skip=lambda r, i: result.add_warning(
+                    i, "opening balance left out - this party repeatedly stalled the "
+                    "migration (timed out twice); see the hang log")):
             if tick:
                 tick()
             tally_name = record["_name"]

--- a/tally_migrator/erpnext/importers/openings.py
+++ b/tally_migrator/erpnext/importers/openings.py
@@ -480,6 +480,10 @@ class PartyOpeningImporter:
         key_field = self._PARTY_KEY_FIELD[party_type]
         # Time-box each party's opening so one party can't freeze the whole phase; a
         # party that hung twice is left out (logged), the resume steps past it.
+        # Unlike BaseImporter.run, this loop's per-party commit happens inside the guarded
+        # span, so a hang could in principle be killed mid-commit. That is safe: a
+        # MariaDB COMMIT is atomic (a killed client leaves it all-or-nothing) and the
+        # resume re-runs idempotently, so no partial opening is ever left behind.
         for record in record_guard.guarded_records(
                 f"Opening:{party_type}", parties, lambda r: r["_name"],
                 on_skip=lambda r, i: result.add_warning(

--- a/tally_migrator/erpnext/importers/party.py
+++ b/tally_migrator/erpnext/importers/party.py
@@ -23,6 +23,7 @@ from tally_migrator.tally.mappings import (
     ERPNEXT_ROOT_GROUPS,
     classify_group,
     gst_category_from_type,
+    normalize_country,
 )
 from tally_migrator.naming import safe_item_code, company_scoped
 from tally_migrator.tally.extractors import TallyExtractor
@@ -336,6 +337,64 @@ def _internal_supplier_scan_skipped():
         Supplier.validate_internal_supplier = original
 
 
+# ── Skip ERPNext's redundant Address→Customer primary-address sync ──────────────
+# ERPNext's ``ERPNextAddress.on_update`` (erpnext/accounts/custom/address.py) runs on
+# EVERY Address save and, to keep a customer's cached ``primary_address`` display in
+# step, does: render ``get_address_display`` (a per-call Jinja recompile), then
+# ``SELECT name FROM tabCustomer WHERE customer_primary_address = <this address>`` and
+# rewrite each match. On a real book that scan was the single costliest query of the
+# party phase (measured 2,511 calls / 3.4s), plus 2,511 wasted template recompiles.
+#
+# It is 100% redundant for the migrator: we create the Address first and only link it
+# as the party's primary AFTER insert, via ``frappe.db.set_value(..., update_modified
+# =False)`` (a direct write that fires no doc events) - so at every Address ``on_update``
+# NO customer yet references the address and the scan returns zero rows every time. And
+# we already compute and write the party's ``primary_address`` display ourselves in
+# ``_set_primary_links`` (byte-identical ``_address_display``). So suspending this sync
+# for the party phase changes no stored data - it only removes the empty scan and its
+# Jinja renders. Frappe's base ``Address`` defines no ``on_update`` (verified), so this
+# method's only behaviour is that sync; we still forward to any future base ``on_update``
+# via the MRO so we can never silently drop a stock behaviour ERPNext adds later.
+def _make_address_on_update_skip_primary(erpnext_address_cls):
+    """Drop-in for ``ERPNextAddress.on_update`` that runs any base ``on_update`` defined
+    ABOVE ERPNextAddress in the instance MRO (none in frappe core today - forward-safe)
+    and skips ERPNextAddress's own redundant customer-primary sync."""
+    def _on_update(self):
+        mro = type(self).__mro__
+        try:
+            start = mro.index(erpnext_address_cls) + 1
+        except ValueError:
+            start = len(mro)
+        for klass in mro[start:]:
+            base_fn = klass.__dict__.get("on_update")
+            if base_fn:
+                base_fn(self)
+                break
+    return _on_update
+
+
+@contextlib.contextmanager
+def _address_primary_sync_suspended():
+    """Skip ERPNext's redundant Address→Customer primary-address sync for the party
+    phase, then restore it. No-op-safe: if ERPNext (or the method) is absent, leave it
+    untouched and yield unchanged. Restored in ``finally``; process-local, serialised by
+    the single-active-run guard (same contract as the suspensions above)."""
+    try:
+        from erpnext.accounts.custom.address import ERPNextAddress
+    except Exception:
+        yield
+        return
+    original = getattr(ERPNextAddress, "on_update", None)
+    if original is None:
+        yield
+        return
+    ERPNextAddress.on_update = _make_address_on_update_skip_primary(ERPNextAddress)
+    try:
+        yield
+    finally:
+        ERPNextAddress.on_update = original
+
+
 # ── Party importers (Customer / Supplier) ──────────────────────────────────────
 
 class PartyImporter(BaseImporter):
@@ -361,10 +420,12 @@ class PartyImporter(BaseImporter):
         of the phase; see ``_gravatar_lookup_suspended`` /
         ``_party_side_effect_hooks_suspended`` / ``_link_title_lightweight``) - and with
         ERPNext's per-supplier internal-uniqueness scan skipped for external suppliers
-        (see ``_internal_supplier_scan_skipped``). Everything else is the standard
-        template."""
+        (see ``_internal_supplier_scan_skipped``), and ERPNext's redundant Address->Customer
+        primary-address sync suspended (see ``_address_primary_sync_suspended``). Everything
+        else is the standard template."""
         with _gravatar_lookup_suspended(), _party_side_effect_hooks_suspended(), \
-                _link_title_lightweight(), _internal_supplier_scan_skipped():
+                _link_title_lightweight(), _internal_supplier_scan_skipped(), \
+                _address_primary_sync_suspended():
             return super().run(records, on_progress=on_progress)
 
     def before_run(self, records: list[dict], result: "ImportResult") -> None:
@@ -538,7 +599,7 @@ class PartyImporter(BaseImporter):
                     if row_pin:
                         addr.pincode = row_pin
                     addr.state = self._extra_address_state(a, data)
-                    addr.country = (data.get("CountryName") or "").strip() or self.company_country
+                    addr.country = normalize_country(data.get("CountryName")) or self.company_country
                     addr.append("links", {"link_doctype": link_type, "link_name": link_name})
                     addr.insert(ignore_permissions=True)
             except Exception as exc:
@@ -684,7 +745,7 @@ class PartyImporter(BaseImporter):
         if not raw_address:
             return ""
         state = self._resolve_state(data)
-        country = (data.get("CountryName") or "").strip() or self.company_country
+        country = normalize_country(data.get("CountryName")) or self.company_country
         # India Compliance hard-requires a state on an Indian address. When Tally
         # gave us nothing to derive one from (no ledger state, valid GSTIN or PIN),
         # the insert is certain to fail - so skip it with a single warning rather

--- a/tally_migrator/hooks.py
+++ b/tally_migrator/hooks.py
@@ -13,3 +13,13 @@ required_apps = ["frappe", "erpnext"]
 # of truth). Page/DocType permissions reference it declaratively.
 
 after_install = "tally_migrator.install.after_install"
+
+# ── Scheduler ─────────────────────────────────────────────────────────────────
+# Auto-resume a run that a per-record hang hard-killed: the guard leaves an in-flight
+# marker, this sweep re-enqueues the run so it steps past the culprit. Idempotent and
+# capped (see resume.py / record_guard.py), so it is safe to run frequently.
+scheduler_events = {
+    "cron": {
+        "*/5 * * * *": ["tally_migrator.migration.resume.resume_stalled_runs"],
+    }
+}

--- a/tally_migrator/migration/master_migrator.py
+++ b/tally_migrator/migration/master_migrator.py
@@ -8,6 +8,7 @@ from tally_migrator.tally.config import TallyConfig
 from tally_migrator.tally.extractors import TallyExtractor, ExtractedMasters
 from tally_migrator.erpnext.importers import ERPNextImporter, ImportResult
 from tally_migrator.migration.overrides import apply_record_overrides, uom_edits
+from tally_migrator.migration import record_guard
 
 
 def _malloc_trim() -> bool:
@@ -276,6 +277,11 @@ class MasterMigrator:
         # Reuse a log handed in by the dispatcher (background runs); otherwise
         # create one now so an interrupted run is still recorded.
         self.log = self.log or self._create_log()
+        # Install the per-record hang guard for this run: it time-boxes every record
+        # across all phases, and skips any record that already hung twice (loaded from
+        # the log) so a resumed run steps past the culprit instead of dying on it again.
+        record_guard.activate(record_guard.RecordGuard(
+            self.log.name, confirmed=record_guard.confirmed_from_log(self.log)))
         try:
             import time as _time
             self._progress(0)
@@ -348,6 +354,14 @@ class MasterMigrator:
         except Exception as exc:
             self._fail_log(exc)
             raise
+        finally:
+            # Torn down on normal completion / normal error (clears the in-flight
+            # marker). NOT reached on a hang - the worker is hard-killed, so the marker
+            # survives for the resume sweep. Best-effort: never mask the real outcome.
+            try:
+                record_guard.deactivate()
+            except Exception:
+                pass
 
     def _pipeline(self, masters: ExtractedMasters, coa, bills) -> list[PipelineStep]:
         """Entity import order. Adding an entity = add one step here.

--- a/tally_migrator/migration/record_guard.py
+++ b/tally_migrator/migration/record_guard.py
@@ -29,6 +29,7 @@ Design constraints this module respects
 import contextlib
 import faulthandler
 import os
+import time
 
 import frappe
 
@@ -67,11 +68,18 @@ def _marker_key(log_name: str) -> str:
 
 
 def set_inflight(log_name: str, phase: str, ident: str) -> None:
-    """Record 'this run is now processing (phase, ident)'. Best-effort: a marker
-    failure must never disturb the import."""
+    """Record 'this run is now processing (phase, ident)' with a wall-clock timestamp.
+    Best-effort: a marker failure must never disturb the import.
+
+    The ``ts`` lets the resume sweep tell a genuinely-dead worker apart from a live one
+    even when RQ can't (a no-fork worker hard-killed by the guard leaves its job stuck
+    'started'): a live worker rewrites this marker every record, so a marker older than
+    the per-record timeout means the record has been stuck past the point the guard
+    would have killed it - i.e. the worker is gone. See ``resume._marker_stale``."""
     try:
         frappe.cache().set_value(
-            _marker_key(log_name), {"phase": phase, "ident": ident}, expires_in_sec=86400)
+            _marker_key(log_name), {"phase": phase, "ident": ident, "ts": time.time()},
+            expires_in_sec=86400)
     except Exception:
         pass
 
@@ -127,10 +135,19 @@ class RecordGuard:
 
     def close(self):
         if self._dump_file is not None:
+            path = getattr(self._dump_file, "name", None)
             try:
                 self._dump_file.close()
             finally:
                 self._dump_file = None
+            # A clean run never wrote to the dump file (a hang would have hard-killed the
+            # worker before reaching here). Remove the empty file so successful runs don't
+            # litter the hangs directory; keep it if anything was actually dumped.
+            try:
+                if path and os.path.exists(path) and os.path.getsize(path) == 0:
+                    os.remove(path)
+            except Exception:
+                pass
 
     def should_skip(self, phase: str, ident: str) -> bool:
         return (phase, ident) in self.confirmed
@@ -201,6 +218,24 @@ def note_stall(log, phase: str, ident: str) -> tuple[int, int]:
     st["resume_count"] = int(st.get("resume_count") or 0) + 1
     log.db_set(_STATE_FIELD, frappe.as_json(st), update_modified=False)
     return entry["attempts"], st["resume_count"]
+
+
+def unnote_stall(log, phase: str, ident: str) -> None:
+    """Undo the last ``note_stall`` for this record: decrement its hang count and the
+    overall resume count (dropping the record entirely when its count hits zero). Used
+    when a re-enqueue fails AFTER the stall was recorded, so a later retry does not
+    double-count one real hang toward the confirmed-skip threshold."""
+    st = _read_state(log)
+    k = _state_key(phase, ident)
+    entry = st["hung"].get(k)
+    if entry:
+        entry["attempts"] = max(0, int(entry.get("attempts") or 0) - 1)
+        if entry["attempts"] == 0:
+            st["hung"].pop(k, None)
+        else:
+            st["hung"][k] = entry
+    st["resume_count"] = max(0, int(st.get("resume_count") or 0) - 1)
+    log.db_set(_STATE_FIELD, frappe.as_json(st), update_modified=False)
 
 
 def current() -> RecordGuard | None:

--- a/tally_migrator/migration/record_guard.py
+++ b/tally_migrator/migration/record_guard.py
@@ -1,0 +1,259 @@
+"""Generic per-record hang guard - no single record can freeze a whole migration.
+
+Why a process-kill and not an in-process interrupt
+---------------------------------------------------
+A record can hang inside C-level code (a C library call, a regex) that holds the GIL
+and never returns. Python signal handlers and thread-based interrupts CANNOT preempt
+that - verified empirically: SIGALRM does not interrupt a running query and cannot
+break a GIL-holding C loop. The only thing that can act while the GIL is held is
+``faulthandler``'s C-level watchdog: even mid-hang it dumps every thread's stack (so
+we learn *where* it hung) and hard-exits the worker.
+
+Recovery is by resume, not by in-process skip (impossible for a C-level hang):
+the scheduler sweep (see ``resume_stalled_runs``) re-enqueues the run; the import is
+idempotent so already-committed records are skipped, and a *confirmed* repeatedly-
+hanging record is skipped from its recorded identity. A record is only skipped after
+it hangs **twice** (retry-once), so a one-off slow record is never dropped - protecting
+data completeness.
+
+Design constraints this module respects
+---------------------------------------
+- **Leaf module**: imports only stdlib + frappe, so both ``BaseImporter`` and the
+  openings importers can use it with no import cycle.
+- **Transparent when inactive**: with no active run guard (unit tests, direct importer
+  calls) every entry point is a no-op, so existing behaviour is unchanged.
+- **The in-flight marker is written *before* each record** (in Redis, which survives
+  the hard kill), because at kill time the GIL is held and no Python - not even the
+  marker write - can run. Resume reads that marker to learn the culprit.
+"""
+import contextlib
+import faulthandler
+import os
+
+import frappe
+
+# ── Configuration (site_config, with safe defaults) ─────────────────────────────
+_DEFAULT_TIMEOUT_S = 60
+_DEFAULT_MAX_RESUMES = 50
+
+
+def record_timeout_s() -> int:
+    """Seconds any one record may take before the worker is dumped + killed. Generous
+    by design: legitimate records take milliseconds, so only a genuine hang trips it,
+    and a false trip would cost a skipped record (a data-completeness loss), so we bias
+    high. Override with ``tally_migrator_record_timeout`` in site_config."""
+    try:
+        v = int(frappe.conf.get("tally_migrator_record_timeout") or _DEFAULT_TIMEOUT_S)
+        return v if v > 0 else _DEFAULT_TIMEOUT_S
+    except Exception:
+        return _DEFAULT_TIMEOUT_S
+
+
+def max_resumes() -> int:
+    """Hard cap on auto-resumes for one run, so a bug can never loop forever. Each
+    confirmed hang costs ~2 resumes (retry-once), so the default tolerates ~25 distinct
+    hanging records before halting for manual attention. Override with
+    ``tally_migrator_max_resumes``."""
+    try:
+        v = int(frappe.conf.get("tally_migrator_max_resumes") or _DEFAULT_MAX_RESUMES)
+        return v if v > 0 else _DEFAULT_MAX_RESUMES
+    except Exception:
+        return _DEFAULT_MAX_RESUMES
+
+
+# ── Redis in-flight marker (survives the hard kill) ─────────────────────────────
+def _marker_key(log_name: str) -> str:
+    return f"tally_inflight:{log_name}"
+
+
+def set_inflight(log_name: str, phase: str, ident: str) -> None:
+    """Record 'this run is now processing (phase, ident)'. Best-effort: a marker
+    failure must never disturb the import."""
+    try:
+        frappe.cache().set_value(
+            _marker_key(log_name), {"phase": phase, "ident": ident}, expires_in_sec=86400)
+    except Exception:
+        pass
+
+
+def read_inflight(log_name: str) -> dict | None:
+    try:
+        return frappe.cache().get_value(_marker_key(log_name)) or None
+    except Exception:
+        return None
+
+
+def clear_inflight(log_name: str) -> None:
+    try:
+        frappe.cache().delete_value(_marker_key(log_name))
+    except Exception:
+        pass
+
+
+def hang_dump_path(log_name: str) -> str:
+    """Where faulthandler writes a hang's all-thread stack for this run - on the shared
+    site filesystem, so the resume worker can read it after the kill."""
+    return os.path.join(frappe.get_site_path("tally_migrator_hangs"), f"{log_name}.log")
+
+
+# ── Active run guard (module-global; migrations are serialised) ──────────────────
+class RecordGuard:
+    """Per-run guard state: the open dump file, the timeout, and the set of records
+    already *confirmed* hung (skip on sight). Created once per run by MasterMigrator
+    and installed with ``activate`` so importers reach it without wiring it through
+    every constructor. Only one migration runs at a time (single-active-run guard), so
+    a module-global is safe and can never bleed across runs."""
+
+    def __init__(self, log_name: str, confirmed: set[tuple[str, str]] | None = None,
+                 timeout_s: int | None = None):
+        self.log_name = log_name
+        self.timeout_s = timeout_s if timeout_s is not None else record_timeout_s()
+        # {(phase, ident)} that hung twice - skip these outright.
+        self.confirmed = confirmed or set()
+        self._dump_file = None
+        self._armed = False   # re-entrancy guard: faulthandler has one global timer
+
+    # -- dump file (opened lazily, kept open for the run) --
+    def _dump_path(self) -> str:
+        os.makedirs(frappe.get_site_path("tally_migrator_hangs"), exist_ok=True)
+        return hang_dump_path(self.log_name)
+
+    def _ensure_dump_file(self):
+        if self._dump_file is None:
+            # Line-buffered append so a dump is on disk before the hard _exit, and
+            # readable by the resume worker (shared site filesystem).
+            self._dump_file = open(self._dump_path(), "a", buffering=1)
+        return self._dump_file
+
+    def close(self):
+        if self._dump_file is not None:
+            try:
+                self._dump_file.close()
+            finally:
+                self._dump_file = None
+
+    def should_skip(self, phase: str, ident: str) -> bool:
+        return (phase, ident) in self.confirmed
+
+
+_active: RecordGuard | None = None
+
+
+def activate(guard: RecordGuard) -> None:
+    global _active
+    _active = guard
+
+
+def deactivate() -> None:
+    """Tear down the run guard on normal completion or a normal exception. Clears the
+    in-flight marker so a finished run is never mistaken for a stalled one. NOT reached
+    on a hang (the worker is hard-killed) - which is exactly why the marker then survives
+    for the resume sweep to find."""
+    global _active
+    if _active is not None:
+        clear_inflight(_active.log_name)
+        _active.close()
+    _active = None
+
+
+# ── Persisted guard state on the log (hung records + resume count) ───────────────
+# One hidden Code field, ``guard_state``, holds the whole picture so a stalled record
+# and the resume count survive across the kill/resume cycle and stay auditable.
+_STATE_FIELD = "guard_state"
+
+
+def _state_key(phase: str, ident: str) -> str:
+    return f"{phase}\x1f{ident}"
+
+
+def _read_state(log) -> dict:
+    raw = log.get(_STATE_FIELD)
+    if not raw:
+        return {"hung": {}, "resume_count": 0}
+    try:
+        d = frappe.parse_json(raw)
+        return {"hung": dict(d.get("hung") or {}),
+                "resume_count": int(d.get("resume_count") or 0)}
+    except Exception:
+        return {"hung": {}, "resume_count": 0}
+
+
+def confirmed_from_log(log) -> set:
+    """The set of ``(phase, ident)`` that have hung twice - skip these on sight. A
+    record must stall TWICE before it is skipped (retry-once), so a one-off slow record
+    is never dropped."""
+    st = _read_state(log)
+    return {
+        (v.get("phase"), v.get("ident"))
+        for v in st["hung"].values() if int(v.get("attempts") or 0) >= 2
+    }
+
+
+def note_stall(log, phase: str, ident: str) -> tuple[int, int]:
+    """Resume bookkeeping for a killed run, in one write: bump this record's hang count
+    (1 = suspect/retry, >=2 = confirmed/skip) and the overall resume count. Returns
+    ``(attempts_for_record, total_resume_count)``."""
+    st = _read_state(log)
+    k = _state_key(phase, ident)
+    entry = st["hung"].get(k) or {"phase": phase, "ident": ident, "attempts": 0}
+    entry["attempts"] = int(entry.get("attempts") or 0) + 1
+    st["hung"][k] = entry
+    st["resume_count"] = int(st.get("resume_count") or 0) + 1
+    log.db_set(_STATE_FIELD, frappe.as_json(st), update_modified=False)
+    return entry["attempts"], st["resume_count"]
+
+
+def current() -> RecordGuard | None:
+    return _active
+
+
+def should_skip(phase: str, ident: str) -> bool:
+    """True when this record is confirmed-hung and must be skipped. No-op (False) when
+    no run guard is active, so direct/test callers are unaffected."""
+    g = _active
+    return bool(g and g.should_skip(phase, ident))
+
+
+@contextlib.contextmanager
+def guard(phase: str, ident: str):
+    """Time-box one record. On overrun, faulthandler dumps every thread's stack to the
+    run's hang log and hard-exits the worker; resume takes it from there.
+
+    No-op when no run guard is active, or when already armed (re-entrancy: faulthandler
+    has a single global timer, so a nested guard must not clobber the outer deadline).
+    """
+    g = _active
+    if g is None or g._armed:
+        yield
+        return
+    # Mark the in-flight record (Redis, survives the hard kill) so resume learns the
+    # culprit. Deliberately no per-record write to the dump file: a clean run would
+    # spew a line per record for nothing; the file gets content only when a hang fires.
+    set_inflight(g.log_name, phase, str(ident))
+    f = g._ensure_dump_file()
+    faulthandler.dump_traceback_later(g.timeout_s, file=f, exit=True)
+    g._armed = True
+    try:
+        yield
+    finally:
+        faulthandler.cancel_dump_traceback_later()
+        g._armed = False
+
+
+def guarded_records(phase: str, records, ident_fn, on_skip=None):
+    """Time-box each record of an importer that does NOT go through ``BaseImporter.run``
+    (the openings loops), WITHOUT re-indenting its loop body.
+
+    Because the guard is armed here and released when the caller asks for the next item,
+    the ``with guard`` spans the caller's loop body (the generator is suspended at
+    ``yield`` inside it). A confirmed-hung record is never yielded - so it cannot hang
+    again - and ``on_skip(record, ident)`` fires so the caller can log the omission.
+    ``break``/exceptions in the caller close the generator, which disarms cleanly."""
+    for r in records:
+        ident = str(ident_fn(r))
+        if should_skip(phase, ident):
+            if on_skip:
+                on_skip(r, ident)
+            continue
+        with guard(phase, ident):
+            yield r

--- a/tally_migrator/migration/resume.py
+++ b/tally_migrator/migration/resume.py
@@ -1,0 +1,128 @@
+"""Auto-resume of a migration a per-record hang killed.
+
+When the hang guard (see ``record_guard``) dumps + hard-kills the worker, the run is
+left ``Running`` with an in-flight marker in Redis naming the record it died on. This
+scheduler sweep notices such a run, records the stall (retry-once, then confirm), and
+re-enqueues it so it can continue: the import is idempotent, so already-committed
+records are skipped, and a *confirmed*-hung record is skipped outright - the run steps
+past the culprit and finishes, ending "Completed with Errors" with the skipped records
+visible in the log.
+
+A hard ``max_resumes`` cap makes a runaway impossible: past the cap the run is failed
+for manual attention instead of resuming forever.
+"""
+import frappe
+
+from tally_migrator.migration import record_guard
+
+
+def resume_stalled_runs() -> None:
+    """Scheduler entry point. Re-enqueue any run a per-record hang killed. Best-effort
+    and defensive: one bad row must never break the sweep for the others."""
+    try:
+        rows = frappe.get_all(
+            "Tally Migration Log",
+            filters={"status": "Running"},
+            fields=["name", "job_id", "company"],
+        )
+    except Exception:
+        return
+    for row in rows:
+        try:
+            _maybe_resume(row)
+        except Exception as exc:
+            frappe.log_error(
+                f"resume_stalled_runs failed for {row.get('name')}: {exc}", "Tally Migrator")
+
+
+def _job_alive(job_id: str) -> bool:
+    # Reuse the same liveness rule the start-guard uses, so "is this run still alive"
+    # is judged identically everywhere.
+    from tally_migrator.api import _is_job_alive
+    return bool(job_id) and _is_job_alive(job_id)
+
+
+def _maybe_resume(row) -> None:
+    # Only act on a run whose worker is genuinely gone.
+    if _job_alive(row.get("job_id")):
+        return
+    marker = record_guard.read_inflight(row["name"])
+    if not marker:
+        # Died, but not inside a guarded record (e.g. OOM/redeploy between records).
+        # Not this mechanism's job - leave it to the existing manual re-run.
+        return
+    phase = marker.get("phase") or ""
+    ident = marker.get("ident") or ""
+
+    log = frappe.get_doc("Tally Migration Log", row["name"])
+    if not log.get("source_file"):
+        # Can't re-run without the source; stop trying and surface it.
+        record_guard.clear_inflight(log.name)
+        _fail(log, "a record stalled the migration but the source file is no longer "
+                   "stored, so it can't be resumed automatically - re-upload and re-run")
+        return
+
+    attempts, resume_count = record_guard.note_stall(log, phase, ident)
+    if resume_count > record_guard.max_resumes():
+        record_guard.clear_inflight(log.name)
+        _fail(log, f"stopped after {resume_count - 1} automatic resumes (limit reached) - "
+                   f"the migration keeps stalling; needs manual attention")
+        frappe.db.commit()
+        return
+
+    # Note the stall on the log itself (the healthy resume process can write to the DB),
+    # pointing at the captured all-thread stack, so the evidence is linked and auditable.
+    verb = ("left out from here on" if attempts >= 2
+            else "will be retried once before being skipped")
+    _append_error(
+        log, f"Run stalled on {phase} / {ident} (attempt {attempts}); {verb}. "
+             f"Full stack captured at {record_guard.hang_dump_path(log.name)}")
+
+    # Clear the marker BEFORE re-enqueuing so the resumed run starts clean; the new job
+    # writes its own marker as it processes.
+    record_guard.clear_inflight(log.name)
+    frappe.db.commit()
+    _reenqueue(log)
+    frappe.logger().info(
+        f"[Tally Migrator] resumed {log.name}: {phase}/{ident} attempts={attempts} "
+        f"resume={resume_count}")
+
+
+def _reenqueue(log) -> None:
+    """Re-enqueue the SAME log (preserving its guard_state) as a background job,
+    reusing _run_masters_job - which re-parses the source and runs into this log."""
+    job_id = log.get("job_id") or f"tally-masters-{log.name}"
+    log.db_set("job_id", job_id, update_modified=False)
+    frappe.enqueue(
+        "tally_migrator.api._run_masters_job",
+        queue="long",
+        timeout=4 * 60 * 60,
+        job_id=job_id,
+        file_url=log.source_file,
+        erpnext_company=log.company,
+        uom_overrides=log.get("uom_overrides") or "",
+        validation_report=log.get("validation_report") or "",
+        record_overrides=log.get("record_overrides") or "",
+        coa_mode=log.get("coa_mode") or "reuse",
+        posting_date=str(log.get("posting_date") or ""),
+        log_name=log.name,
+        created_uoms="",
+    )
+
+
+def _append_error(log, line: str) -> None:
+    """Append a line to the log's plain-text error_log, so a stall and its captured
+    stack are visible in the migration log itself."""
+    try:
+        existing = log.get("error_log") or ""
+        log.db_set("error_log", (existing + "\n" + line).strip(), update_modified=False)
+    except Exception:
+        pass
+
+
+def _fail(log, reason: str) -> None:
+    frappe.log_error(f"{log.name}: {reason}", "Tally Migrator")
+    try:
+        log.db_set("status", "Failed", commit=True)
+    except Exception:
+        pass

--- a/tally_migrator/migration/resume.py
+++ b/tally_migrator/migration/resume.py
@@ -11,9 +11,18 @@ visible in the log.
 A hard ``max_resumes`` cap makes a runaway impossible: past the cap the run is failed
 for manual attention instead of resuming forever.
 """
+import time
+
 import frappe
 
 from tally_migrator.migration import record_guard
+
+# Grace beyond the per-record timeout before a stuck in-flight marker is treated as a
+# dead worker. A live worker rewrites the marker every record and the guard kills any
+# record that exceeds the timeout, so a marker older than timeout + grace cannot belong
+# to a healthy run - it means the worker is gone (covers no-fork workers, where a
+# hard-killed worker leaves its RQ job stuck 'started' so job-liveness can't see death).
+_RESUME_GRACE_S = 120
 
 
 def resume_stalled_runs() -> None:
@@ -42,14 +51,32 @@ def _job_alive(job_id: str) -> bool:
     return bool(job_id) and _is_job_alive(job_id)
 
 
+def _marker_stale(marker) -> bool:
+    """True when the in-flight record has been marked longer than one record could
+    legitimately take (timeout + grace). A live worker rewrites the marker every record
+    and the guard kills any record that overruns the timeout, so a marker this old means
+    the worker is gone even if RQ still reports its job 'started' (no-fork case). A
+    legacy marker without a timestamp returns False, so we fall back to job-liveness."""
+    ts = marker.get("ts")
+    if not ts:
+        return False
+    return (time.time() - ts) > (record_guard.record_timeout_s() + _RESUME_GRACE_S)
+
+
 def _maybe_resume(row) -> None:
-    # Only act on a run whose worker is genuinely gone.
-    if _job_alive(row.get("job_id")):
-        return
     marker = record_guard.read_inflight(row["name"])
     if not marker:
-        # Died, but not inside a guarded record (e.g. OOM/redeploy between records).
-        # Not this mechanism's job - leave it to the existing manual re-run.
+        # Died, but not inside a guarded record (e.g. OOM/redeploy between records, or
+        # during the pre-record parse). Not this mechanism's job - leave it to the
+        # existing manual re-run.
+        return
+    # Resume when the worker is genuinely gone (fork workers: RQ marks the job failed
+    # promptly, so it is not alive) OR when the in-flight record has been stuck past the
+    # guard's own deadline (covers no-fork workers, where a hard-killed worker leaves its
+    # RQ job stuck 'started'). A live, healthy worker can never hold a marker older than
+    # the per-record timeout - the guard would have killed that record - so this can
+    # never re-enqueue a run that is still working.
+    if _job_alive(row.get("job_id")) and not _marker_stale(marker):
         return
     phase = marker.get("phase") or ""
     ident = marker.get("ident") or ""
@@ -82,7 +109,17 @@ def _maybe_resume(row) -> None:
     # writes its own marker as it processes.
     record_guard.clear_inflight(log.name)
     frappe.db.commit()
-    _reenqueue(log)
+    try:
+        _reenqueue(log)
+    except Exception:
+        # Re-enqueue failed (e.g. the queue is full) after we cleared the marker and
+        # recorded the stall. Restore both so a later sweep retries instead of leaving
+        # the run orphaned in 'Running' with no marker, and so this one real hang is not
+        # double-counted toward the confirmed-skip threshold on the retry.
+        record_guard.unnote_stall(log, phase, ident)
+        record_guard.set_inflight(log.name, phase, ident)
+        frappe.db.commit()
+        raise
     frappe.logger().info(
         f"[Tally Migrator] resumed {log.name}: {phase}/{ident} attempts={attempts} "
         f"resume={resume_count}")

--- a/tally_migrator/tally/mappings.py
+++ b/tally_migrator/tally/mappings.py
@@ -121,6 +121,44 @@ DEFAULT_TERRITORY      = "All Territories"
 DEFAULT_WAREHOUSE      = "All Warehouses"
 
 
+# ── Country name aliases: Tally free-text → canonical ERPNext Country ─────────
+# ERPNext's Address.country is a Link to the Country doctype, so a value whose
+# name is not a Country row (e.g. Tally's "UAE") fails link validation and loses
+# the WHOLE address. Tally writes the country as free text, and books commonly
+# use a handful of unambiguous abbreviations. Map ONLY those - each maps to a
+# name that ships on every ERPNext install (the standard Country fixtures) - and
+# pass everything else through unchanged, so a value that is already a real
+# country name (the overwhelming majority) is never altered. Deliberately
+# conservative: only aliases with a single unambiguous target, to avoid ever
+# mapping to the wrong country. Keyed by a normalised (lower, no dots) form.
+# Keyed by the value with dots and whitespace removed and lower-cased, so all of
+# "UAE", "U.A.E.", "u.a.e" collapse to the same "uae". Safe because no real
+# multi-word country name collapses to one of these short keys (e.g. "United
+# States" -> "unitedstates", which is not a key, so it passes through unchanged).
+COUNTRY_ALIASES: dict[str, str] = {
+    "uae": "United Arab Emirates",
+    "usa": "United States",
+    "us":  "United States",
+    "uk":  "United Kingdom",
+}
+
+_COUNTRY_KEY = re.compile(r"[.\s]+")
+
+
+def normalize_country(name: str) -> str:
+    """Canonical ERPNext Country name for a Tally country value.
+
+    Returns the mapped name for a known unambiguous alias (case/dot/space
+    insensitive), else the original value trimmed - so a real country name passes
+    through byte-for-byte and only a recognised abbreviation is rewritten. Blank
+    stays blank (callers fall back to the company country)."""
+    raw = (name or "").strip()
+    if not raw:
+        return ""
+    key = _COUNTRY_KEY.sub("", raw.lower())
+    return COUNTRY_ALIASES.get(key, raw)
+
+
 # ── Chart of Accounts: Tally group → ERPNext account classification ───────────
 #
 # Tally ships ~28 reserved "primary" groups whose meaning is fixed. Every other

--- a/tally_migrator/tally_migration/doctype/tally_migration_log/tally_migration_log.json
+++ b/tally_migrator/tally_migration/doctype/tally_migration_log/tally_migration_log.json
@@ -282,6 +282,14 @@
    "fieldtype": "Long Text",
    "label": "Error Log (plain text)",
    "read_only": 1
+  },
+  {
+   "fieldname": "guard_state",
+   "fieldtype": "Code",
+   "label": "Hang Guard State (JSON)",
+   "hidden": 1,
+   "read_only": 1,
+   "description": "Internal: records that stalled the run (retry-once then skip) and the auto-resume count."
   }
  ],
  "permissions": [

--- a/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
+++ b/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
@@ -165,6 +165,10 @@ class TallyMigratorPage {
 						${TallyMigratorPage.callout("success", TallyMigratorPage.iconRow("success", `<strong>Nothing to resolve.</strong> We found no data-quality issues (GST numbers, states, units, HSN codes) that need your input before importing.`))}
 					</div>
 
+					<!-- Honest failure state: the check could not complete. NEVER shown as
+					     clean; Continue stays blocked until a successful re-check. -->
+					<div id="check-failed" class="tm-section" style="display:none;"></div>
+
 					<!-- Data-quality report (read-only; informational + consent) -->
 					<div id="dq-section" class="tm-section" style="display:none;">
 						<div id="dq-cards" class="tm-stats" style="margin-bottom:var(--margin-sm);"></div>
@@ -811,6 +815,7 @@ class TallyMigratorPage {
 		this.uomIssues = [];
 		this.allUoms = [];
 		this.qualityReport = null;
+		this.qualityError = null;
 		this.coverageReport = null;
 		this.accountMapping = null;
 		this.readiness = null;
@@ -818,6 +823,7 @@ class TallyMigratorPage {
 
 		$("#check-loading").show();
 		$("#check-clean").hide();
+		$("#check-failed").hide();
 		$("#check-issues").hide();
 		$("#dq-section").hide();
 		$("#readiness-section").hide();
@@ -830,78 +836,110 @@ class TallyMigratorPage {
 		this._checkLoading = true;
 		this._updateCheckContinue();
 
-		// Two independent read-only scans run in parallel: data-quality (GST / HSN /
-		// duplicates / collisions) and UOM resolution. Render once both return.
-		let pending = 2;
-		const done = () => {
-			if (--pending > 0) return;
-			$("#check-loading").hide();
-			this._checkLoading = false;
-			this._updateCheckContinue();
-			const noUom = !this.uomIssues.length;
-			const noDq = !this.qualityReport || this.qualityReport.clean;
-			if (noUom && noDq) {
-				$("#check-clean").show();
-			}
-			// When resuming a draft that was past the Check step, advance to the saved
-			// step now that the scans (and account mapping) have loaded. Readiness
-			// blockers still gate Migrate, exactly as a forward walk would.
-			if (this._resumeStep) {
-				const step = this._resumeStep;
-				this._resumeStep = null;
-				if (step === "section-review" && this.hasAccounts()) {
-					// Render the preview from the now-loaded account mapping before
-					// showing it - mirrors gotoReviewOrRun(); without this the Review
-					// section shows blank on resume.
-					this.renderAccountMapping();
-					this.show("section-review");
-				} else if (step === "section-run") {
-					this.gotoRun();
-				}
-			}
-		};
+		// One background-safe pre-flight scan (data-quality + UOM + coverage + mapping +
+		// readiness) from a single parse. It returns a status: 'running' (still computing
+		// in the background - we poll), 'ready' (render the real result), or 'failed' (we
+		// show "couldn't validate" and BLOCK Continue - never a false "all clear").
+		this._preflightPoll = 0;
+		this._pollPreflight();
+	}
 
+	_preflightArgs() {
+		return {
+			file_url: this.fileUrl,
+			erpnext_company: this.getCompany(),
+			// Apply the user's saved inline fixes (e.g. a resumed draft) so the scan
+			// reflects them on first load - mirrors recheck()'s args.
+			record_overrides: JSON.stringify(this.recordOverrides || {}),
+			posting_date: this.getDate(),
+		};
+	}
+
+	_pollPreflight() {
 		frappe.call({
 			method: "tally_migrator.api.validate_masters_data",
-			args: {
-				file_url: this.fileUrl,
-				erpnext_company: this.getCompany(),
-				// Apply the user's saved inline fixes (e.g. a resumed draft) so the
-				// scan reflects them on first load - otherwise edits stay invisible
-				// until the user manually clicks Re-check. Mirrors recheck()'s args.
-				record_overrides: JSON.stringify(this.recordOverrides || {}),
-				posting_date: this.getDate(),
-			},
-			callback: (r) => {
-				this.qualityReport = r.message || null;
-				this.states = (r.message && r.message.states) || [];
-				this.coverageReport = (r.message && r.message.coverage) || null;
-				this.accountMapping = (r.message && r.message.account_mapping) || null;
-				this.readiness = (r.message && r.message.readiness) || null;
-				this.renderDataQuality();
-				this.renderReadiness();
-				this.renderCoverage();
-				done();
-			},
-			error: () => done(),  // non-fatal - importer still reports failures later
+			args: this._preflightArgs(),
+			callback: (r) => this._onPreflight(r.message || {}),
+			// A transport/500 error IS a failed validation - surface it honestly,
+			// never fall through to "no issues".
+			error: () => this._onPreflightFailed(
+				__("We couldn't reach the server to validate your file.")),
 		});
+	}
 
-		frappe.call({
-			method: "tally_migrator.api.validate_masters_file",
-			args: { file_url: this.fileUrl },
-			callback: (r) => {
-				const data = r.message || {};
-				const issues = (data.issues || []).filter((i) => !i.exists);
-				this.uomIssues = issues;
-				this.allUoms = data.all_uoms || [];
-				if (issues.length) {
-					$("#check-issues").show();
-					this.renderUomIssues();
-				}
-				done();
-			},
-			error: () => done(),
+	_onPreflight(m) {
+		if (m.status === "running") {
+			// Still computing - poll again, with a ceiling so a stuck scan surfaces as
+			// "couldn't validate" rather than spinning forever.
+			if (++this._preflightPoll > 150) {   // ~5 min at 2s
+				return this._onPreflightFailed(
+					__("Validating your file is taking longer than expected."));
+			}
+			return setTimeout(() => this._pollPreflight(), 2000);
+		}
+		if (m.status === "failed") {
+			return this._onPreflightFailed(m.error || __("The file could not be validated."));
+		}
+		// status === "ready": a genuine, complete result.
+		this._checkLoading = false;
+		this.qualityError = null;
+		this.qualityReport = m;
+		this.states = m.states || [];
+		this.coverageReport = m.coverage || null;
+		this.accountMapping = m.account_mapping || null;
+		this.readiness = m.readiness || null;
+		this.uomIssues = (m.uom_issues || []).filter((i) => !i.exists);
+		this.allUoms = m.all_uoms || [];
+
+		$("#check-loading").hide();
+		$("#check-failed").hide();
+		this.renderDataQuality();
+		this.renderReadiness();
+		this.renderCoverage();
+		if (this.uomIssues.length) {
+			$("#check-issues").show();
+			this.renderUomIssues();
+		}
+		// Clean ONLY when we have a real report that says clean (never because a report
+		// is missing/failed) AND there are no UOM issues.
+		const noUom = !this.uomIssues.length;
+		const noDq = !!(this.qualityReport && this.qualityReport.clean);
+		if (noUom && noDq) {
+			$("#check-clean").show();
+		}
+		this._updateCheckContinue();
+
+		// Resumed-draft: advance to the saved step now the scan (+ mapping) has loaded.
+		if (this._resumeStep) {
+			const step = this._resumeStep;
+			this._resumeStep = null;
+			if (step === "section-review" && this.hasAccounts()) {
+				this.renderAccountMapping();
+				this.show("section-review");
+			} else if (step === "section-run") {
+				this.gotoRun();
+			}
+		}
+	}
+
+	_onPreflightFailed(msg) {
+		this._checkLoading = false;
+		this.qualityError = msg || __("The file could not be validated.");
+		this.qualityReport = null;
+		$("#check-loading").hide();
+		$("#check-clean").hide();
+		$("#check-issues").hide();
+		const esc = frappe.utils.escape_html;
+		$("#check-failed").html(TallyMigratorPage.callout("error", TallyMigratorPage.iconRow(
+			"error",
+			`<strong>${__("We couldn't validate your file.")}</strong> ${esc(this.qualityError)}<br>` +
+			`${__("Importing without a successful check is not allowed.")} ` +
+			`<a href="#" id="btn-retry-preflight">${__("Try again")}</a>`))).show();
+		$("#btn-retry-preflight").off("click").on("click", (e) => {
+			e.preventDefault();
+			this.proceedToCheck();
 		});
+		this._updateCheckContinue();
 	}
 
 	// Single owner of the Step-3 Continue button's enabled state. The two async
@@ -918,7 +956,9 @@ class TallyMigratorPage {
 		const report = this.qualityReport;
 		const hasErrors = !!(report && !report.clean && (report.error_count || 0) > 0);
 		const consented = $("#dq-consent-check").is(":checked");
-		const blocked = loading || blockers || (hasErrors && !consented);
+		// A failed/incomplete validation blocks Continue outright - importing without a
+		// successful check is not allowed (the whole point of Phase 2's honest states).
+		const blocked = loading || !!this.qualityError || blockers || (hasErrors && !consented);
 		$("#btn-next-check").prop("disabled", blocked);
 		return blocked;
 	}
@@ -1585,33 +1625,51 @@ class TallyMigratorPage {
 	// engine, so resolved issues drop off and any remaining ones stay visible.
 	recheck() {
 		frappe.dom.freeze(__("Re-checking..."));
+		this._recheckPoll = 0;
+		this._doRecheck();
+	}
+
+	_doRecheck() {
 		frappe.call({
 			method: "tally_migrator.api.validate_masters_data",
-			args: {
-				file_url: this.fileUrl,
-				record_overrides: JSON.stringify(this.recordOverrides),
-				// Pass the company + date so the readiness panel (incl. frozen-period
-				// checks) is recomputed alongside the data fixes, not left stale.
-				erpnext_company: this.getCompany(),
-				posting_date: this.getDate(),
-			},
+			// Pass company + date so the readiness panel (incl. frozen-period checks) is
+			// recomputed alongside the data fixes, not left stale.
+			args: this._preflightArgs(),
 			callback: (r) => {
+				const m = r.message || {};
+				if (m.status === "running") {
+					if (++this._recheckPoll > 150) {   // ~5 min at 2s
+						frappe.dom.unfreeze();
+						return this._onPreflightFailed(__("Re-check is taking longer than expected."));
+					}
+					return setTimeout(() => this._doRecheck(), 2000);
+				}
 				frappe.dom.unfreeze();
-				this.qualityReport = r.message || null;
-				this.states = (r.message && r.message.states) || this.states;
+				if (m.status === "failed") {
+					return this._onPreflightFailed(m.error || __("Re-check could not be completed."));
+				}
+				// ready: a genuine recomputed result.
+				this.qualityError = null;
+				this.qualityReport = m;
+				this.states = m.states || this.states;
 				// The server recomputes coverage + account mapping against the fixed
 				// data on every call; refresh them too, or the Review step (and the
 				// coverage notice) would keep showing the pre-fix snapshot.
-				this.coverageReport = (r.message && r.message.coverage) || null;
-				this.accountMapping = (r.message && r.message.account_mapping) || null;
-				if (r.message && r.message.readiness) {
-					this.readiness = r.message.readiness;
+				this.coverageReport = m.coverage || null;
+				this.accountMapping = m.account_mapping || null;
+				if (m.readiness) {
+					this.readiness = m.readiness;
 					this.renderReadiness();
 				}
+				$("#check-failed").hide();
 				this.renderDataQuality();
 				this.renderCoverage();
+				this._updateCheckContinue();
 			},
-			error: () => frappe.dom.unfreeze(),
+			error: () => {
+				frappe.dom.unfreeze();
+				this._onPreflightFailed(__("We couldn't reach the server to re-check."));
+			},
 		});
 	}
 
@@ -2589,7 +2647,9 @@ class TallyMigratorPage {
 		$("#btn-next-upload").prop("disabled", true);
 		$("#check-loading").show();
 		$("#check-clean").hide();
+		$("#check-failed").hide();
 		$("#check-issues").hide();
+		this.qualityError = null;
 		$("#uom-issue-list").html("");
 		this.setCoa("reuse");
 		this.updateCoaHint();

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -794,6 +794,60 @@ class TestERPNextImporter(unittest.TestCase):
         self.assertFalse(frappe.local.flags.ignore_update_nsm, "flag must be restored")
         rebuilt.assert_called_once()   # rebuild still fires in finally (self-healing)
 
+    def test_account_import_defers_per_insert_nsm_updates(self):
+        """Proves the optimisation is actually engaged (not just that the tree ends up
+        valid - which per-insert numbering would also achieve): with ignore_update_nsm
+        set around the loop, frappe's per-insert update_nsm must NOT run; a single
+        rebuild_tree replaces it. Without the deferral this fires once per account."""
+        require_company()
+        from unittest import mock
+        from frappe.utils import nestedset
+        from tally_migrator.erpnext.importers.accounts import AccountImporter
+        from tally_migrator.tally.extractors import AccountNode
+
+        abbr = frappe.get_value("Company", self.company, "abbr")
+        nodes = [
+            AccountNode(name="_TMTest NsmGrp", parent="", is_group=True,
+                        root_type="Asset", account_type="", is_reserved=False),
+            AccountNode(name="_TMTest NsmLed", parent="_TMTest NsmGrp", is_group=False,
+                        root_type="Asset", account_type="", is_reserved=False),
+        ]
+        with mock.patch.object(nestedset, "update_nsm", wraps=nestedset.update_nsm) as spy:
+            result = AccountImporter(self.company, abbr, mode="reuse").run(nodes)
+        self.assertEqual(result.failed, 0, msg=str(result.errors))
+        self.assertEqual(
+            spy.call_count, 0,
+            "per-insert update_nsm must be skipped (deferred to a single rebuild_tree)")
+
+    # ── Party primary links with ERPNext's redundant sync suspended (Phase 3) ────
+
+    def test_party_import_sets_primary_links_with_erpnext_sync_suspended(self):
+        """With ERPNext's redundant Address->Customer primary sync suspended for the
+        party phase, OUR code must still set the customer's primary address / contact /
+        display correctly - proving the suspension removes only the empty scan, never the
+        outcome."""
+        require_company()
+        customer = {
+            "_name": "_TMTest PrimaryLinks",
+            "Address": "12 MG Road",
+            "LedgerState": "Karnataka",
+            "LedgerMobile": "9845012345",
+        }
+        result = self.importer.import_customers([customer])
+        self.assertEqual(result.failed, 0, msg=str(result.errors))
+        name = frappe.db.get_value(
+            "Customer", {"customer_name": "_TMTest PrimaryLinks"}, "name")
+        self.assertTrue(name)
+        addr, disp, contact = frappe.db.get_value(
+            "Customer", name,
+            ["customer_primary_address", "primary_address", "customer_primary_contact"])
+        self.assertTrue(addr, "customer_primary_address must be set by our code")
+        self.assertTrue(disp, "primary_address display must be populated by our code")
+        self.assertTrue(contact, "customer_primary_contact must be set by our code")
+        self.assertEqual(
+            frappe.db.get_value("Address", addr, "is_primary_address"), 1,
+            "the linked address must be flagged primary")
+
     # ── Stock Groups → nested Item Groups ───────────────────────────────────────
 
     def test_stock_groups_create_nested_item_groups(self):

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -720,6 +720,80 @@ class TestERPNextImporter(unittest.TestCase):
             "the child must nest under the existing ledger's parent")
         self.assertTrue(any("kept as a ledger" in w["reason"] for w in result.warnings))
 
+    # ── Deferred nested-set rebuild (Phase 4) ───────────────────────────────────
+
+    def test_account_tree_is_correctly_nested_after_deferred_rebuild(self):
+        """With per-insert nested-set updates deferred (ignore_update_nsm) and a single
+        rebuild_tree at the end, the imported accounts must end with a VALID nested set:
+        non-zero lft/rgt and strict parent-contains-child ordering. A missing rebuild
+        would leave lft/rgt at 0 (caught here), and wrong numbering would break
+        containment - so this proves the optimisation preserves the tree exactly."""
+        require_company()
+        from tally_migrator.erpnext.importers.accounts import AccountImporter
+        from tally_migrator.tally.extractors import AccountNode
+        from tally_migrator.naming import company_scoped
+
+        abbr = frappe.get_value("Company", self.company, "abbr")
+        nodes = [
+            AccountNode(name="_TMTest TreeGrp", parent="", is_group=True,
+                        root_type="Asset", account_type="", is_reserved=False),
+            AccountNode(name="_TMTest TreeSub", parent="_TMTest TreeGrp", is_group=True,
+                        root_type="Asset", account_type="", is_reserved=False),
+            AccountNode(name="_TMTest TreeLedA", parent="_TMTest TreeSub", is_group=False,
+                        root_type="Asset", account_type="", is_reserved=False),
+            AccountNode(name="_TMTest TreeLedB", parent="_TMTest TreeGrp", is_group=False,
+                        root_type="Asset", account_type="", is_reserved=False),
+        ]
+        # Set a known prior flag so we can assert it is restored, not just cleared.
+        frappe.local.flags.ignore_update_nsm = False
+        result = AccountImporter(self.company, abbr, mode="reuse").run(nodes)
+        self.assertEqual(result.failed, 0, msg=str(result.errors))
+        # The deferral flag must be restored to its prior value after the phase.
+        self.assertFalse(frappe.local.flags.ignore_update_nsm)
+
+        def bounds(base):
+            return frappe.db.get_value(
+                "Account", company_scoped(base, abbr), ["lft", "rgt"], as_dict=True)
+
+        grp, sub = bounds("_TMTest TreeGrp"), bounds("_TMTest TreeSub")
+        led_a, led_b = bounds("_TMTest TreeLedA"), bounds("_TMTest TreeLedB")
+        # Rebuild actually ran: every node has real (non-zero) boundaries.
+        for b in (grp, sub, led_a, led_b):
+            self.assertTrue(b.lft and b.rgt and b.rgt > b.lft, msg=str(b))
+        # Strict nesting: group contains subgroup contains ledger A; ledger B in group.
+        self.assertLess(grp.lft, sub.lft)
+        self.assertLess(sub.lft, led_a.lft)
+        self.assertLess(led_a.rgt, sub.rgt)
+        self.assertLess(sub.rgt, grp.rgt)
+        self.assertTrue(grp.lft < led_b.lft < led_b.rgt < grp.rgt)
+        # A ledger must never have acquired children (validate_ledger's guarantee holds
+        # by construction even though it was deferred with the rest of on_update).
+        self.assertFalse(
+            frappe.db.exists("Account",
+                             {"parent_account": company_scoped("_TMTest TreeLedA", abbr)}),
+            "a ledger account must have no child accounts")
+
+    def test_account_run_restores_nsm_flag_and_rebuilds_on_exception(self):
+        """If the insert loop raises, the finally must still restore the flag AND run
+        the rebuild - so a crash mid-phase never leaves the flag stuck on (which would
+        silently disable tree maintenance for later phases) or the tree unnumbered."""
+        require_company()
+        from unittest import mock
+        from tally_migrator.erpnext.importers.accounts import AccountImporter
+        from tally_migrator.tally.extractors import AccountNode
+
+        abbr = frappe.get_value("Company", self.company, "abbr")
+        imp = AccountImporter(self.company, abbr, mode="reuse")
+        node = AccountNode(name="_TMTest TreeErr", parent="", is_group=True,
+                           root_type="Asset", account_type="", is_reserved=False)
+        frappe.local.flags.ignore_update_nsm = False
+        with mock.patch.object(imp, "_upsert", side_effect=RuntimeError("boom")), \
+                mock.patch.object(imp, "_rebuild_account_tree") as rebuilt:
+            with self.assertRaises(RuntimeError):
+                imp.run([node])
+        self.assertFalse(frappe.local.flags.ignore_update_nsm, "flag must be restored")
+        rebuilt.assert_called_once()   # rebuild still fires in finally (self-healing)
+
     # ── Stock Groups → nested Item Groups ───────────────────────────────────────
 
     def test_stock_groups_create_nested_item_groups(self):

--- a/tally_migrator/tests/test_party_perf.py
+++ b/tally_migrator/tests/test_party_perf.py
@@ -1,0 +1,163 @@
+"""Phase 3 party-import performance + country-alias fixes.
+
+Two changes, both data-neutral:
+
+  * ``normalize_country`` - Tally writes a country as free text; ERPNext's
+    Address.country is a Link to Country, so an unrecognised abbreviation ("UAE")
+    loses the whole address. A minimal, evidence-based alias map rewrites only
+    unambiguous abbreviations to their canonical ERPNext Country name and passes
+    everything else through byte-for-byte.
+  * ``_address_primary_sync_suspended`` - ERPNext's ``ERPNextAddress.on_update``
+    runs, on every Address save, a ``SELECT ... FROM tabCustomer WHERE
+    customer_primary_address = <this address>`` scan (2,511 calls / 3.4s on a real
+    book) to refresh a customer's cached primary-address display. In the migrator
+    that scan is always empty (we link the primary AFTER insert with a direct
+    ``set_value``) and we write the display ourselves, so it is pure overhead. The
+    suspension skips ONLY that sync and still forwards to any base ``on_update``.
+
+Pure/Frappe-tier: ``normalize_country`` needs no site; the suspension tests use a
+synthetic class hierarchy (the MRO drop-in) and a real class-attribute swap/restore,
+so no DB is touched.
+"""
+import contextlib
+import unittest
+
+from tally_migrator.tally.mappings import normalize_country
+from tally_migrator.erpnext.importers import party
+
+
+class TestNormalizeCountry(unittest.TestCase):
+    """Only unambiguous aliases are rewritten; everything else passes through."""
+
+    def test_known_aliases_map_to_canonical_erpnext_names(self):
+        cases = {
+            "UAE": "United Arab Emirates",
+            "uae": "United Arab Emirates",
+            "U.A.E.": "United Arab Emirates",
+            "USA": "United States",
+            "usa": "United States",
+            "U.S.A.": "United States",
+            "US": "United States",
+            "U.S.": "United States",
+            "UK": "United Kingdom",
+            "uk": "United Kingdom",
+            "U.K.": "United Kingdom",
+        }
+        for raw, expected in cases.items():
+            self.assertEqual(normalize_country(raw), expected, raw)
+
+    def test_real_country_names_pass_through_verbatim(self):
+        # A value that is already a valid ERPNext Country name is never altered.
+        for name in ["India", "United States", "United Arab Emirates",
+                     "Germany", "Sri Lanka", "United Kingdom"]:
+            self.assertEqual(normalize_country(name), name)
+
+    def test_unknown_values_pass_through_trimmed(self):
+        # Not an alias -> returned as-is (trimmed); never guessed at.
+        self.assertEqual(normalize_country("  Narnia  "), "Narnia")
+        self.assertEqual(normalize_country("Bharat"), "Bharat")
+
+    def test_blank_stays_blank(self):
+        # Blank -> "" so the caller falls back to the company country.
+        for blank in ["", "   ", None]:
+            self.assertEqual(normalize_country(blank), "")
+
+    def test_case_and_dot_insensitive_but_not_over_eager(self):
+        # "us" is an alias; a longer word that merely starts with it is not.
+        self.assertEqual(normalize_country("us"), "United States")
+        self.assertEqual(normalize_country("USB"), "USB")          # not "United States"
+        self.assertEqual(normalize_country("United"), "United")    # not mapped
+
+
+class TestAddressOnUpdateDropIn(unittest.TestCase):
+    """The MRO drop-in skips ERPNextAddress's own sync but forwards a base on_update."""
+
+    def _run(self, mid_cls, runtime_cls):
+        inst = runtime_cls()
+        inst.calls = []
+        fn = party._make_address_on_update_skip_primary(mid_cls)
+        fn(inst)
+        return inst.calls
+
+    def test_forwards_to_a_base_on_update_and_skips_the_sync(self):
+        class Base:
+            def on_update(self):
+                self.calls.append("base")
+
+        class Mid(Base):                       # stand-in for ERPNextAddress
+            def on_update(self):
+                self.calls.append("redundant-sync")
+
+        class Runtime(Mid):                    # the composed controller subclass
+            pass
+
+        # Base's on_update runs (forward-safe); the redundant sync does NOT.
+        self.assertEqual(self._run(Mid, Runtime), ["base"])
+
+    def test_no_base_on_update_means_a_clean_no_op(self):
+        class Mid:                             # only ERPNextAddress defines on_update
+            def on_update(self):
+                self.calls.append("redundant-sync")
+
+        class Runtime(Mid):
+            pass
+
+        # Nothing above Mid defines on_update -> the sync is simply skipped.
+        self.assertEqual(self._run(Mid, Runtime), [])
+
+    def test_missing_class_in_mro_is_handled(self):
+        # Defensive: a self whose MRO does not contain the given class -> no crash,
+        # no base call (there is nothing after an absent anchor).
+        class Unrelated:
+            pass
+
+        class Mid:
+            def on_update(self):
+                self.calls.append("sync")
+
+        inst = Unrelated()
+        inst.calls = []
+        party._make_address_on_update_skip_primary(Mid)(inst)
+        self.assertEqual(inst.calls, [])
+
+
+class TestAddressPrimarySyncSuspended(unittest.TestCase):
+    """The context manager swaps ERPNextAddress.on_update in and restores it out."""
+
+    def setUp(self):
+        try:
+            from erpnext.accounts.custom.address import ERPNextAddress  # noqa: F401
+        except Exception:
+            self.skipTest("erpnext not installed")
+        self.ERPNextAddress = ERPNextAddress
+
+    def test_swaps_inside_and_restores_after(self):
+        original = self.ERPNextAddress.on_update
+        with party._address_primary_sync_suspended():
+            self.assertIsNot(self.ERPNextAddress.on_update, original)
+        self.assertIs(self.ERPNextAddress.on_update, original)
+
+    def test_restores_even_on_exception(self):
+        original = self.ERPNextAddress.on_update
+        with self.assertRaises(RuntimeError):
+            with party._address_primary_sync_suspended():
+                raise RuntimeError("boom")
+        self.assertIs(self.ERPNextAddress.on_update, original)
+
+    def test_patched_on_update_does_not_scan_customers(self):
+        # Inside the CM, the installed on_update must not run the tabCustomer scan.
+        from unittest import mock
+        with party._address_primary_sync_suspended():
+            patched = self.ERPNextAddress.on_update
+            # Build a minimal instance whose MRO ends at ERPNextAddress with no base
+            # on_update, so the drop-in is a clean no-op; assert get_all is untouched.
+            class _Runtime(self.ERPNextAddress):
+                pass
+            inst = _Runtime.__new__(_Runtime)
+            with mock.patch.object(party.frappe.db, "get_all") as g:
+                patched(inst)
+            g.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tally_migrator/tests/test_preflight.py
+++ b/tally_migrator/tests/test_preflight.py
@@ -1,0 +1,131 @@
+"""Phase 2: the Step-3 pre-flight orchestrator (validate_masters_data).
+
+The safety-critical guarantee: a scan that FAILS returns ``{"status": "failed"}`` -
+never a bare/empty payload the UI could mistake for "clean". Also: small files compute
+inline (ready), large files go async (running -> cached ready/failed), and the cache key
+is unique per file version / edits / company / user. No parsing needed - the compute is
+mocked so these test the orchestration + honest-state contract.
+"""
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from tally_migrator import api
+
+
+def _file(name="F1", modified="2026-01-01"):
+    return SimpleNamespace(name=name, modified=modified)
+
+
+class _FakeCache:
+    def __init__(self, initial=None):
+        self.store = dict(initial or {})
+        self.sets = []
+
+    def get_value(self, k):
+        return self.store.get(k)
+
+    def set_value(self, k, v, expires_in_sec=None):
+        self.store[k] = v
+        self.sets.append((k, v, expires_in_sec))
+
+
+class TestPreflightOrchestrator(unittest.TestCase):
+    def setUp(self):
+        # Resolve/access are exercised elsewhere; here we isolate the orchestration.
+        self.p_resolve = mock.patch.object(api, "_resolve_file_doc", return_value=_file())
+        self.p_access = mock.patch.object(api, "_assert_file_access")
+        self.p_only = mock.patch.object(api.frappe, "only_for")
+        self.p_resolve.start(); self.p_access.start(); self.p_only.start()
+
+    def tearDown(self):
+        mock.patch.stopall()
+
+    # -- small file: inline --
+    def test_small_file_ready(self):
+        with mock.patch.object(api, "_should_run_async", return_value=False), \
+             mock.patch.object(api, "_compute_preflight",
+                               return_value={"clean": True, "groups": [], "uom_issues": []}):
+            out = api.validate_masters_data("/files/x.xml")
+        self.assertEqual(out["status"], "ready")
+        self.assertTrue(out["clean"])
+
+    def test_small_file_failure_is_honest_not_clean(self):
+        # The whole point of Phase 2: a crash must NOT look like "no issues".
+        with mock.patch.object(api, "_should_run_async", return_value=False), \
+             mock.patch.object(api, "_compute_preflight", side_effect=ValueError("bad xml")), \
+             mock.patch.object(api.frappe, "log_error"):
+            out = api.validate_masters_data("/files/x.xml")
+        self.assertEqual(out["status"], "failed")
+        self.assertIn("bad xml", out["error"])
+        self.assertNotIn("clean", out)          # no payload that could read as clean
+
+    # -- large file: async --
+    def test_large_file_enqueues_and_returns_running(self):
+        cache = _FakeCache()
+        with mock.patch.object(api, "_should_run_async", return_value=True), \
+             mock.patch.object(api.frappe, "cache", return_value=cache), \
+             mock.patch.object(api.frappe, "enqueue") as enq:
+            out = api.validate_masters_data("/files/big.xml")
+        self.assertEqual(out["status"], "running")
+        enq.assert_called_once()
+        # running marker was cached so concurrent polls don't re-enqueue
+        self.assertTrue(any(v.get("status") == "running" for _, v, _ in cache.sets))
+
+    def test_large_file_returns_cached_ready_without_reenqueue(self):
+        key = api._preflight_key(_file(), "", "", "")
+        cache = _FakeCache({key: {"status": "ready", "clean": False, "groups": [1]}})
+        with mock.patch.object(api, "_should_run_async", return_value=True), \
+             mock.patch.object(api.frappe, "cache", return_value=cache), \
+             mock.patch.object(api.frappe, "enqueue") as enq:
+            out = api.validate_masters_data("/files/big.xml")
+        self.assertEqual(out["status"], "ready")
+        enq.assert_not_called()
+
+    def test_large_file_returns_cached_failed(self):
+        key = api._preflight_key(_file(), "", "", "")
+        cache = _FakeCache({key: {"status": "failed", "error": "boom"}})
+        with mock.patch.object(api, "_should_run_async", return_value=True), \
+             mock.patch.object(api.frappe, "cache", return_value=cache), \
+             mock.patch.object(api.frappe, "enqueue") as enq:
+            out = api.validate_masters_data("/files/big.xml")
+        self.assertEqual(out["status"], "failed")
+        enq.assert_not_called()
+
+
+class TestPreflightJob(unittest.TestCase):
+    def test_job_caches_ready_on_success(self):
+        cache = _FakeCache()
+        with mock.patch.object(api.frappe, "cache", return_value=cache), \
+             mock.patch.object(api, "_compute_preflight",
+                               return_value={"clean": True, "groups": []}):
+            api._run_preflight_job("K", "/f.xml", "", "", "")
+        self.assertEqual(cache.store["K"]["status"], "ready")
+        self.assertTrue(cache.store["K"]["clean"])
+
+    def test_job_caches_failed_and_reraises(self):
+        cache = _FakeCache()
+        with mock.patch.object(api.frappe, "cache", return_value=cache), \
+             mock.patch.object(api.frappe, "log_error"), \
+             mock.patch.object(api, "_compute_preflight", side_effect=RuntimeError("nope")):
+            with self.assertRaises(RuntimeError):
+                api._run_preflight_job("K", "/f.xml", "", "", "")
+        self.assertEqual(cache.store["K"]["status"], "failed")
+        self.assertIn("nope", cache.store["K"]["error"])
+
+
+class TestPreflightKey(unittest.TestCase):
+    def test_key_changes_with_inputs(self):
+        base = api._preflight_key(_file(), "", "Co", "2026-01-01")
+        self.assertNotEqual(base, api._preflight_key(_file(modified="2026-02-02"), "", "Co", "2026-01-01"))
+        self.assertNotEqual(base, api._preflight_key(_file(), '{"a":1}', "Co", "2026-01-01"))
+        self.assertNotEqual(base, api._preflight_key(_file(), "", "Other", "2026-01-01"))
+        self.assertEqual(base, api._preflight_key(_file(), "", "Co", "2026-01-01"))  # stable
+
+    def test_error_message_is_short_and_safe(self):
+        self.assertEqual(api._preflight_error_message(ValueError("")), "the file could not be read or validated")
+        self.assertTrue(len(api._preflight_error_message(ValueError("x" * 500))) <= 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tally_migrator/tests/test_record_guard.py
+++ b/tally_migrator/tests/test_record_guard.py
@@ -60,7 +60,12 @@ class TestGuardConfig(unittest.TestCase):
 class TestMarker(unittest.TestCase):
     def test_marker_round_trip_and_clear(self):
         rg.set_inflight("MK1", "Customer", "Acme")
-        self.assertEqual(rg.read_inflight("MK1"), {"phase": "Customer", "ident": "Acme"})
+        m = rg.read_inflight("MK1")
+        self.assertEqual(m["phase"], "Customer")
+        self.assertEqual(m["ident"], "Acme")
+        # A wall-clock timestamp is stamped so the resume sweep can detect a dead worker
+        # even when RQ still reports the job 'started' (no-fork case).
+        self.assertIsInstance(m["ts"], float)
         rg.clear_inflight("MK1")
         self.assertIsNone(rg.read_inflight("MK1"))
 
@@ -248,12 +253,60 @@ class TestResumeSweep(unittest.TestCase):
         # first stall -> suspect, not yet confirmed (retry-once)
         self.assertEqual(rg.confirmed_from_log(log), set())
 
-    def test_live_run_is_left_alone(self):
+    def test_live_run_with_fresh_marker_is_left_alone(self):
+        # Alive worker, and the in-flight record was marked just now -> still working,
+        # never re-enqueue.
+        import time as _t
         from tally_migrator.migration import resume
         with mock.patch.object(resume, "_job_alive", return_value=True), \
+             mock.patch.object(resume.record_guard, "read_inflight",
+                               return_value={"phase": "Customer", "ident": "Acme",
+                                             "ts": _t.time()}), \
              mock.patch.object(resume, "_reenqueue") as reenq:
             resume._maybe_resume(self._row())
         reenq.assert_not_called()
+
+    def test_stuck_marker_resumes_even_when_job_reports_alive(self):
+        # No-fork case: a hard-killed worker leaves its RQ job stuck 'started' (job_alive
+        # True), but the in-flight record has been marked far longer than the per-record
+        # timeout, so the sweep still resumes it.
+        import time as _t
+        from tally_migrator.migration import resume
+        log = self._log()
+        stale_ts = _t.time() - (rg.record_timeout_s() + resume._RESUME_GRACE_S + 5)
+        with mock.patch.object(resume, "_job_alive", return_value=True), \
+             mock.patch.object(resume.record_guard, "read_inflight",
+                               return_value={"phase": "Customer", "ident": "Acme",
+                                             "ts": stale_ts}), \
+             mock.patch.object(resume.frappe, "get_doc", return_value=log), \
+             mock.patch.object(resume.frappe.db, "commit"), \
+             mock.patch.object(resume, "_reenqueue") as reenq:
+            resume._maybe_resume(self._row())
+        reenq.assert_called_once()
+
+    def test_reenqueue_failure_restores_marker_and_uncounts_stall(self):
+        # If re-enqueue raises after the marker was cleared and the stall recorded, both
+        # must be undone so a later sweep retries without double-counting the one hang.
+        from tally_migrator.migration import resume
+        log = self._log()
+        restored = {}
+        with mock.patch.object(resume, "_job_alive", return_value=False), \
+             mock.patch.object(resume.record_guard, "read_inflight",
+                               return_value={"phase": "Customer", "ident": "Acme"}), \
+             mock.patch.object(resume.frappe, "get_doc", return_value=log), \
+             mock.patch.object(resume.frappe.db, "commit"), \
+             mock.patch.object(resume.record_guard, "set_inflight",
+                               side_effect=lambda *a: restored.setdefault("set", a)), \
+             mock.patch.object(resume, "_reenqueue", side_effect=RuntimeError("queue full")):
+            with self.assertRaises(RuntimeError):
+                resume._maybe_resume(self._row())
+        # marker was restored, and the stall was un-counted (attempts back to 0 -> record
+        # dropped from the hung set, so it is not one step closer to confirmed-skip).
+        self.assertIn("set", restored)
+        self.assertEqual(rg.confirmed_from_log(log), set())
+        st = rg._read_state(log)
+        self.assertEqual(st["resume_count"], 0)
+        self.assertNotIn(rg._state_key("Customer", "Acme"), st["hung"])
 
     def test_no_marker_is_left_alone(self):
         from tally_migrator.migration import resume

--- a/tally_migrator/tests/test_record_guard.py
+++ b/tally_migrator/tests/test_record_guard.py
@@ -1,0 +1,285 @@
+"""Tests for the per-record hang guard (record_guard).
+
+Covers: config + defaults, the Redis in-flight marker, the retry-once -> confirm state
+machine, should_skip / guarded_records skip behaviour, guard arm/cancel + re-entrancy,
+and - in a real subprocess - that a hung record is actually dumped and hard-killed with
+its exact stack captured. Pure-logic parts need no site (mocked like test_async_decision);
+the subprocess part is self-contained.
+"""
+import faulthandler
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from unittest import mock
+
+from tally_migrator.migration import record_guard as rg
+
+
+class _FakeLog:
+    """Minimal stand-in for a Tally Migration Log: get()/db_set() over a dict, which is
+    all the guard-state helpers touch."""
+    def __init__(self, name="TML-TEST"):
+        self.name = name
+        self._d = {}
+
+    def get(self, k):
+        return self._d.get(k)
+
+    def db_set(self, k, v, **kw):
+        self._d[k] = v
+
+
+class TestGuardConfig(unittest.TestCase):
+    def _conf(self, **kw):
+        return mock.patch.object(rg.frappe, "conf", kw)
+
+    def test_timeout_default_60(self):
+        with self._conf():
+            self.assertEqual(rg.record_timeout_s(), 60)
+
+    def test_timeout_override(self):
+        with self._conf(tally_migrator_record_timeout=30):
+            self.assertEqual(rg.record_timeout_s(), 30)
+
+    def test_timeout_invalid_falls_back(self):
+        with self._conf(tally_migrator_record_timeout=-5):
+            self.assertEqual(rg.record_timeout_s(), 60)
+        with self._conf(tally_migrator_record_timeout="nonsense"):
+            self.assertEqual(rg.record_timeout_s(), 60)
+
+    def test_max_resumes_default_and_override(self):
+        with self._conf():
+            self.assertEqual(rg.max_resumes(), 50)
+        with self._conf(tally_migrator_max_resumes=10):
+            self.assertEqual(rg.max_resumes(), 10)
+
+
+class TestMarker(unittest.TestCase):
+    def test_marker_round_trip_and_clear(self):
+        rg.set_inflight("MK1", "Customer", "Acme")
+        self.assertEqual(rg.read_inflight("MK1"), {"phase": "Customer", "ident": "Acme"})
+        rg.clear_inflight("MK1")
+        self.assertIsNone(rg.read_inflight("MK1"))
+
+
+class TestStateMachine(unittest.TestCase):
+    def test_retry_once_then_confirm(self):
+        log = _FakeLog()
+        self.assertEqual(rg.confirmed_from_log(log), set())
+        # first stall -> suspect (attempts 1), NOT confirmed: a one-off slow record is
+        # given a second chance, so a good record is never dropped.
+        attempts, resume = rg.note_stall(log, "Customer", "Acme")
+        self.assertEqual((attempts, resume), (1, 1))
+        self.assertEqual(rg.confirmed_from_log(log), set())
+        # second stall -> confirmed (attempts 2) -> skip on sight
+        attempts, resume = rg.note_stall(log, "Customer", "Acme")
+        self.assertEqual((attempts, resume), (2, 2))
+        self.assertEqual(rg.confirmed_from_log(log), {("Customer", "Acme")})
+
+    def test_resume_count_is_shared_attempts_are_per_record(self):
+        log = _FakeLog()
+        rg.note_stall(log, "Customer", "A")
+        attempts, resume = rg.note_stall(log, "Customer", "B")
+        self.assertEqual(attempts, 1)     # B's own first stall
+        self.assertEqual(resume, 2)       # but the second resume overall
+
+    def test_state_survives_reload(self):
+        log = _FakeLog()
+        rg.note_stall(log, "Item", "Widget")
+        rg.note_stall(log, "Item", "Widget")
+        # a fresh log object reading the same persisted field sees the confirmation
+        reloaded = _FakeLog()
+        reloaded._d["guard_state"] = log._d["guard_state"]
+        self.assertEqual(rg.confirmed_from_log(reloaded), {("Item", "Widget")})
+
+
+class TestSkipAndGuard(unittest.TestCase):
+    def tearDown(self):
+        rg.deactivate()
+        faulthandler.cancel_dump_traceback_later()
+
+    def test_should_skip_noop_when_inactive(self):
+        rg.deactivate()
+        self.assertFalse(rg.should_skip("Customer", "Anything"))
+
+    def test_should_skip_only_confirmed(self):
+        rg.activate(rg.RecordGuard("L", confirmed={("Customer", "Acme")}))
+        self.assertTrue(rg.should_skip("Customer", "Acme"))
+        self.assertFalse(rg.should_skip("Customer", "Fresh"))
+
+    def test_guarded_records_skips_confirmed_and_reports(self):
+        rg.activate(rg.RecordGuard("L", confirmed={("Customer", "Acme")}, timeout_s=999))
+        skipped, seen = [], []
+        recs = [{"_name": "Acme"}, {"_name": "Fresh"}, {"_name": "Zed"}]
+        for r in rg.guarded_records("Customer", recs, lambda x: x["_name"],
+                                    on_skip=lambda r, i: skipped.append(i)):
+            seen.append(r["_name"])
+        self.assertEqual(seen, ["Fresh", "Zed"])   # confirmed one never yielded
+        self.assertEqual(skipped, ["Acme"])
+
+    def test_guard_arms_and_cancels(self):
+        rg.activate(rg.RecordGuard("L", timeout_s=999))
+        with rg.guard("Customer", "X"):
+            self.assertTrue(rg.current()._armed)
+        self.assertFalse(rg.current()._armed)
+
+    def test_guard_reentrancy_keeps_outer_timer(self):
+        rg.activate(rg.RecordGuard("L", timeout_s=999))
+        with rg.guard("Customer", "X"):
+            with rg.guard("Customer", "Y"):   # nested must not clobber the outer timer
+                pass
+            self.assertTrue(rg.current()._armed)
+
+    def test_guard_is_noop_when_inactive(self):
+        rg.deactivate()
+        with rg.guard("Customer", "X"):   # must not raise, must not arm
+            pass
+        self.assertIsNone(rg.current())
+
+
+class TestActualKill(unittest.TestCase):
+    """The whole point: a hung record must dump its stack and hard-kill the worker."""
+
+    def test_hung_record_is_dumped_and_killed(self):
+        dump_dir = tempfile.mkdtemp(prefix="tm_guard_kill_")
+        child = textwrap.dedent(f"""
+            import sys, types, json, time, os
+            _c = {{}}
+            class C:
+                def set_value(s,k,v,expires_in_sec=None): _c[k]=v
+                def get_value(s,k): return _c.get(k)
+                def delete_value(s,k): _c.pop(k,None)
+            f = types.ModuleType('frappe'); f.conf={{}}; f.cache=lambda: C()
+            f.as_json=json.dumps; f.parse_json=lambda s: json.loads(s) if isinstance(s,str) else s
+            f.get_site_path=lambda *a: os.path.join({dump_dir!r}, *a)
+            sys.modules['frappe']=f
+            sys.path.insert(0, {os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))!r})
+            from tally_migrator.migration import record_guard as rg
+            rg.activate(rg.RecordGuard('LKILL', timeout_s=1))
+            def the_stuck_record():
+                time.sleep(30)
+            with rg.guard('Customer', 'StuckCo'):
+                the_stuck_record()
+            print('SHOULD_NOT_REACH')
+        """)
+        proc = subprocess.run([sys.executable, "-c", child], capture_output=True,
+                              text=True, timeout=30)
+        # hard-killed, not a normal exit
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertNotIn("SHOULD_NOT_REACH", proc.stdout)
+        dump = os.path.join(dump_dir, "tally_migrator_hangs", "LKILL.log")
+        self.assertTrue(os.path.exists(dump), "hang dump file not written")
+        content = open(dump).read()
+        self.assertIn("Timeout", content)                 # faulthandler fired
+        self.assertIn("the_stuck_record", content)         # exact hung line captured
+        # (the record identity lives in the Redis marker + resume log, not the dump)
+
+
+from tally_migrator.erpnext.importers.base import BaseImporter
+
+
+class _FakeImporter(BaseImporter):
+    """Exercises BaseImporter.run's guard wiring without touching the DB."""
+    doctype = "GuardTestDT"
+    key_field = "name"
+
+    def __init__(self):
+        super().__init__("Co", "C")
+        self.processed = []
+
+    def _prefetch_existing(self):
+        return None
+
+    def build_doc(self, record):
+        return dict(record)
+
+    def _upsert(self, result, data):
+        self.processed.append(data["name"])
+        result.add_created(data["name"])
+        return data["name"], True
+
+
+class TestBaseRunWiring(unittest.TestCase):
+    def tearDown(self):
+        rg.deactivate()
+        faulthandler.cancel_dump_traceback_later()
+
+    def test_noop_without_active_guard(self):
+        rg.deactivate()
+        imp = _FakeImporter()
+        result = imp.run([{"name": "A"}, {"name": "B"}])
+        self.assertEqual(imp.processed, ["A", "B"])
+        self.assertEqual(result.created, 2)
+        self.assertEqual(result.failed, 0)
+
+    def test_confirmed_record_is_skipped_and_recorded_rest_import(self):
+        imp = _FakeImporter()
+        rg.activate(rg.RecordGuard("L", confirmed={("GuardTestDT", "B")}, timeout_s=999))
+        result = imp.run([{"name": "A"}, {"name": "B"}, {"name": "C"}])
+        self.assertEqual(imp.processed, ["A", "C"])          # B never processed
+        self.assertEqual(result.created, 2)
+        self.assertEqual(result.failed, 1)                   # B is a visible failure
+        self.assertIn("B", [e["name"] for e in result.errors])
+
+
+class TestResumeSweep(unittest.TestCase):
+    def _row(self):
+        return {"name": "TML-R", "job_id": "j", "company": "Co"}
+
+    def _log(self):
+        log = _FakeLog("TML-R")
+        log._d.update(source_file="/files/x.xml", company="Co")
+        return log
+
+    def test_dead_run_with_marker_reenqueues_and_records_stall(self):
+        from tally_migrator.migration import resume
+        log = self._log()
+        with mock.patch.object(resume, "_job_alive", return_value=False), \
+             mock.patch.object(resume.record_guard, "read_inflight",
+                               return_value={"phase": "Customer", "ident": "Acme"}), \
+             mock.patch.object(resume.frappe, "get_doc", return_value=log), \
+             mock.patch.object(resume.frappe.db, "commit"), \
+             mock.patch.object(resume, "_reenqueue") as reenq:
+            resume._maybe_resume(self._row())
+        reenq.assert_called_once()
+        # first stall -> suspect, not yet confirmed (retry-once)
+        self.assertEqual(rg.confirmed_from_log(log), set())
+
+    def test_live_run_is_left_alone(self):
+        from tally_migrator.migration import resume
+        with mock.patch.object(resume, "_job_alive", return_value=True), \
+             mock.patch.object(resume, "_reenqueue") as reenq:
+            resume._maybe_resume(self._row())
+        reenq.assert_not_called()
+
+    def test_no_marker_is_left_alone(self):
+        from tally_migrator.migration import resume
+        with mock.patch.object(resume, "_job_alive", return_value=False), \
+             mock.patch.object(resume.record_guard, "read_inflight", return_value=None), \
+             mock.patch.object(resume, "_reenqueue") as reenq:
+            resume._maybe_resume(self._row())
+        reenq.assert_not_called()
+
+    def test_cap_exceeded_fails_run_without_reenqueue(self):
+        from tally_migrator.migration import resume
+        log = self._log()
+        # pre-seed resume_count at the cap so the next stall trips it
+        import json as _json
+        log._d["guard_state"] = _json.dumps({"hung": {}, "resume_count": rg.max_resumes()})
+        with mock.patch.object(resume, "_job_alive", return_value=False), \
+             mock.patch.object(resume.record_guard, "read_inflight",
+                               return_value={"phase": "Customer", "ident": "Acme"}), \
+             mock.patch.object(resume.frappe, "get_doc", return_value=log), \
+             mock.patch.object(resume.frappe, "log_error"), \
+             mock.patch.object(resume.frappe.db, "commit"), \
+             mock.patch.object(resume, "_reenqueue") as reenq:
+            resume._maybe_resume(self._row())
+        reenq.assert_not_called()
+        self.assertEqual(log._d.get("status"), "Failed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tally_migrator/tests/test_zip_and_drive.py
+++ b/tally_migrator/tests/test_zip_and_drive.py
@@ -80,6 +80,60 @@ class TestUnzipIfZip(unittest.TestCase):
         self.assertEqual(unzip_if_zip(raw, CAP), payload)
 
 
+_UNSET = object()
+
+
+class TestConfiguredMaxUpload(unittest.TestCase):
+    """The size-ceiling config must be coerced to an int.
+
+    ``bench set-config tally_migrator_max_upload_mb 1024`` stores the STRING
+    "1024"; without coercion ``max_mb * 1024 * 1024`` builds a giant string and the
+    later ``file_size > ceiling`` comparison raises TypeError, turning a *raised*
+    limit into a 500 on every upload. These lock that down.
+    """
+
+    def _with_conf(self, value):
+        conf = {} if value is _UNSET else {"tally_migrator_max_upload_mb": value}
+        return mock.patch.object(api.frappe, "conf", conf)
+
+    def test_string_config_is_coerced_to_int(self):
+        with self._with_conf("1024"):
+            self.assertEqual(api._configured_max_upload_mb(), 1024)
+            # The real crash was here: this must be an int, not a str, and not raise.
+            self.assertEqual(api._max_upload_bytes(), 1024 * 1024 * 1024)
+
+    def test_string_config_size_guard_still_works(self):
+        # 5 MB "file" under a string-configured 1024 MB cap: must NOT raise.
+        with self._with_conf("1024"):
+            api._assert_within_size_limit(5 * 1024 * 1024)
+        # 2000 MB over a string-configured 1024 MB cap: must raise a clean throw.
+        with self._with_conf("1024"), self.assertRaises(Exception):
+            api._assert_within_size_limit(2000 * 1024 * 1024)
+
+    def test_int_config_respected(self):
+        with self._with_conf(2048):
+            self.assertEqual(api._configured_max_upload_mb(), 2048)
+
+    def test_missing_config_uses_default(self):
+        with self._with_conf(_UNSET):
+            self.assertEqual(api._configured_max_upload_mb(), api._DEFAULT_MAX_UPLOAD_MB)
+
+    def test_default_is_1024(self):
+        self.assertEqual(api._DEFAULT_MAX_UPLOAD_MB, 1024)
+
+    def test_garbage_string_falls_back_to_default(self):
+        for bad in ("", "lots", "10MB", None):
+            with self._with_conf(bad):
+                self.assertEqual(
+                    api._configured_max_upload_mb(), api._DEFAULT_MAX_UPLOAD_MB)
+
+    def test_zero_or_negative_falls_back_to_default(self):
+        for bad in (0, "0", -5, "-5"):
+            with self._with_conf(bad):
+                self.assertEqual(
+                    api._configured_max_upload_mb(), api._DEFAULT_MAX_UPLOAD_MB)
+
+
 class TestParseDriveId(unittest.TestCase):
     def test_file_d_link(self):
         url = "https://drive.google.com/file/d/1A2b3C4d5E6f7G8h9I0j/view?usp=sharing"


### PR DESCRIPTION
Hardens the masters migration against the failure modes seen on a real ~700 MB customer run, plus a config-robustness fix. Each area is a self-contained commit.

## What's in it

**Per-record hang guard with auto-resume** (`050d014`)
A single record can no longer stall the whole migration. Each record is wrapped in a generic time guard; if it exceeds the limit (60s default, configurable) the worker is recovered and the run auto-resumes, skipping the offending record once rather than wedging indefinitely. Covers the C-level/GIL hang that froze a live run.

**Trustworthy Step 3 validation** (`c0d8f15`)
The pre-flight check now reports honest states. A failed or too-slow check on a large file is never rendered as a false "no issues found" - large files are scanned in a background job (cached across workers) and the wizard polls until `ready` or `failed`.

**Faster party + account import** (`f7a5578`, `ca26cc2`)
Drops a redundant address-primary scan during the party phase, maps country aliases (e.g. Tally "UAE" -> "United Arab Emirates") so addresses aren't dropped, and batches the Account nested-set rebuild (O(n^2) -> O(n)) via a single `rebuild_tree`.

**Review follow-ups** (`5669959`)
Worker-mode-agnostic resume, no orphaned marker on re-enqueue failure, preflight off the short queue with dedup, dump-file cleanup, and strengthened tests.

**Upload size-limit config fix** (`4192452`)
`tally_migrator_max_upload_mb` was read without numeric coercion, so setting it via `bench set-config` (which stores a string) produced `TypeError: '>' not supported between instances of 'int' and 'str'` on every upload. Now coerced to a positive int with default fallback, and the default ceiling is raised 512 -> 1024 MB so a large export imports without per-site tuning.

## Validation
Exercised end-to-end against an ~800 MB synthetic masters export (14,210 customers / 1,086 suppliers / ~800 accounts) modelled on the real customer run: Step 3 returned an honest non-clean result with all injected bad GSTINs flagged, accounts + both party phases imported with no hang and a valid account tree. Full test suite green (635 tests); docs (README + user guide) updated for the size limit, config knob, and the honest Step-3 state.