### PR TITLE
Match Tally group names case- and whitespace-insensitively

### DIFF
--- a/tally_migrator/tally/extractors.py
+++ b/tally_migrator/tally/extractors.py
@@ -1,7 +1,7 @@
 import unicodedata
 import re
 from dataclasses import dataclass, field
-from .mappings import TALLY_ROOT_PARENT, TALLY_SYSTEM_LEDGERS, classify_group
+from .mappings import TALLY_ROOT_PARENT, classify_group, is_system_ledger
 from .resolver import ACCOUNT, CUSTOMER, SUPPLIER, LedgerResolver
 
 
@@ -443,7 +443,7 @@ class TallyExtractor:
         # Ledger nodes (skip parties - handled as Customers/Suppliers - and Tally
         # system ledgers like "Profit & Loss A/c" that ERPNext derives itself).
         for l in ledgers:
-            if l["_name"] in TALLY_SYSTEM_LEDGERS:
+            if is_system_ledger(l["_name"]):
                 excluded.append({
                     "name": l["_name"],
                     "reason": "ERPNext maintains this account on its own, so it was not "

--- a/tally_migrator/tally/mappings.py
+++ b/tally_migrator/tally/mappings.py
@@ -2,10 +2,29 @@ from __future__ import annotations
 
 import re
 
+
+def norm_group(name: str) -> str:
+    """Canonical key for MATCHING a Tally group / ledger name: case- and
+    whitespace-insensitive.
+
+    Tally group names are matched against the reserved-group tables and the Sundry
+    Debtors / Creditors roots by this key, so a chart that types its groups in a
+    different case ("SUNDRY DEBTORS") or with stray / doubled spaces still classifies
+    correctly - otherwise every party under a differently-cased root imports as a plain
+    ledger instead of a Customer / Supplier. Used ONLY for lookups: the original name is
+    always what gets created in ERPNext, so the imported record keeps its Tally casing.
+    ``casefold`` (not ``lower``) so non-ASCII names fold correctly; ``" ".join(split())``
+    trims the ends and collapses internal runs of whitespace."""
+    return " ".join(str(name or "").split()).casefold()
+
+
 # ── Tally root groups that classify ledgers as customers / suppliers ──────────
 
 DEBTOR_ROOTS   = {"Sundry Debtors"}
 CREDITOR_ROOTS = {"Sundry Creditors"}
+# Normalised forms used for the actual matching (see norm_group / LedgerResolver).
+DEBTOR_ROOTS_NORM   = {norm_group(n) for n in DEBTOR_ROOTS}
+CREDITOR_ROOTS_NORM = {norm_group(n) for n in CREDITOR_ROOTS}
 
 # ── Stock vs non-stock item classification ────────────────────────────────────
 
@@ -237,6 +256,14 @@ TALLY_ROOT_PARENT = "Primary"
 # Tally system ledgers ERPNext derives itself (it computes its own P&L) - never
 # migrated as ledger Accounts.
 TALLY_SYSTEM_LEDGERS = {"Profit & Loss A/c"}
+_SYSTEM_LEDGERS_NORM = {norm_group(n) for n in TALLY_SYSTEM_LEDGERS}
+
+
+def is_system_ledger(name: str) -> bool:
+    """True for a Tally system ledger ERPNext maintains itself (e.g. "Profit & Loss
+    A/c"), matched case/whitespace-insensitively so a differently-cased export still
+    skips it rather than importing it as an ordinary account."""
+    return norm_group(name) in _SYSTEM_LEDGERS_NORM
 
 # Tally's explicit GST registration type → ERPNext GST Category. Tally states this
 # on the party ledger, so when present it is authoritative - unlike inferring the
@@ -277,11 +304,21 @@ ERPNEXT_ROOT_GROUPS: dict[str, str] = {
 }
 
 
+# Normalised-key views of the classification + alias tables, built once, so the
+# lookup is case/whitespace-insensitive (see norm_group). The aliases map a normalised
+# display variant to the normalised canonical key.
+_CLASSIFICATION_BY_NORM = {norm_group(k): v for k, v in TALLY_GROUP_CLASSIFICATION.items()}
+_ALIASES_BY_NORM = {norm_group(k): norm_group(v) for k, v in TALLY_GROUP_ALIASES.items()}
+
+
 def classify_group(name: str) -> dict | None:
     """Return the classification for a reserved Tally group, else None.
 
-    Accepts display-name aliases. ``None`` means the group is user-defined and its
-    nature must be inherited from its nearest reserved ancestor.
+    Matching is case- and whitespace-insensitive (see norm_group) and accepts display-
+    name aliases, so "Bank Accounts", "BANK ACCOUNTS" and "bank  accounts" all resolve.
+    ``None`` means the group is user-defined and its nature must be inherited from its
+    nearest reserved ancestor.
     """
-    key = TALLY_GROUP_ALIASES.get(name, name)
-    return TALLY_GROUP_CLASSIFICATION.get(key)
+    key = norm_group(name)
+    key = _ALIASES_BY_NORM.get(key, key)
+    return _CLASSIFICATION_BY_NORM.get(key)

--- a/tally_migrator/tally/resolver.py
+++ b/tally_migrator/tally/resolver.py
@@ -18,12 +18,13 @@ from dataclasses import dataclass
 
 from .mappings import (
     ASSET,
-    CREDITOR_ROOTS,
-    DEBTOR_ROOTS,
+    CREDITOR_ROOTS_NORM,
+    DEBTOR_ROOTS_NORM,
     EXPENSE,
     INCOME,
     LIABILITY,
     classify_group,
+    norm_group,
 )
 
 CUSTOMER = "customer"
@@ -77,8 +78,10 @@ class LedgerResolver:
             )
             for g in groups
         }
-        self._debtor_groups = self._descendants(DEBTOR_ROOTS)
-        self._creditor_groups = self._descendants(CREDITOR_ROOTS)
+        # Sets of NORMALISED group names under each party root (see norm_group), so a
+        # differently-cased Sundry Debtors/Creditors root still classifies its parties.
+        self._debtor_groups = self._descendants(DEBTOR_ROOTS_NORM)
+        self._creditor_groups = self._descendants(CREDITOR_ROOTS_NORM)
         self._by_name: dict[str, LedgerTarget] = {}
         for ledger in ledgers or []:
             name = ledger["_name"]
@@ -123,20 +126,30 @@ class LedgerResolver:
     # ── Internals ────────────────────────────────────────────────────────────
 
     def _classify(self, name: str, parent: str) -> LedgerTarget:
-        if parent in self._debtor_groups:
+        parent_norm = norm_group(parent)
+        if parent_norm in self._debtor_groups:
             return LedgerTarget(name, CUSTOMER)
-        if parent in self._creditor_groups:
+        if parent_norm in self._creditor_groups:
             return LedgerTarget(name, SUPPLIER)
         nature = self.group_nature(parent)
         return LedgerTarget(name, ACCOUNT, nature["root"], nature["account_type"])
 
-    def _descendants(self, roots: set[str]) -> set[str]:
-        """All groups nested under the given roots (arbitrary depth)."""
-        result, changed = set(roots), True
+    def _descendants(self, roots_norm: set[str]) -> set[str]:
+        """All groups nested under the given (normalised) root names, at any depth.
+
+        Returns a set of NORMALISED names (see norm_group). Seeded with the roots
+        themselves - so a ledger sitting directly under a root still matches even when
+        the root group is not emitted as its own node - then grown by any group whose
+        parent is already in the set. Matching on the normalised form makes the whole
+        chain case/whitespace-insensitive; because Tally is internally consistent within
+        one export (a ledger's PARENT equals its group's NAME byte-for-byte), the deeper
+        hops still line up."""
+        result, changed = set(roots_norm), True
         while changed:
             changed = False
             for name, parent in self._parent_of.items():
-                if name not in result and parent in result:
-                    result.add(name)
+                n = norm_group(name)
+                if n not in result and norm_group(parent) in result:
+                    result.add(n)
                     changed = True
         return result

--- a/tally_migrator/tests/test_coa.py
+++ b/tally_migrator/tests/test_coa.py
@@ -4,8 +4,8 @@
 import unittest
 
 from tally_migrator.tally.extractors import TallyExtractor
-from tally_migrator.tally.mappings import classify_group
-from tally_migrator.tally.resolver import LedgerResolver, CUSTOMER, ACCOUNT
+from tally_migrator.tally.mappings import classify_group, is_system_ledger
+from tally_migrator.tally.resolver import LedgerResolver, CUSTOMER, SUPPLIER, ACCOUNT
 
 
 class _Src:
@@ -55,6 +55,57 @@ class TestClassify(unittest.TestCase):
 
     def test_custom_group_is_none(self):
         self.assertIsNone(classify_group("Retail Customers"))
+
+    def test_reserved_match_is_case_and_whitespace_insensitive(self):
+        # A chart typed in another case (or with stray spaces) must still classify -
+        # otherwise account_type (Bank/Tax/Payable/...) is silently lost.
+        self.assertEqual(classify_group("BANK ACCOUNTS")["account_type"], "Bank")
+        self.assertEqual(classify_group("bank  accounts")["account_type"], "Bank")
+        self.assertEqual(classify_group("DUTIES & TAXES")["account_type"], "Tax")
+        # Aliases fold too ("Duties and Taxes" -> "Duties & Taxes").
+        self.assertEqual(classify_group("duties and taxes")["account_type"], "Tax")
+        # A genuinely custom group is still unclassified (must not false-match).
+        self.assertIsNone(classify_group("RETAIL CUSTOMERS"))
+
+    def test_system_ledger_case_insensitive(self):
+        self.assertTrue(is_system_ledger("Profit & Loss A/c"))
+        self.assertTrue(is_system_ledger("PROFIT & LOSS A/C"))
+        self.assertFalse(is_system_ledger("Sales A/c"))
+
+
+class TestCaseInsensitivePartyRoots(unittest.TestCase):
+    """Regression: parties under a differently-cased/spaced Sundry Debtors / Creditors
+    root must still classify as Customer / Supplier, not fall through to a ledger.
+    (Reported symptom: an all-caps 'SUNDRY DEBTORS' chart imported every party as an
+    Account.)"""
+
+    def test_caps_debtor_root_nested(self):
+        r = LedgerResolver(
+            [_g("SUNDRY DEBTORS", ""), _g("DEBTORS FOR BROKERAGE", "SUNDRY DEBTORS")],
+            [_l("GirishKumar", "DEBTORS FOR BROKERAGE")])
+        self.assertEqual(r.kind_of("GirishKumar"), CUSTOMER)
+
+    def test_caps_creditor_root(self):
+        r = LedgerResolver([_g("SUNDRY CREDITORS", "")], [_l("Acme Freight", "SUNDRY CREDITORS")])
+        self.assertEqual(r.kind_of("Acme Freight"), SUPPLIER)
+
+    def test_whitespace_variant_root(self):
+        r = LedgerResolver([_g("  Sundry   Debtors ", "")], [_l("WsCust", "  Sundry   Debtors ")])
+        self.assertEqual(r.kind_of("WsCust"), CUSTOMER)
+
+    def test_ledger_directly_under_root_not_emitted_as_group(self):
+        # No group node for the root at all - a ledger directly under it must still be a
+        # customer (the descendant set is seeded with the roots themselves).
+        r = LedgerResolver([], [_l("DirectCust", "Sundry Debtors")])
+        self.assertEqual(r.kind_of("DirectCust"), CUSTOMER)
+
+    def test_created_name_keeps_original_casing(self):
+        # Normalisation is for MATCHING only - the extracted account keeps Tally casing.
+        src = _Src([_g("SUNDRY DEBTORS", ""), _g("DEBTORS FOR BROKERAGE", "SUNDRY DEBTORS")],
+                   [_l("GirishKumar", "DEBTORS FOR BROKERAGE")])
+        coa = TallyExtractor(src).extract_coa()
+        names = {a.name for a in coa.accounts}
+        self.assertIn("DEBTORS FOR BROKERAGE", names)   # original casing, not folded
 
 
 class TestResolver(unittest.TestCase):


### PR DESCRIPTION
## Problem

Customer/Supplier classification and reserved-group nature were keyed on an **exact, case-sensitive** match of the Tally group name.

If a chart's `Sundry Debtors` / `Sundry Creditors` root is typed in a different case (e.g. `SUNDRY DEBTORS`) or with stray/doubled spaces, it no longer matched the hardcoded strings. Consequence: **every party beneath that root fell through and imported as a plain ledger Account instead of a Customer/Supplier.** The same fragility silently dropped `account_type` (Bank, Tax, Cash, ...) on any reserved group typed in a different case.

## Fix

- Add `norm_group()` - `casefold` + collapse whitespace - and apply it at every match site:
  - the Sundry Debtors/Creditors root detection in `LedgerResolver._descendants` / `_classify` (covers **both** debtors and creditors, at any nesting depth),
  - `classify_group()` (reserved-group nature + `account_type` + `is_reserved`),
  - the system-ledger skip (`is_system_ledger`, e.g. `Profit & Loss A/c`).
- Normalisation is used **only for matching**. The original Tally casing is preserved on everything created in ERPNext, so imported record names are unchanged.
- Title-case charts behave exactly as before (only ever makes matching more forgiving, never less; a genuinely custom group still classifies as unclassified).

## Scope note

This closes the **case/whitespace** hole. A genuinely *renamed* root (e.g. `Trade Receivables`) is a separate, additive concern (a user-mapping step) and is intentionally out of scope here.

## Tests

New regression tests: caps debtor root (nested), caps creditor root, whitespace-variant root, ledger directly under a non-emitted root, created-name casing preserved, and case-insensitive `classify_group` / `is_system_ledger`. Full suite: **645 passing**.