### PR TITLE
fix: re-parse a released source instead of serving it from cache

### DIFF
--- a/tally_migrator/api.py
+++ b/tally_migrator/api.py
@@ -653,9 +653,14 @@ def _source_from_file(file_url):
     cache_key = (frappe.session.user, file_doc.name, str(file_doc.modified))
     with _SOURCE_CACHE_LOCK:
         source = _SOURCE_CACHE.get(cache_key)
-        if source is not None:
+        if source is not None and not getattr(source, "released", False):
             _SOURCE_CACHE.move_to_end(cache_key)     # mark most-recently used
             return file_doc, source
+        # A released source (its parsed buffers freed after a run to reclaim memory)
+        # can no longer serve get_collection, so fall through and re-parse, overwriting
+        # the stale entry below - otherwise a second use of the same file in this worker
+        # (a re-run, a re-preview, or an import into another company) would extract
+        # nothing from the emptied source and silently import zero records.
         # A zipped XML is accepted transparently: unzip (with the uncompressed
         # size held to the same cap) before decoding, so the parser only ever
         # sees plain XML bytes regardless of how the file was uploaded. The raw

--- a/tally_migrator/tally/file_source.py
+++ b/tally_migrator/tally/file_source.py
@@ -319,6 +319,9 @@ class FileTallySource:
         # collections, so memoise each (obj_type, fields) result to avoid
         # re-walking the retained records on every call.
         self._collection_cache: dict = {}
+        # Set by release() once extraction is done. A released source has dropped its
+        # parsed records and can no longer serve get_collection; api._source_from_file
+        # treats a released cached source as a miss and re-parses, so reuse stays correct.
         self.released = False
 
     def release(self) -> None:
@@ -332,8 +335,8 @@ class FileTallySource:
         run keeps the parsed file resident through the long import phases for no benefit
         - the lever that matters on a RAM-capped worker (e.g. Frappe Cloud).
 
-        Idempotent and safe: after release the source is marked released so a caller can
-        tell it must re-parse rather than reuse. Best-effort by the caller.
+        Idempotent and safe: after release the source is marked so the request-level
+        cache won't hand it back (it re-parses instead). Best-effort by the caller.
         """
         self._by_tag = {}
         self._collection_cache = {}

--- a/tally_migrator/tests/test_file_lookup.py
+++ b/tally_migrator/tests/test_file_lookup.py
@@ -75,5 +75,58 @@ class TestSharedFileUrlResolution(unittest.TestCase):
             self._run(rows)
 
 
+class TestReleasedSourceReparsed(unittest.TestCase):
+    """A released cached source (its parsed buffers freed after a run to reclaim
+    memory) must NOT be handed back - ``_source_from_file`` must re-parse and
+    overwrite the stale entry. Otherwise a second use of the same file in one worker
+    (a re-run, a re-preview, or importing the same file into another company) would
+    extract nothing from the emptied source and silently import zero records.
+    """
+
+    def _call(self, preset):
+        file_doc = types.SimpleNamespace(name="F1", modified="t", file_name="x.xml")
+        parses = []
+
+        def fake_source(raw):
+            s = types.SimpleNamespace(released=False, raw=raw)
+            parses.append(s)
+            return s
+
+        key = ("u@example.com", "F1", "t")
+        prev_user = api.frappe.session.user
+        api.frappe.session.user = "u@example.com"
+        try:
+            with mock.patch.object(api, "_resolve_file_doc", return_value=file_doc), \
+                 mock.patch.object(api, "_raw_file_bytes", return_value=b"<x/>"), \
+                 mock.patch.object(api, "unzip_if_zip", side_effect=lambda raw, cap: raw), \
+                 mock.patch.object(api, "FileTallySource", side_effect=fake_source), \
+                 mock.patch.dict(api._SOURCE_CACHE, clear=True):
+                if preset is not None:
+                    api._SOURCE_CACHE[key] = preset
+                _, source = api._source_from_file("/private/files/x.xml")
+                return source, parses, dict(api._SOURCE_CACHE), key
+        finally:
+            api.frappe.session.user = prev_user
+
+    def test_released_cached_source_is_reparsed(self):
+        released = types.SimpleNamespace(released=True, raw=b"STALE")
+        source, parses, cache, key = self._call(released)
+        self.assertEqual(len(parses), 1, "a released source must trigger a re-parse")
+        self.assertIsNot(source, released, "must not hand back the released source")
+        self.assertFalse(getattr(source, "released", False))
+        self.assertIs(cache[key], source, "the stale entry must be overwritten")
+
+    def test_live_cached_source_is_reused_without_reparse(self):
+        live = types.SimpleNamespace(released=False, raw=b"LIVE")
+        source, parses, _, _ = self._call(live)
+        self.assertEqual(len(parses), 0, "a live cached source must be reused, not re-parsed")
+        self.assertIs(source, live)
+
+    def test_absent_source_parses_and_caches(self):
+        source, parses, cache, key = self._call(None)
+        self.assertEqual(len(parses), 1)
+        self.assertIs(cache[key], source)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem
`_source_from_file` caches the parsed `FileTallySource` per `(user, file, version)` in a process-global LRU. A migration run frees that source's buffers via `release()` to reclaim memory (`release()` empties `_by_tag`), mutating the very object the cache still holds. The reuse check only tested `source is not None`, so a **second use of the same file in the same worker** - a re-run, a re-preview, or importing the same file into another company - got the emptied source back, **extracted zero records, and silently imported nothing while reporting success**. The `released` flag existed but was written and never read (dead code).

## Scope / severity (honest)
- **Not** reachable on the default forking `bench worker` (fork isolation).
- Reachable on the **web-worker sync path** (small files run synchronously) and **nofork** workers.
- Often masked (an idempotent re-run legitimately creates 0), but genuinely wrong and silent when hit - e.g. importing the same small file into a second company.

## Fix
Guard the cache hit with `not getattr(source, "released", False)` so a released entry falls through to a re-parse and overwrites the stale object. This is the exact guard the `fc/e2e-profiler` branch already ships; this brings `main` to parity.

## Validation
- New regression test (released → re-parse, live → reuse, absent → parse); **fails without the guard** (`0 != 1: a released source must trigger a re-parse`), passes with it.
- Zero regression: same suite with the change stashed vs applied showed identical results; full suite green (638 tests) on a set-up site.