### PR TITLE
fix: keep stock-account openings out of the opening JE under perpetual inventory

### DIFF
--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -880,6 +880,12 @@ Migrator handles a real-world wrinkle in Tally data.
 - **Income and expense openings** cannot carry an opening balance in ERPNext, so they
   are not posted as account lines; their amount stays inside the Temporary Opening
   difference (and the reconciliation accounts for this), with a warning.
+- **Stock-account (Stock-in-Hand) openings**, on a company that uses perpetual inventory
+  (the ERPNext default), are not posted as account lines either: ERPNext only lets a
+  stock account be updated by stock transactions, not a journal entry. The amount stays
+  inside the Temporary Opening difference, with a warning, and your actual opening stock
+  is posted from your items as Stock Reconciliations (below). On a company without
+  perpetual inventory the stock ledger opening posts as a normal account line.
 - **Party openings** post bill by bill as opening invoices and payment entries, as
   described on the Preview step.
 - **Opening invoices are named after the Tally bill** so the ERPNext document id is

--- a/tally_migrator/api.py
+++ b/tally_migrator/api.py
@@ -165,7 +165,7 @@ def _compute_preflight(file_url, record_overrides, erpnext_company, posting_date
         validate_extraction(masters=masters, coa=coa), records_by_key(masters))
     payload["states"] = erpnext_states()
     payload["coverage"] = coverage_report(source)
-    payload["account_mapping"] = account_mapping(source)
+    payload["account_mapping"] = account_mapping(source, erpnext_company)
     if erpnext_company:
         payload["readiness"] = check_readiness(erpnext_company, posting_date)
     items = source.get_collection("Stock Item", ITEM_FIELDS, ITEM_TAGS)
@@ -376,7 +376,7 @@ def rerun_from_log(log_name: str):
         validation_report=log.validation_report or "",
         # Recomputed from the (unchanged) source so the new log's coverage is current.
         coverage_report=frappe.as_json(coverage_report(source)),
-        mapping_report=frappe.as_json(account_mapping(source)),
+        mapping_report=frappe.as_json(account_mapping(source, log.company)),
         # Repeat the original run's options rather than silently reverting to
         # defaults (reuse / fiscal-year start).
         coa_mode=log.coa_mode or "reuse",
@@ -881,7 +881,7 @@ def _build_masters_config(file_url, file_name, erpnext_company, source,
         # Computed server-side from the actual file so the stored audit record of
         # un-migrated fields is authoritative, not client-supplied.
         coverage_report=frappe.as_json(coverage_report(source)),
-        mapping_report=frappe.as_json(account_mapping(source)),
+        mapping_report=frappe.as_json(account_mapping(source, erpnext_company)),
         coa_mode=coa_mode if coa_mode in ("reuse", "mirror") else "reuse",
         posting_date=posting_date or "",
     )

--- a/tally_migrator/erpnext/importers/openings.py
+++ b/tally_migrator/erpnext/importers/openings.py
@@ -107,6 +107,20 @@ class OpeningBalanceImporter:
         self.company = company
         self.abbr = abbr
 
+    @property
+    def _perpetual(self) -> bool:
+        """True when the target company uses perpetual inventory (ERPNext's default),
+        resolved once per run. Fail-safe True: if the flag can't be read we assume
+        perpetual and keep stock openings out of the JE (see _account_lines), because
+        posting one under perpetual would fail the whole batch."""
+        if not hasattr(self, "_perp"):
+            try:
+                import erpnext
+                self._perp = bool(erpnext.is_perpetual_inventory_enabled(self.company))
+            except Exception:
+                self._perp = True
+        return self._perp
+
     def run(self, accounts: list, customers: list, suppliers: list,
             posting_date: str) -> ImportResult:
         result = ImportResult("Journal Entry")
@@ -276,6 +290,25 @@ class OpeningBalanceImporter:
                     "This is an income or expense account, which ERPNext does not allow "
                     f"to carry an opening balance, so {abs(node.opening_balance):,.2f} was "
                     "not posted. It is included in the Temporary Opening total instead.")
+                continue
+            # Under PERPETUAL inventory (ERPNext's default) a journal-entry line to a
+            # stock account is rejected on submit ("... can only be updated via Stock
+            # Transactions"), which would fail the WHOLE root-type batch and lose every
+            # opening balance in it. Opening stock is posted the perpetual-correct way
+            # instead - from the items, via the Opening Stock reconciliation
+            # (StockOpeningImporter) - so drop the ledger's stock opening here and disclose
+            # it: it folds into the Temporary Opening residual, exactly like the income/
+            # expense case above (reconciliation.source_totals folds it there too). Only
+            # under perpetual: a non-perpetual company allows the JE line and needs it (its
+            # stock reconciliation posts no GL), so there it stays.
+            if self._perpetual and getattr(node, "account_type", "") == "Stock":
+                result.add_warning(
+                    node.name,
+                    "This is a stock account. Under perpetual inventory ERPNext does not "
+                    "allow an opening balance to be posted to it through a journal entry - "
+                    "opening stock is posted from your items instead - so "
+                    f"{abs(node.opening_balance):,.2f} was not posted here. It is included "
+                    "in the Temporary Opening total instead.")
                 continue
             account = company_scoped(node.name, self.abbr)
             is_group = frappe.db.get_value("Account", account, "is_group")

--- a/tally_migrator/migration/account_mapping.py
+++ b/tally_migrator/migration/account_mapping.py
@@ -39,8 +39,13 @@ _PLUG_EPSILON = 0.01
 _PARTY_PLUG_THRESHOLD = 1.0
 
 
-def account_mapping(source) -> dict:
-    """Build the accounts-mapping preview for an uploaded Tally masters file."""
+def account_mapping(source, company: str = "") -> dict:
+    """Build the accounts-mapping preview for an uploaded Tally masters file.
+
+    ``company`` (the chosen ERPNext target, when known) lets the opening plug reflect the
+    company's inventory mode, so the Review-screen plug matches the post-import
+    reconciliation. Blank when no company is chosen yet - the plug then counts stock, as
+    before."""
     extractor = TallyExtractor(source)
     coa = extractor.extract_coa()
     masters = extractor.extract_all()
@@ -94,7 +99,7 @@ def account_mapping(source) -> dict:
         "inferred_count": len(inferred),
         "inferred": inferred,
         "groups": groups_out,
-        "opening": _opening_plug(coa, masters),
+        "opening": _opening_plug(coa, masters, company),
         "party_openings": _party_openings(masters, bills),
     }
 
@@ -261,7 +266,7 @@ def _party_openings(masters, bills) -> dict:
     }
 
 
-def _opening_plug(coa, masters) -> dict:
+def _opening_plug(coa, masters, company: str = "") -> dict:
     """Net residual across the whole opening trial balance → Temporary Opening.
 
     Delegates to ``reconciliation.source_totals`` so the plug shown on the Review
@@ -273,10 +278,14 @@ def _opening_plug(coa, masters) -> dict:
     ``OpeningBalanceImporter`` and ``StockOpeningImporter``). An earlier version
     here omitted opening stock and so understated the plug on any file with opening
     inventory; ``source_totals`` includes it, which is what actually posts.
-    """
-    from tally_migrator.migration.reconciliation import source_totals
 
-    totals = source_totals(coa, masters)
+    ``company`` selects the same inventory mode the import will use, so under perpetual
+    inventory a stock-account *ledger* opening folds into the plug (it is not posted to
+    the JE) exactly as the reconciliation and the importer treat it.
+    """
+    from tally_migrator.migration.reconciliation import source_totals, is_perpetual
+
+    totals = source_totals(coa, masters, perpetual=is_perpetual(company))
     temp = totals["temporary_opening"]
     plug = round(temp["amount"], 2)
     # Total opening value = the magnitude of every row in the trial balance, so the

--- a/tally_migrator/migration/reconciliation.py
+++ b/tally_migrator/migration/reconciliation.py
@@ -80,8 +80,12 @@ def _signed_of(side) -> float:
 
 # ── Source side (pure) ────────────────────────────────────────────────────────
 
-def source_totals(coa, masters) -> dict:
-    """The opening trial balance as Tally states it (extracted masters + COA)."""
+def source_totals(coa, masters, perpetual: bool = False) -> dict:
+    """The opening trial balance as Tally states it (extracted masters + COA).
+
+    ``perpetual`` mirrors the target company's inventory mode so the source side matches
+    what the migration actually posts: under perpetual inventory a stock-account opening
+    is not posted to the opening JE (it folds into Temporary Opening; see below)."""
     by_class: dict[str, float] = {c: 0.0 for c in _CLASS_ORDER}
     for a in coa.accounts:
         if a.is_group or not a.opening_balance:
@@ -92,6 +96,13 @@ def source_totals(coa, masters) -> dict:
         # class totals entirely: that folds it into the temporary_opening residual below,
         # matching what ERPNext actually holds, so the trial balance reconciles.
         if a.root_type in ("Income", "Expense"):
+            continue
+        # A stock-account opening is likewise not posted to the opening JE under perpetual
+        # inventory (ERPNext rejects a JE line to a stock account - see
+        # OpeningBalanceImporter._account_lines), so it folds into Temporary Opening the
+        # same way. The item-derived opening stock is reported on its own ``stock`` line
+        # below, so the trial balance still reconciles.
+        if perpetual and a.account_type == "Stock":
             continue
         cls = _class_of(a.root_type)
         by_class[cls] = by_class.get(cls, 0.0) + _signed(
@@ -353,6 +364,22 @@ def compare(source: dict, erp: dict) -> dict:
     }
 
 
+def is_perpetual(company: str) -> bool:
+    """Whether ``company`` uses perpetual inventory (ERPNext's default). Blank/unknown
+    -> False, so a caller without a chosen company (e.g. a pre-selection preview) keeps
+    the pre-perpetual behaviour of counting stock. A set company whose flag can't be read
+    -> True, matching OpeningBalanceImporter's fail-safe (stock kept out of the JE)."""
+    if not company:
+        return False
+    try:
+        import erpnext
+        return bool(erpnext.is_perpetual_inventory_enabled(company))
+    except Exception:
+        return True
+
+
 def build_reconciliation(company: str, abbr: str, coa, masters) -> dict:
     """Compose the source trial balance, read the ERPNext side, and compare. Read-only."""
-    return compare(source_totals(coa, masters), erpnext_totals(company, abbr))
+    return compare(
+        source_totals(coa, masters, perpetual=is_perpetual(company)),
+        erpnext_totals(company, abbr))

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -2168,3 +2168,44 @@ class TestPartyPanSanitisation(unittest.TestCase):
         doc = imp.build_doc({"_name": "_TMTest Good",
                              "INCOMETAXNumber": "AAACT2727Q"})
         self.assertEqual(doc["pan"], "AAACT2727Q")
+
+
+class TestStockOpeningExcludedUnderPerpetual(unittest.TestCase):
+    """Under perpetual inventory ERPNext rejects a journal-entry line to a stock account
+    ("... can only be updated via Stock Transactions"), which would fail the whole Asset
+    opening batch. OpeningBalanceImporter must keep stock-account openings OUT of the JE
+    (folding them into Temporary Opening, disclosed), while a non-perpetual company keeps
+    them. Proven live against ERPNext; frozen here as a unit test."""
+
+    def _nodes(self):
+        from tally_migrator.tally.extractors import AccountNode
+        mk = lambda name, atype: AccountNode(
+            name=name, parent="", is_group=False, root_type="Asset",
+            account_type=atype, is_reserved=False, opening_balance=1000.0, opening_dr_cr="Dr")
+        return [mk("_TMTest Bank", "Bank"), mk("_TMTest Stock In Hand", "Stock")]
+
+    def _lines(self, perpetual):
+        from unittest import mock
+        from tally_migrator.erpnext.importers.openings import OpeningBalanceImporter
+        from tally_migrator.erpnext.importers.base import ImportResult
+        imp = OpeningBalanceImporter("_TMTest Co", "TMT")
+        imp._perp = perpetual   # bypass the live is_perpetual_inventory_enabled read
+        result = ImportResult("Journal Entry")
+        # Every referenced account "exists" and is a ledger (is_group=0), so line-building
+        # proceeds; the stock skip happens before this lookup.
+        with mock.patch("frappe.db.get_value", return_value=0):
+            lines = imp._account_lines(self._nodes(), result)
+        return [l["account"] for l in lines], result
+
+    def test_stock_ledger_excluded_and_warned_when_perpetual(self):
+        accounts, result = self._lines(perpetual=True)
+        self.assertTrue(any("_TMTest Bank" in a for a in accounts))
+        self.assertFalse(any("Stock In Hand" in a for a in accounts),
+                         "stock ledger must be kept out of the opening JE under perpetual")
+        self.assertTrue(any("stock account" in w["reason"].lower() for w in result.warnings),
+                        "the excluded stock opening must be disclosed as a warning")
+
+    def test_stock_ledger_kept_when_not_perpetual(self):
+        accounts, _ = self._lines(perpetual=False)
+        self.assertTrue(any("Stock In Hand" in a for a in accounts),
+                        "a non-perpetual company allows and needs the JE stock line")

--- a/tally_migrator/tests/test_reconciliation.py
+++ b/tally_migrator/tests/test_reconciliation.py
@@ -65,6 +65,23 @@ class TestSourceTotals(unittest.TestCase):
         # Only the asset (10200 Dr) drives the contra; the P&L lines are folded in.
         self.assertEqual(s["temporary_opening"], {"amount": 10200.0, "dr_cr": "Cr"})
 
+    def test_stock_ledger_folds_into_temp_only_under_perpetual(self):
+        # A stock-account ledger opening is posted to the JE under PERIODIC inventory but
+        # NOT under perpetual (ERPNext rejects a JE line to a stock account), where it
+        # folds into Temporary Opening like a P&L opening. source_totals must mirror the
+        # importer so the trial balance reconciles either way.
+        stock = AccountNode(name="Stock In Hand", parent="", is_group=False,
+                            root_type="Asset", account_type="Stock", is_reserved=False,
+                            opening_balance=1000.0, opening_dr_cr="Dr")
+        coa = _coa([_acct("HDFC Bank", "Asset", 5000, "Dr"), stock])
+        # Periodic: stock counted in the Asset class (bank + stock = 6000).
+        peri = _classes(source_totals(coa, _masters(), perpetual=False))
+        self.assertEqual(peri["Asset"], {"amount": 6000.0, "dr_cr": "Dr"})
+        # Perpetual: stock excluded from Asset (bank only), folded into Temporary Opening.
+        perp = source_totals(coa, _masters(), perpetual=True)
+        self.assertEqual(_classes(perp)["Asset"], {"amount": 5000.0, "dr_cr": "Dr"})
+        self.assertEqual(perp["temporary_opening"], {"amount": 5000.0, "dr_cr": "Cr"})
+
     def test_liability_and_equity_merge_into_one_class(self):
         # Tally calls capital Equity, ERPNext often roots it under Liability; merging
         # them avoids a false mismatch. A loan (Liability) + capital (Equity) net into


### PR DESCRIPTION
## Problem

Under perpetual inventory (ERPNext's default), a journal-entry line to a stock account is rejected on submit ("... can only be updated via Stock Transactions"). The opening-balance importer posts one JE per root type, so a single stock-in-hand ledger opening fails the **entire Asset batch** - losing every opening balance in it.

## Fix

When the target company uses perpetual inventory, a stock-account (`account_type = "Stock"`) ledger opening is not posted to the opening JE. It folds into the Temporary Opening residual (exactly like income/expense openings already do) and is disclosed with a warning. The actual opening stock is posted the perpetual-correct way - from the items, via Stock Reconciliation.

On a company **without** perpetual inventory, behaviour is unchanged: the stock ledger opening posts as a normal JE account line (its stock reconciliation posts no GL).

- Fail-safe: if the perpetual flag can't be read for a set company, it's treated as perpetual (stock kept out of the JE), since posting it would fail the batch.
- `reconciliation.source_totals` and the Review-screen opening plug mirror the same inventory mode, so the trial balance reconciles either way.

## Validation

- Verified live against ERPNext: a JE line to a stock account under perpetual throws `StockAccountInvalidTransaction`; with the fix the Asset batch submits, stock is excluded with a warning, and the JE carries only the non-stock lines.
- Full test suite green (648 tests). New unit tests cover the perpetual/non-perpetual split in both the importer and the reconciliation.
- Docs updated.