### PR TITLE
fix: run the Step-1 file preview asynchronously so a large export cannot time out

### DIFF
--- a/tally_migrator/api.py
+++ b/tally_migrator/api.py
@@ -30,11 +30,76 @@ def preview_masters_file(file_url: str):
     Read-only: imports nothing. Lets the user confirm the file is valid and see
     record counts (customers / suppliers / items / warehouses) *before* running
     the migration, so there are no surprises.
+
+    Status-wrapped exactly like ``validate_masters_data`` so a large export can never
+    time the web request out: a small plain file is counted inline ('ready'); a large
+    file (or a zip / remote link) is counted once in a background job and cached in
+    Redis - 'running' while it computes, then 'ready' with the counts or 'failed' with a
+    reason. The wizard polls this endpoint until it leaves 'running'. A failure is
+    reported honestly, never as an empty (zero-count) 'ready'.
     """
     frappe.only_for(ALLOWED_ROLES)
+    file_doc = _resolve_file_doc(file_url)
+    _assert_file_access(file_doc)
+    # Small file: count inline (fast, no timeout risk).
+    if not _should_run_async(file_doc):
+        try:
+            return {"status": "ready", **_compute_preview(file_url)}
+        except Exception as exc:
+            frappe.log_error(f"preview (inline) failed: {exc}", "Tally Migrator")
+            return {"status": "failed", "error": _preflight_error_message(exc)}
+
+    # Large file: the parse can exceed the web request timeout, so count it once in a
+    # background job and cache the result (shared across workers). The wizard polls.
+    key = _preview_key(file_doc)
+    cached = frappe.cache().get_value(key)
+    if cached:
+        return cached
+    # Mark running before enqueuing so concurrent polls don't each enqueue; the
+    # key-derived job_id + deduplicate close the double-enqueue window. On 'default'
+    # (not 'short'): a large-book parse can run for minutes, which the short queue
+    # is not for.
+    frappe.cache().set_value(key, {"status": "running"}, expires_in_sec=_PREFLIGHT_TTL)
+    frappe.enqueue(
+        "tally_migrator.api._run_preview_job", queue="default", timeout=30 * 60,
+        job_id=f"preview::{key}", deduplicate=True,
+        key=key, file_url=file_url)
+    return {"status": "running"}
+
+
+def _preview_key(file_doc) -> str:
+    """Redis key for a preview result, unique to the file version and the user. Unlike
+    the pre-flight key it depends on neither company nor inline edits (the preview shows
+    only raw record counts), so re-entering the upload step reuses the same result and a
+    new upload (new File / modified) never serves a stale one."""
+    h = hashlib.sha1(
+        f"{file_doc.name}|{file_doc.modified}|{frappe.session.user}".encode()).hexdigest()
+    return f"tally_preview:{h}"
+
+
+def _compute_preview(file_url) -> dict:
+    """The upload-step record counts (customers / suppliers / items / warehouses /
+    accounts), from a single parse. Writes nothing."""
     _, source = _source_from_file(file_url)
     extractor = TallyExtractor(source)
     return {**extractor.extract_all().summary, **extractor.extract_coa().summary}
+
+
+def _run_preview_job(key, file_url):
+    """Background worker: count the file once and cache the result (or a failure), so the
+    polling wizard picks it up. Off the web request, so a large file can't time it out."""
+    try:
+        payload = _compute_preview(file_url)
+        frappe.cache().set_value(
+            key, {"status": "ready", **payload}, expires_in_sec=_PREFLIGHT_TTL)
+    except Exception as exc:
+        frappe.log_error(f"preview job failed: {exc}", "Tally Migrator")
+        # Cache the failure (short TTL) so the wizard shows 'couldn't read' instead of
+        # polling forever, and a retry can recompute soon.
+        frappe.cache().set_value(
+            key, {"status": "failed", "error": _preflight_error_message(exc)},
+            expires_in_sec=120)
+        raise
 
 
 @frappe.whitelist(methods=["GET", "POST"])

--- a/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
+++ b/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
@@ -464,49 +464,86 @@ class TallyMigratorPage {
 			.show()
 			.html(`<span class="text-muted"><span class="tm-spin"></span> &nbsp;Reading your file...</span>`);
 		$("#btn-next-upload").prop("disabled", true);
+		// Capture the file this preview is for, so a slow poll for an earlier upload can
+		// never overwrite the box after the user has uploaded a different file. Reset the
+		// poll ceiling for this fresh preview.
+		this._previewUrl = this.fileUrl;
+		this._previewPoll = 0;
+		this._pollPreview();
+	}
 
+	_pollPreview() {
+		// preview_masters_file is status-wrapped like the Step-3 scan: a large file counts
+		// in the background and this endpoint returns 'running' until it is done. Poll
+		// until 'ready' or 'failed'. Reading counts never times the request out now.
+		const startedFor = this._previewUrl;
 		frappe.call({
 			method: "tally_migrator.api.preview_masters_file",
-			args: { file_url: this.fileUrl },
+			args: { file_url: startedFor },
 			callback: (r) => {
-				const p = r.message || {};
-				this.preview = p;
-				// Now that we know whether the file carries accounts, refresh the
-				// stepper so its step count is stable from here on (no 4 -> 5 jump).
-				this.renderStepper("section-upload");
-				const masters =
-					(p.customers || 0) + (p.suppliers || 0) + (p.items || 0) + (p.warehouses || 0);
-				const accounts = (p.account_groups || 0) + (p.ledger_accounts || 0);
-				if (masters === 0 && accounts === 0) {
-					// Nothing at all - the export is empty or not a masters export.
-					$("#preview-box").html(
-						TallyMigratorPage.callout("error", TallyMigratorPage.iconRow("error", `We read the file, but found no Accounts, Customers, Suppliers, Items or Warehouses in it. Make sure you exported <strong>Masters</strong> (with <strong>Show All Masters = Yes</strong>) from Tally.`))
-					);
-					$("#btn-next-upload").prop("disabled", true);
-					return;
-				}
-				if (masters === 0) {
-					// Accounts but no business masters - a valid chart-of-accounts-only
-					// export, but a common sign the user exported a narrower scope than
-					// intended. Allow it, but ask them to confirm before spending a run.
-					$("#preview-box").html(
-						TallyMigratorPage.callout("info", TallyMigratorPage.iconRow("info", `<strong>This looks like a chart-of-accounts-only export.</strong> We found accounts and opening balances, but no Customers, Suppliers, Items or Warehouses. If that is what you intended, continue. If you expected those too, re-export from Tally with <strong>Show All Masters = Yes</strong> and upload again.${this.countsHtml(p)}`))
-					);
-					$("#btn-next-upload").prop("disabled", false);
-					return;
-				}
-				$("#preview-box").html(
-					TallyMigratorPage.callout("success", TallyMigratorPage.iconRow("success", `<strong>File read successfully.</strong> Here's what we found:${this.countsHtml(p)}`))
-				);
-				$("#btn-next-upload").prop("disabled", false);
+				if (this._previewUrl !== startedFor) return;   // a newer upload took over
+				this._onPreview(r.message || {});
 			},
+			// A transport/500 error IS a failed read - surface it honestly.
 			error: () => {
-				$("#preview-box").html(
-					TallyMigratorPage.callout("error", TallyMigratorPage.iconRow("error", `We couldn't read this file. Please make sure it's a valid Tally <strong>Masters XML</strong> export and upload it again.`))
-				);
-				$("#btn-next-upload").prop("disabled", true);
+				if (this._previewUrl !== startedFor) return;
+				this._onPreviewFailed();
 			},
 		});
+	}
+
+	_onPreview(p) {
+		if (p.status === "running") {
+			// Still counting in the background - poll again, with a ceiling so a stuck
+			// scan surfaces as "couldn't read" rather than spinning forever.
+			if (++this._previewPoll > 150) {   // ~5 min at 2s
+				return this._onPreviewFailed(
+					__("Reading your file is taking longer than expected. Please try again."));
+			}
+			return setTimeout(() => this._pollPreview(), 2000);
+		}
+		if (p.status === "failed") {
+			return this._onPreviewFailed(p.error);
+		}
+		// status === "ready": a genuine, complete count.
+		this.preview = p;
+		// Now that we know whether the file carries accounts, refresh the stepper so its
+		// step count is stable from here on (no 4 -> 5 jump).
+		this.renderStepper("section-upload");
+		const masters =
+			(p.customers || 0) + (p.suppliers || 0) + (p.items || 0) + (p.warehouses || 0);
+		const accounts = (p.account_groups || 0) + (p.ledger_accounts || 0);
+		if (masters === 0 && accounts === 0) {
+			// Nothing at all - the export is empty or not a masters export.
+			$("#preview-box").html(
+				TallyMigratorPage.callout("error", TallyMigratorPage.iconRow("error", `We read the file, but found no Accounts, Customers, Suppliers, Items or Warehouses in it. Make sure you exported <strong>Masters</strong> (with <strong>Show All Masters = Yes</strong>) from Tally.`))
+			);
+			$("#btn-next-upload").prop("disabled", true);
+			return;
+		}
+		if (masters === 0) {
+			// Accounts but no business masters - a valid chart-of-accounts-only export,
+			// but a common sign the user exported a narrower scope than intended. Allow
+			// it, but ask them to confirm before spending a run.
+			$("#preview-box").html(
+				TallyMigratorPage.callout("info", TallyMigratorPage.iconRow("info", `<strong>This looks like a chart-of-accounts-only export.</strong> We found accounts and opening balances, but no Customers, Suppliers, Items or Warehouses. If that is what you intended, continue. If you expected those too, re-export from Tally with <strong>Show All Masters = Yes</strong> and upload again.${this.countsHtml(p)}`))
+			);
+			$("#btn-next-upload").prop("disabled", false);
+			return;
+		}
+		$("#preview-box").html(
+			TallyMigratorPage.callout("success", TallyMigratorPage.iconRow("success", `<strong>File read successfully.</strong> Here's what we found:${this.countsHtml(p)}`))
+		);
+		$("#btn-next-upload").prop("disabled", false);
+	}
+
+	_onPreviewFailed(reason) {
+		const esc = frappe.utils.escape_html;
+		const detail = reason ? ` ${esc(reason)}` : "";
+		$("#preview-box").html(
+			TallyMigratorPage.callout("error", TallyMigratorPage.iconRow("error", `We couldn't read this file.${detail} Please make sure it's a valid Tally <strong>Masters XML</strong> export and upload it again.`))
+		);
+		$("#btn-next-upload").prop("disabled", true);
 	}
 
 	countsHtml(p) {

--- a/tally_migrator/tests/test_preflight.py
+++ b/tally_migrator/tests/test_preflight.py
@@ -114,6 +114,84 @@ class TestPreflightJob(unittest.TestCase):
         self.assertIn("nope", cache.store["K"]["error"])
 
 
+class TestPreviewOrchestrator(unittest.TestCase):
+    """Step-1 preview is status-wrapped like the Step-3 scan so a large file cannot time
+    the web request out: small inline (ready), large async (running -> cached
+    ready/failed), and a failure is reported honestly, never as an empty 'ready'."""
+
+    def setUp(self):
+        self.p_resolve = mock.patch.object(api, "_resolve_file_doc", return_value=_file())
+        self.p_access = mock.patch.object(api, "_assert_file_access")
+        self.p_only = mock.patch.object(api.frappe, "only_for")
+        self.p_resolve.start(); self.p_access.start(); self.p_only.start()
+
+    def tearDown(self):
+        mock.patch.stopall()
+
+    def test_small_file_ready_with_counts(self):
+        with mock.patch.object(api, "_should_run_async", return_value=False), \
+             mock.patch.object(api, "_compute_preview",
+                               return_value={"customers": 3, "ledger_accounts": 5}):
+            out = api.preview_masters_file("/files/x.xml")
+        self.assertEqual(out["status"], "ready")
+        self.assertEqual(out["customers"], 3)
+
+    def test_small_file_failure_is_honest(self):
+        with mock.patch.object(api, "_should_run_async", return_value=False), \
+             mock.patch.object(api, "_compute_preview", side_effect=ValueError("bad xml")), \
+             mock.patch.object(api.frappe, "log_error"):
+            out = api.preview_masters_file("/files/x.xml")
+        self.assertEqual(out["status"], "failed")
+        self.assertIn("bad xml", out["error"])
+        self.assertNotIn("customers", out)       # no partial counts on failure
+
+    def test_large_file_enqueues_and_returns_running(self):
+        cache = _FakeCache()
+        with mock.patch.object(api, "_should_run_async", return_value=True), \
+             mock.patch.object(api.frappe, "cache", return_value=cache), \
+             mock.patch.object(api.frappe, "enqueue") as enq:
+            out = api.preview_masters_file("/files/big.zip")
+        self.assertEqual(out["status"], "running")
+        enq.assert_called_once()
+        self.assertTrue(any(v.get("status") == "running" for _, v, _ in cache.sets))
+
+    def test_large_file_returns_cached_ready_without_reenqueue(self):
+        key = api._preview_key(_file())
+        cache = _FakeCache({key: {"status": "ready", "customers": 9}})
+        with mock.patch.object(api, "_should_run_async", return_value=True), \
+             mock.patch.object(api.frappe, "cache", return_value=cache), \
+             mock.patch.object(api.frappe, "enqueue") as enq:
+            out = api.preview_masters_file("/files/big.zip")
+        self.assertEqual(out["status"], "ready")
+        self.assertEqual(out["customers"], 9)
+        enq.assert_not_called()
+
+    def test_preview_key_independent_of_company_and_edits(self):
+        # The preview counts depend on neither the company nor inline edits, so the key
+        # is stable across them (unlike the pre-flight key) - one parse serves the step.
+        self.assertEqual(api._preview_key(_file()), api._preview_key(_file()))
+
+
+class TestPreviewJob(unittest.TestCase):
+    def test_job_caches_ready_on_success(self):
+        cache = _FakeCache()
+        with mock.patch.object(api.frappe, "cache", return_value=cache), \
+             mock.patch.object(api, "_compute_preview", return_value={"items": 7}):
+            api._run_preview_job("K", "/f.xml")
+        self.assertEqual(cache.store["K"]["status"], "ready")
+        self.assertEqual(cache.store["K"]["items"], 7)
+
+    def test_job_caches_failed_and_reraises(self):
+        cache = _FakeCache()
+        with mock.patch.object(api.frappe, "cache", return_value=cache), \
+             mock.patch.object(api.frappe, "log_error"), \
+             mock.patch.object(api, "_compute_preview", side_effect=RuntimeError("nope")):
+            with self.assertRaises(RuntimeError):
+                api._run_preview_job("K", "/f.xml")
+        self.assertEqual(cache.store["K"]["status"], "failed")
+        self.assertIn("nope", cache.store["K"]["error"])
+
+
 class TestPreflightKey(unittest.TestCase):
     def test_key_changes_with_inputs(self):
         base = api._preflight_key(_file(), "", "Co", "2026-01-01")


### PR DESCRIPTION
## Problem

The upload-step preview (`preview_masters_file`) parsed the entire masters file inside the web request to show record counts. On a large export that parse can exceed the request timeout, so the user saw "we couldn't read this file" for a file that is actually fine.

## Fix

Status-wrap the preview exactly like the Step-3 pre-flight scan already is:

- A small plain file is counted **inline** (`ready`).
- A large file (or a zip / remote link) is counted **once in a background job** and cached in Redis: `running` while it computes, then `ready` with the counts or `failed` with a reason.
- The wizard polls the endpoint until the status leaves `running` (with a ceiling so a stuck scan surfaces as a read failure rather than spinning forever).
- A failure is reported honestly, never as an empty zero-count `ready`.
- A stale-upload guard drops a slow poll belonging to an earlier file, so it can't overwrite the box after the user has uploaded a different file.

The cache key is namespaced separately from the pre-flight key and depends only on the file version + user (the preview counts depend on neither company nor inline edits), so re-entering the upload step reuses the same result and a new upload never serves a stale one.

## Validation

- Full test suite green (655). New orchestrator + job tests mirror the pre-flight ones (small inline ready, honest failure, large async enqueue-once, cached ready without re-enqueue, key stability).
- Live endpoint returns `{status: "ready", ...counts}` for a small file.