### PR TITLE
fix: set the target company on company Bank Accounts

### DIFF
--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -838,10 +838,12 @@ Migrator handles a real-world wrinkle in Tally data.
 - **Account ordering.** Groups are created parent-before-child, and any circular
   parent loop is broken rather than crashing (with a pre-flight warning).
 - **Bank ledgers.** A Tally bank ledger carrying the company's own account number and
-  IFSC creates a company Bank Account linked to that GL account. When several bank
-  ledgers share the same account-holder name (Tally often repeats it), each still gets
-  its own Bank Account - the name is made unique with the account number, so no
-  ledger's bank details are lost to a name clash.
+  IFSC creates a company Bank Account linked to that GL account and tied to the company
+  you are migrating into (so on a multi-company site it lands under the right company,
+  not whichever one happens to be your default). When several bank ledgers share the same
+  account-holder name (Tally often repeats it), each still gets its own Bank Account - the
+  name is made unique with the account number, so no ledger's bank details are lost to a
+  name clash.
 - **Cost centres** import flat or nested, under the company's root cost centre.
 - **Warehouses / godowns** import with their full nesting. A godown that is the parent
   of another is created as a group warehouse so the tree renders correctly. Each

--- a/tally_migrator/erpnext/importers/accounts.py
+++ b/tally_migrator/erpnext/importers/accounts.py
@@ -279,6 +279,7 @@ class AccountImporter:
             account_no=node.bank_account_no,
             ifsc=node.bank_ifsc,
             gl_account=account_name,        # link to the GL account just created
+            company=self.company,           # same company the GL account was created under
             is_company=True,
             result=result,
             warn_name=node.name,

--- a/tally_migrator/erpnext/importers/banks.py
+++ b/tally_migrator/erpnext/importers/banks.py
@@ -92,16 +92,17 @@ def _ensure_bank(bank_name: str, result: "ImportResult | None" = None, *,
 def _insert_bank_account(*, account_name: str, bank: str, account_no: str,
                          ifsc: str, result: "ImportResult", warn_name: str,
                          party_type: str = "", party: str = "",
-                         gl_account: str = "", is_company: bool = False,
+                         gl_account: str = "", company: str = "",
+                         is_company: bool = False,
                          count_created: bool = False) -> str:
     """Insert one Bank Account doc, shared by the party and company bank paths.
 
     Both paths build the same doc (account name + bank + account no + IFSC) and
     differ only in how it's linked: a party account points at a Customer/Supplier
     (``party_type``/``party``), a company account at the GL account and sets
-    ``is_company_account`` (``gl_account``/``is_company``). Non-fatal - a failure
-    is logged, recorded as a warning, rolled back, and "" returned so a Bank
-    Account quirk never aborts the party/account that was just created.
+    ``is_company_account`` + ``company`` (``gl_account``/``company``/``is_company``).
+    Non-fatal - a failure is logged, recorded as a warning, rolled back, and "" returned
+    so a Bank Account quirk never aborts the party/account that was just created.
     """
     try:
         # Savepoint-isolated (see _ensure_bank): a failure rolls back only this Bank
@@ -119,6 +120,16 @@ def _insert_bank_account(*, account_name: str, bank: str, account_no: str,
             if is_company:
                 ba.account = gl_account
                 ba.is_company_account = 1
+                # ERPNext requires company on a company Bank Account
+                # (BankAccount.validate_is_company_account throws otherwise), and never
+                # cross-checks it against the GL account's company. Set it explicitly to
+                # the migration's target company - the same company the GL account was
+                # created under - instead of relying on frappe.new_doc's ambient default
+                # (the global/user default), which is blank on a site with no default set
+                # (hard failure) or the wrong company on a multi-company site (silent
+                # mis-attribution to whichever company happens to be the default).
+                if company:
+                    ba.company = company
             else:
                 ba.party_type = party_type
                 ba.party = party

--- a/tally_migrator/tests/test_bank_commit_batching.py
+++ b/tally_migrator/tests/test_bank_commit_batching.py
@@ -69,6 +69,57 @@ class TestBankHelpersCommitOnlyForCompany(unittest.TestCase):
         commit.assert_not_called()
 
 
+class TestCompanyBankAccountSetsCompany(unittest.TestCase):
+    """A company Bank Account must carry ``company`` explicitly: ERPNext requires it on a
+    company account and never cross-checks it against the GL account, so leaning on
+    frappe.new_doc's ambient default is a bug (blank on a no-default site -> hard failure;
+    the wrong company on a multi-company site -> silent mis-attribution). A party account
+    must NOT get a company (a party's bank account is not company-bound). The pre-existing
+    mocked tests could not see this - a MagicMock swallows every attribute - so this fake
+    records exactly which fields the helper assigns."""
+
+    class _RecordingDoc:
+        def __init__(self):
+            object.__setattr__(self, "assigned", {})
+            object.__setattr__(self, "name", "BA-0001")
+
+        def __setattr__(self, key, value):
+            if key not in ("assigned", "name"):
+                self.assigned[key] = value
+            object.__setattr__(self, key, value)
+
+        def insert(self, **kwargs):
+            pass
+
+    def _assigned_fields(self, *, is_company, company="_TMTest Target Co"):
+        doc = self._RecordingDoc()
+        res = ImportResult("Account")
+        with mock.patch.object(banks, "atomic", _noop_atomic), \
+                mock.patch.object(banks, "frappe") as fr:
+            fr.new_doc.return_value = doc
+            fr.db.exists.return_value = False   # bank account name is free
+            banks._insert_bank_account(
+                account_name="Acme", bank="HDFC Bank", account_no="123", ifsc="",
+                result=res, warn_name="Acme",
+                gl_account="Bank - AC" if is_company else "",
+                company=company if is_company else "",
+                party_type="" if is_company else "Customer",
+                party="" if is_company else "Acme",
+                is_company=is_company, count_created=is_company)
+        return doc.assigned
+
+    def test_company_path_sets_company_and_flag(self):
+        assigned = self._assigned_fields(is_company=True, company="_TMTest Target Co")
+        self.assertEqual(assigned.get("company"), "_TMTest Target Co")
+        self.assertEqual(assigned.get("is_company_account"), 1)
+        self.assertEqual(assigned.get("account"), "Bank - AC")
+
+    def test_party_path_does_not_set_company(self):
+        assigned = self._assigned_fields(is_company=False)
+        self.assertNotIn("company", assigned)
+        self.assertEqual(assigned.get("party_type"), "Customer")
+
+
 class TestUniqueBankAccountName(unittest.TestCase):
     """Tally repeats one holder name across several bank ledgers of a company; since
     ERPNext names a Bank Account 'account_name - bank', they would collide and all but

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -2209,3 +2209,86 @@ class TestStockOpeningExcludedUnderPerpetual(unittest.TestCase):
         accounts, _ = self._lines(perpetual=False)
         self.assertTrue(any("Stock In Hand" in a for a in accounts),
                         "a non-perpetual company allows and needs the JE stock line")
+
+
+class TestCompanyBankAccountCompany(unittest.TestCase):
+    """A company Bank Account must carry the migration's TARGET company, not whatever
+    frappe.new_doc's ambient default happens to be. ERPNext requires ``company`` on a
+    company account and never cross-checks it against the linked GL account, so the old
+    code (which set neither) worked only by luck of a matching default - blank on a
+    no-default site (every company bank account fails), or the wrong company on a
+    multi-company site (silent mis-attribution). This exercises the REAL ERPNext
+    validation with the ambient default neutralised, so only the explicit company arg can
+    make the doc valid - which the fully-mocked unit tests can never do."""
+
+    BANK = "_TMTest Bank Co"
+
+    def setUp(self):
+        frappe.set_user("Administrator")
+        self.company = require_company()
+        self.abbr = frappe.get_cached_value("Company", self.company, "abbr")
+        self.gl_name = f"_TMTest Bank Ledger - {self.abbr}"
+        self._cleanup()
+        if not frappe.db.exists("Bank", self.BANK):
+            frappe.get_doc({"doctype": "Bank", "bank_name": self.BANK}).insert(
+                ignore_permissions=True)
+        parent = frappe.get_all(
+            "Account",
+            filters={"company": self.company, "is_group": 1, "root_type": "Asset"},
+            pluck="name", limit=1)[0]
+        self.gl = frappe.get_doc({
+            "doctype": "Account", "account_name": "_TMTest Bank Ledger",
+            "company": self.company, "parent_account": parent,
+            "account_type": "Bank", "is_group": 0,
+        }).insert(ignore_permissions=True).name
+        frappe.db.commit()
+
+    def tearDown(self):
+        self._cleanup()
+
+    def _cleanup(self):
+        # Bank Accounts first (they reference the GL account and the Bank), then the
+        # account, then the Bank. The importer commits, so rollback alone is insufficient.
+        for ba in frappe.get_all(
+                "Bank Account", filters={"account_name": ["like", "_TMTest%"]}, pluck="name"):
+            try:
+                frappe.delete_doc("Bank Account", ba, force=True, ignore_permissions=True)
+            except Exception:
+                pass
+        for acc in (self.gl_name, f"_TMTest Bank Ledger - {self.abbr}"):
+            if frappe.db.exists("Account", acc):
+                try:
+                    frappe.delete_doc("Account", acc, force=True, ignore_permissions=True)
+                except Exception:
+                    pass
+        if frappe.db.exists("Bank", self.BANK):
+            try:
+                frappe.delete_doc("Bank", self.BANK, force=True, ignore_permissions=True)
+            except Exception:
+                pass
+        frappe.db.commit()
+
+    def test_company_bank_account_uses_target_company_despite_wrong_default(self):
+        from unittest import mock
+        from tally_migrator.erpnext.importers.banks import _insert_bank_account
+        from tally_migrator.erpnext.importers.base import ImportResult
+
+        res = ImportResult("Account")
+        # Point the ambient default company at a non-existent name: create_new.get_new_doc
+        # only auto-fills a Link default when the target exists, so new_doc leaves company
+        # blank - simulating a no-default site. Old code would then fail ERPNext's
+        # "Company is mandatory for company account"; the fix sets it explicitly.
+        defaults = {**frappe.defaults.get_defaults(), "company": "__TM No Such Company__"}
+        with mock.patch("frappe.defaults.get_defaults", return_value=defaults):
+            name = _insert_bank_account(
+                account_name="_TMTest Holder", bank=self.BANK, account_no="000111",
+                ifsc="", result=res, warn_name="_TMTest Holder",
+                gl_account=self.gl, company=self.company,
+                is_company=True, count_created=True)
+
+        self.assertTrue(
+            name, f"company bank account was not created; warnings={res.warnings}")
+        self.assertEqual(
+            frappe.db.get_value("Bank Account", name, "company"), self.company,
+            "Bank Account must carry the migration target company, not the ambient default")
+        self.assertEqual(frappe.db.get_value("Bank Account", name, "account"), self.gl)


### PR DESCRIPTION
## Problem

A Tally bank ledger carrying the company's own account number creates a **company Bank Account** (`is_company_account`) linked to its GL account. The importer set the account link and the flag but **never set `company`**, relying on `frappe.new_doc`'s ambient default (the global/user default company).

ERPNext's `BankAccount.validate_is_company_account` **requires** `company` on a company account and does **not** cross-check it against the linked GL account. So the ambient default was load-bearing, and wrong in two real cases:

- **No global/user default company on the site** - `company` blank - ERPNext throws `Company is mandatory for company account` - **every company Bank Account fails** to a warning (the GL account still lands).
- **Multi-company site**, or a user whose default differs from the company chosen in the wizard - the Bank Account is **silently attached to the wrong company** while pointing at the right GL account (ERPNext never flags the mismatch).

## Fix

Set `company` explicitly to the migration target - the same company the GL account was created under - threaded through `_insert_bank_account`. The party path is unchanged (a party's bank account is not company-bound).

## Tests

- **Unit** (`test_bank_commit_batching.py`): a recording-fake doc asserts the company path sets `company` + `is_company_account` and the party path sets neither. The pre-existing mocked tests used a `MagicMock` that swallowed every attribute, which is exactly why the missing company was invisible.
- **Integration** (`test_importer.py`, bench tier): creates a real company Bank Account with the ambient default company **neutralised**, so only the explicit `company` arg can make the doc valid. Verified it **fails on the old code** with the exact ERPNext error and **passes with the fix**.
- Full suite green (658). Docs updated.