### PR TITLE
feat: import Tally BOM co-products, by-products, and scrap as secondary items

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ even when your ERPNext is hosted in the cloud and your Tally is on an office PC.
 | Stock items | Items, with their units, HSN codes, and GST tax rates |
 | Units of measure | UOMs, including the GST unit codes (UQC) needed for returns |
 | Price levels (Retail, Wholesale, MRP) | Price Lists, Item Prices, and discount Pricing Rules |
-| Bills of Materials | BOMs (including multiple BOMs per item) |
+| Bills of Materials | BOMs (multiple per item, with co-products, by-products, and scrap) |
 | Batch-tracked stock | Batches, with manufacturing and expiry dates |
 | Chart of accounts and cost centres | Accounts and Cost Centers |
 | Warehouses / godowns | Warehouses (including parent/child groups) |
@@ -47,8 +47,8 @@ trial balance next to what landed in ERPNext, so you can confirm the books match
 Tally Migrator focuses on migrating masters and opening balances, not historical
 transactions such as Sales Invoices, Purchase Invoices, Payments, or Journal Entries.
 GST-specific fields require the India Compliance app. The app is currently built and
-tested for Indian users on ERPNext v16 and Tally Prime. Features such as TDS/TCS,
-HR/Payroll, and BOM co-products, by-products, and scrap are not yet supported.
+tested for Indian users on ERPNext v16 and Tally Prime. Features such as TDS/TCS and
+HR/Payroll are not yet supported.
 Foreign-currency advances and custom fields (UDFs) are also left out. Anything that is
 skipped is recorded in the Migration Log, so nothing disappears silently.
 

--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -106,8 +106,6 @@ the Migration Log rather than dropping them silently.
   carrying payroll fields (gender, PF number, bank, dates of birth and joining).
   The cost centres themselves import, but these HR fields do not. Bring employees
   across separately through HR / Payroll.
-- **Co-products, by-products, and scrap in a BOM.** Only true Component rows are
-  imported into the ERPNext BOM. The others are skipped with a warning.
 - **Foreign-currency advances.** A foreign-currency receivable or payable invoice
   is migrated; a foreign-currency advance or credit is flagged for you to enter
   manually.
@@ -855,8 +853,10 @@ Migrator handles a real-world wrinkle in Tally data.
 
 - Each Tally BOM becomes a submitted, active ERPNext BOM. The first BOM per item is
   the default; multiple BOMs per item are supported.
-- Only true **Component** rows are imported. Co-products, by-products, and scrap are
-  skipped with a warning.
+- **Component** rows become the BOM's raw materials. **Co-Product**, **By-Product**, and
+  **Scrap** rows become the BOM's secondary items, each carrying the cost-allocation
+  percentage set in Tally; ERPNext reduces the finished good's own share so the total
+  stays 100%. A row with an unrecognised type is skipped with a warning.
 - A component that is not found as an item, or that is the finished item itself
   (a self-reference), or that has no quantity, is skipped with a warning.
 - If a component's quantity is in a unit different from its stock unit, the BOM still

--- a/tally_migrator/erpnext/importers/bom.py
+++ b/tally_migrator/erpnext/importers/bom.py
@@ -5,14 +5,25 @@ import frappe
 from tally_migrator.naming import safe_item_code
 from .base import BaseImporter, ImportResult
 
+# Tally BOM "Type of Item" (NATUREOFITEM, normalised by _norm_nature) -> ERPNext
+# BOM Secondary Item.type. Verified against a real TallyPrime export: the raw values are
+# exactly "Component" / "Co-Product" / "By-Product" / "Scrap", and ERPNext's type options
+# ("Co-Product" / "By-Product" / "Scrap" / "Additional Finished Good") match the first
+# three verbatim. "Component" is not here - those rows are the BOM's raw materials.
+_SECONDARY_TYPE = {"coproduct": "Co-Product", "byproduct": "By-Product", "scrap": "Scrap"}
+
 
 class BomImporter:
     """Create ERPNext BOMs from Tally bills of materials.
 
     Each Tally BOM becomes a submitted, active BOM; the first BOM per item is the
-    default. Runs after Items so the finished item and components exist. Only
-    NATUREOFITEM=Component rows are migrated; by-products/co-products/scrap are
-    skipped with a warning (no fixture coverage to build secondary_items against).
+    default. Runs after Items so the finished item and components exist. Tally's
+    NATUREOFITEM classifies each row: "Component" rows become the BOM's raw materials
+    (``items``), while "Co-Product" / "By-Product" / "Scrap" rows become ``secondary_items``
+    carrying their cost-allocation percentage (Tally's ADDLCOSTALLOCPERC -> ERPNext's
+    cost_allocation_per). ERPNext auto-reduces the finished good's own allocation so the
+    total stays 100%. The type strings map verbatim (verified against a real TallyPrime
+    export); an unrecognised type is skipped with a warning.
 
     Idempotent by skip-if-exists: BOM names auto-increment, so a re-run would
     create duplicates; if any BOM already exists for an item we skip it entirely.
@@ -46,10 +57,12 @@ class BomImporter:
         return result
 
     def _import_bom(self, result, code, item_name, bom, is_default):
-        rows, warns = self._component_rows(code, bom.get("components") or [])
+        rows, secondary_rows, warns = self._classify_rows(code, bom.get("components") or [])
         for w in warns:
             result.add_warning(item_name, w)
         if not rows:
+            # A BOM needs at least one raw material; a Tally BOM with only secondaries
+            # (or no usable component) can't post, so skip it (its warnings are recorded).
             result.add_warning(item_name, "BOM skipped - no usable Component rows.")
             return
         qty, uom = self._parse_qty_uom(bom.get("basic_qty"))
@@ -58,6 +71,12 @@ class BomImporter:
             "quantity": qty or 1, "currency": self.currency, "conversion_rate": 1,
             "is_active": 1, "is_default": 1 if is_default else 0, "items": rows,
         }
+        if secondary_rows:
+            # Co-Product / By-Product / Scrap. Only type/item_code/qty/cost_allocation_per
+            # are supplied; ERPNext fills uom, conversion_factor, and the derived costs, and
+            # reduces the finished good's cost_allocation_per so the total is 100% (verified
+            # live against ERPNext's BOM.set_fg_cost_allocation / validate_total_cost_allocation).
+            doc["secondary_items"] = secondary_rows
         if uom and frappe.db.exists("UOM", uom):
             doc["uom"] = uom
         try:
@@ -70,14 +89,23 @@ class BomImporter:
             frappe.db.rollback()
             result.add_error(f"{item_name} (BOM {bom.get('name')})", exc)
 
-    def _component_rows(self, finished_code, components):
-        rows, warns = [], []
+    def _classify_rows(self, finished_code, components):
+        """Split a Tally BOM's rows into ERPNext raw materials (``items``) and secondary
+        outputs (``secondary_items``) by NATUREOFITEM. Returns (rows, secondary_rows, warns).
+
+        Shares the same per-row guards for both (item must exist, not be the finished item
+        itself, and carry a quantity). Secondary rows additionally carry the cost-allocation
+        percentage; ERPNext derives their uom/conversion/cost, so only type/item_code/qty/
+        cost_allocation_per are supplied (verified live)."""
+        rows, secondary_rows, warns = [], [], []
         for c in components:
             nature = (c.get("natureofitem") or "Component").strip()
             cname = (c.get("stockitemname") or "").strip()
-            if nature.lower() != "component":
-                warns.append(f"component '{cname}' is a {nature}, not migrated "
-                             "(only Components are imported into the BOM).")
+            norm = self._norm_nature(nature)
+            sec_type = _SECONDARY_TYPE.get(norm)
+            if norm != "component" and not sec_type:
+                warns.append(f"BOM row '{cname}' has an unrecognised type '{nature}' "
+                             "- skipped.")
                 continue
             ccode = safe_item_code(cname)
             if not frappe.db.exists("Item", ccode):
@@ -100,8 +128,32 @@ class BomImporter:
                         "defines that conversion - verify the BOM quantity.")
             else:
                 uom = stock_uom
-            rows.append({"item_code": ccode, "qty": qty, "uom": uom})
-        return rows, warns
+            if sec_type:
+                secondary_rows.append({
+                    "type": sec_type, "item_code": ccode, "qty": qty,
+                    "cost_allocation_per": self._parse_percent(c.get("addlcostallocperc")),
+                })
+            else:
+                rows.append({"item_code": ccode, "qty": qty, "uom": uom})
+        return rows, secondary_rows, warns
+
+    @staticmethod
+    def _norm_nature(nature: str) -> str:
+        """Normalise a Tally NATUREOFITEM for lookup: lowercase, drop spaces/hyphens/
+        underscores. 'Co-Product' -> 'coproduct', 'By-Product' -> 'byproduct'."""
+        return "".join((nature or "").lower().split()).replace("-", "").replace("_", "")
+
+    @staticmethod
+    def _parse_percent(raw) -> float:
+        """'20' / ' 20 ' / '20%' -> 20.0; blank/garbage -> 0.0 (a valid allocation that
+        ERPNext accepts - the finished good simply keeps that share)."""
+        raw = (raw or "").strip()
+        if not raw:
+            return 0.0
+        try:
+            return float(raw.replace(",", "").replace("%", "").strip())
+        except ValueError:
+            return 0.0
 
     @staticmethod
     def _parse_qty_uom(raw):

--- a/tally_migrator/tally/file_source.py
+++ b/tally_migrator/tally/file_source.py
@@ -567,8 +567,11 @@ class FileTallySource:
         Reads Tally bills of materials from MULTICOMPONENTLIST.LIST (Tally supports
         multiple BOMs per item), each carrying COMPONENTLISTNAME, COMPONENTBASICQTY
         ("1 Nos" = qty the BOM makes) and MULTICOMPONENTITEMLIST.LIST components
-        (NATUREOFITEM / STOCKITEMNAME / GODOWNNAME / ACTUALQTY "1 Ream"). The legacy
-        empty COMPONENTLIST.LIST is ignored. Raw strings; the importer parses qty/uom."""
+        (NATUREOFITEM / STOCKITEMNAME / GODOWNNAME / ACTUALQTY "1 Ream", plus
+        ADDLCOSTALLOCPERC - the cost-allocation percentage Tally records only on a
+        Co-Product / By-Product / Scrap row, verified against a real TallyPrime export).
+        The legacy empty COMPONENTLIST.LIST is ignored. Raw strings; the importer
+        parses qty/uom/percent."""
         out: dict = {}
         for elem in self._by_tag.get("STOCKITEM", ()):
             name = (elem.get("NAME") or elem.findtext("NAME") or "").strip()
@@ -590,7 +593,8 @@ class FileTallySource:
                         row = {}
                         for c in ch:
                             ct = c.tag.split("}")[-1].upper()
-                            if ct in ("NATUREOFITEM", "STOCKITEMNAME", "GODOWNNAME", "ACTUALQTY"):
+                            if ct in ("NATUREOFITEM", "STOCKITEMNAME", "GODOWNNAME",
+                                      "ACTUALQTY", "ADDLCOSTALLOCPERC"):
                                 row[ct.lower()] = (c.text or "").strip()
                         if row.get("stockitemname"):
                             comps.append(row)

--- a/tally_migrator/tests/test_bom.py
+++ b/tally_migrator/tests/test_bom.py
@@ -4,8 +4,9 @@ Phase 5 tests: Tally multi-component lists -> ERPNext BOM.
 Covers the two guards live re-validation proved necessary: a component UOM that
 differs from the item's stock UOM is kept but WARNED (ERPNext silently assumes
 1:1, so it needs review), and a self-referential component is explicitly skipped
-(ERPNext does not reject it). Plus skip-if-exists idempotency and skip+warn for
-non-Component natures.
+(ERPNext does not reject it). Plus skip-if-exists idempotency, and the Co-Product /
+By-Product / Scrap mapping to ERPNext secondary_items (structure verified against a
+real TallyPrime export; the ERPNext side verified live).
 """
 import types
 import unittest
@@ -18,6 +19,8 @@ from tally_migrator.erpnext.importers import ImportResult
 
 class TestBomExtraction(unittest.TestCase):
     def test_reads_multicomponent_ignores_empty_legacy_list(self):
+        # Component + a Scrap secondary carrying ADDLCOSTALLOCPERC, in the exact tag shape
+        # of a real TallyPrime export (a single MULTICOMPONENTITEMLIST.LIST per row).
         xml = (
             '<ENVELOPE><BODY><IMPORTDATA><REQUESTDATA><TALLYMESSAGE>'
             '<STOCKITEM NAME="Kit"><NAME>Kit</NAME>'
@@ -27,14 +30,22 @@ class TestBomExtraction(unittest.TestCase):
             '<MULTICOMPONENTITEMLIST.LIST><NATUREOFITEM>Component</NATUREOFITEM>'
             '<STOCKITEMNAME>A4 Paper Ream</STOCKITEMNAME><GODOWNNAME>Main</GODOWNNAME>'
             '<ACTUALQTY> 1 Ream</ACTUALQTY></MULTICOMPONENTITEMLIST.LIST>'
+            '<MULTICOMPONENTITEMLIST.LIST><NATUREOFITEM>Scrap</NATUREOFITEM>'
+            '<STOCKITEMNAME>Offcut</STOCKITEMNAME><GODOWNNAME>Main</GODOWNNAME>'
+            '<ADDLCOSTALLOCPERC> 2</ADDLCOSTALLOCPERC>'
+            '<ACTUALQTY> 1 Nos</ACTUALQTY></MULTICOMPONENTITEMLIST.LIST>'
             '</MULTICOMPONENTLIST.LIST></STOCKITEM>'
             '</TALLYMESSAGE></REQUESTDATA></IMPORTDATA></BODY></ENVELOPE>'
         )
         boms = FileTallySource(xml).item_boms()["Kit"]
         self.assertEqual(len(boms), 1)
         self.assertEqual(boms[0]["basic_qty"], "1 Nos")
-        self.assertEqual(boms[0]["components"][0]["stockitemname"], "A4 Paper Ream")
-        self.assertEqual(boms[0]["components"][0]["actualqty"], "1 Ream")
+        comps = boms[0]["components"]
+        self.assertEqual(comps[0]["stockitemname"], "A4 Paper Ream")
+        self.assertEqual(comps[0]["actualqty"], "1 Ream")
+        # The Scrap row's cost-allocation percentage is now captured.
+        self.assertEqual(comps[1]["natureofitem"], "Scrap")
+        self.assertEqual(comps[1]["addlcostallocperc"], "2")
 
 
 class TestParseQtyUom(unittest.TestCase):
@@ -45,23 +56,46 @@ class TestParseQtyUom(unittest.TestCase):
         self.assertEqual(BomImporter._parse_qty_uom(""), (0.0, ""))
 
 
-class TestComponentRows(unittest.TestCase):
+class TestParsePercent(unittest.TestCase):
+    def test_parse(self):
+        self.assertEqual(BomImporter._parse_percent(" 20"), 20.0)
+        self.assertEqual(BomImporter._parse_percent("5%"), 5.0)
+        self.assertEqual(BomImporter._parse_percent(""), 0.0)
+        self.assertEqual(BomImporter._parse_percent("junk"), 0.0)
+
+
+class TestNormNature(unittest.TestCase):
+    def test_norm(self):
+        self.assertEqual(BomImporter._norm_nature("Co-Product"), "coproduct")
+        self.assertEqual(BomImporter._norm_nature("By-Product"), "byproduct")
+        self.assertEqual(BomImporter._norm_nature(" Scrap "), "scrap")
+        self.assertEqual(BomImporter._norm_nature("Component"), "component")
+
+
+class TestClassifyRows(unittest.TestCase):
     def _imp(self):
         with mock.patch("frappe.get_cached_value", return_value="INR"):
             return BomImporter("Frappe Tech", "FT")
 
-    def test_guards(self):
+    def test_components_and_secondaries_split_with_guards(self):
         imp = self._imp()
         comps = [
             {"natureofitem": "Component",  "stockitemname": "A", "actualqty": "2 Box"},
-            {"natureofitem": "By-Product", "stockitemname": "BP", "actualqty": "1 Nos"},
+            {"natureofitem": "Co-Product", "stockitemname": "CO", "actualqty": "1 Nos",
+             "addlcostallocperc": " 20"},
+            {"natureofitem": "By-Product", "stockitemname": "BP", "actualqty": "1 Nos",
+             "addlcostallocperc": " 5"},
+            {"natureofitem": "Scrap",      "stockitemname": "SC", "actualqty": "1 Nos",
+             "addlcostallocperc": " 2"},
+            {"natureofitem": "Mystery",    "stockitemname": "MY", "actualqty": "1 Nos"},  # unknown
             {"natureofitem": "Component",  "stockitemname": "Missing", "actualqty": "1 Nos"},
             {"natureofitem": "Component",  "stockitemname": "Kit", "actualqty": "1 Nos"},   # self
             {"natureofitem": "Component",  "stockitemname": "C", "actualqty": "1 Nos"},     # uom mismatch
             {"natureofitem": "Component",  "stockitemname": "D", "actualqty": ""},          # no qty
         ]
-        existing = {"A", "C", "Kit", "D"}
-        stock = {"A": "Box", "C": "Box", "Kit": "Nos", "D": "Nos"}
+        existing = {"A", "CO", "BP", "SC", "MY", "C", "Kit", "D"}
+        stock = {"A": "Box", "CO": "Nos", "BP": "Nos", "SC": "Nos", "MY": "Nos",
+                 "C": "Box", "Kit": "Nos", "D": "Nos"}
 
         def fake_exists(dt, name=None):
             if dt == "Item":
@@ -71,14 +105,22 @@ class TestComponentRows(unittest.TestCase):
             return False
         with mock.patch("frappe.db.exists", side_effect=fake_exists), \
                 mock.patch("frappe.db.get_value", side_effect=lambda d, n, f: stock.get(n)):
-            rows, warns = imp._component_rows("Kit", comps)
+            rows, secondary_rows, warns = imp._classify_rows("Kit", comps)
 
+        # Components -> items (uom resolved; the mismatch one kept + warned).
         self.assertEqual(rows, [
             {"item_code": "A", "qty": 2.0, "uom": "Box"},
             {"item_code": "C", "qty": 1.0, "uom": "Nos"},     # kept, but warned
         ])
+        # Co-/By-/Scrap -> secondary_items with type + cost_allocation_per (no uom: ERPNext
+        # derives it), verbatim ERPNext type names.
+        self.assertEqual(secondary_rows, [
+            {"type": "Co-Product", "item_code": "CO", "qty": 1.0, "cost_allocation_per": 20.0},
+            {"type": "By-Product", "item_code": "BP", "qty": 1.0, "cost_allocation_per": 5.0},
+            {"type": "Scrap",      "item_code": "SC", "qty": 1.0, "cost_allocation_per": 2.0},
+        ])
         joined = " ".join(warns)
-        self.assertIn("By-Product", joined)          # non-Component skipped
+        self.assertIn("unrecognised type 'Mystery'", joined)  # unknown nature skipped
         self.assertIn("Missing", joined)             # missing item skipped
         self.assertIn("self-reference", joined)      # self skipped
         self.assertIn("stock unit is 'Box'", joined)  # C uom mismatch warned

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -2292,3 +2292,82 @@ class TestCompanyBankAccountCompany(unittest.TestCase):
             frappe.db.get_value("Bank Account", name, "company"), self.company,
             "Bank Account must carry the migration target company, not the ambient default")
         self.assertEqual(frappe.db.get_value("Bank Account", name, "account"), self.gl)
+
+
+class TestBomSecondaryItemsIntegration(unittest.TestCase):
+    """Tally's Co-Product / By-Product / Scrap BOM rows must become ERPNext
+    ``secondary_items`` with the right type and cost-allocation percentage. This builds a
+    real, submitted BOM through the importer and asserts the rows landed - the tag shape is
+    from a real TallyPrime export and the ERPNext behaviour (auto-derived uom/cost, and the
+    finished good's allocation auto-reduced so the total is 100%) was verified live."""
+
+    ITEMS = ["_TMBom FG", "_TMBom RM1", "_TMBom RM2",
+             "_TMBom Co", "_TMBom By", "_TMBom Scrap"]
+
+    def setUp(self):
+        frappe.set_user("Administrator")
+        self.company = require_company()
+        self.hsn = (frappe.get_all("GST HSN Code", pluck="name", limit=1) or [None])[0]
+        grp = frappe.get_all("Item Group", filters={"is_group": 0}, pluck="name", limit=1)[0]
+        self._cleanup()
+        for code in self.ITEMS:
+            doc = {"doctype": "Item", "item_code": code, "item_name": code,
+                   "item_group": grp, "stock_uom": "Nos", "is_stock_item": 1,
+                   "valuation_rate": 100}
+            if self.hsn:                     # India Compliance makes HSN mandatory
+                doc["gst_hsn_code"] = self.hsn
+            frappe.get_doc(doc).insert(ignore_permissions=True)
+        frappe.db.commit()
+
+    def tearDown(self):
+        self._cleanup()
+
+    def _cleanup(self):
+        for name in frappe.get_all("BOM", filters={"item": ["like", "_TMBom%"]}, pluck="name"):
+            try:
+                d = frappe.get_doc("BOM", name)
+                if d.docstatus == 1:
+                    d.cancel()
+                frappe.delete_doc("BOM", name, force=True, ignore_permissions=True)
+            except Exception:
+                pass
+        for code in self.ITEMS:
+            if frappe.db.exists("Item", code):
+                try:
+                    frappe.delete_doc("Item", code, force=True, ignore_permissions=True)
+                except Exception:
+                    pass
+        frappe.db.commit()
+
+    def test_secondary_items_created_with_type_and_allocation(self):
+        from tally_migrator.erpnext.importers.bom import BomImporter
+        abbr = frappe.get_cached_value("Company", self.company, "abbr")
+        items = [{"_name": "_TMBom FG", "Boms": [{
+            "name": "_TMBom FG BOM", "basic_qty": "1 Nos", "components": [
+                {"natureofitem": "Component", "stockitemname": "_TMBom RM1", "actualqty": "2 Nos"},
+                {"natureofitem": "Component", "stockitemname": "_TMBom RM2", "actualqty": "1 Nos"},
+                {"natureofitem": "Co-Product", "stockitemname": "_TMBom Co",
+                 "actualqty": "1 Nos", "addlcostallocperc": " 20"},
+                {"natureofitem": "By-Product", "stockitemname": "_TMBom By",
+                 "actualqty": "1 Nos", "addlcostallocperc": " 5"},
+                {"natureofitem": "Scrap", "stockitemname": "_TMBom Scrap",
+                 "actualqty": "1 Nos", "addlcostallocperc": " 2"},
+            ]}]}]
+        res = BomImporter(self.company, abbr).run(items)
+        self.assertEqual(res.created, 1, f"BOM not created; warnings={res.warnings}")
+
+        bom_name = frappe.db.get_value("BOM", {"item": "_TMBom FG"}, "name")
+        self.assertTrue(bom_name)
+        bom = frappe.get_doc("BOM", bom_name)
+        # Raw materials only in `items`, secondaries only in `secondary_items`.
+        self.assertEqual({r.item_code for r in bom.items}, {"_TMBom RM1", "_TMBom RM2"})
+        by_item = {s.item_code: s for s in bom.secondary_items}
+        self.assertEqual(by_item["_TMBom Co"].type, "Co-Product")
+        self.assertEqual(by_item["_TMBom Co"].cost_allocation_per, 20.0)
+        self.assertEqual(by_item["_TMBom By"].type, "By-Product")
+        self.assertEqual(by_item["_TMBom By"].cost_allocation_per, 5.0)
+        self.assertEqual(by_item["_TMBom Scrap"].type, "Scrap")
+        self.assertEqual(by_item["_TMBom Scrap"].cost_allocation_per, 2.0)
+        # ERPNext reduced the finished good's own allocation so the total is 100%.
+        self.assertEqual(bom.cost_allocation_per, 73.0)
+        self.assertEqual(bom.docstatus, 1)          # submitted + active


### PR DESCRIPTION
## Summary

Tally BOM rows classified as **Co-Product / By-Product / Scrap** are now imported as ERPNext BOM **`secondary_items`** (previously only `Component` rows were imported; the rest were skipped with a warning because the tag shape had never been confirmed against a real export).

## Validated against real data

Built after reading a **real TallyPrime masters export**:
- `NATUREOFITEM` values are exactly `Component` / `Co-Product` / `By-Product` / `Scrap`.
- All four rows live in the same `MULTICOMPONENTITEMLIST.LIST`.
- Only the three secondary rows carry `ADDLCOSTALLOCPERC` (the cost-allocation %).
- ERPNext's `BOM Secondary Item.type` options (`Co-Product` / `By-Product` / `Scrap`) match verbatim.

And a **live probe against ERPNext** confirmed the write side: supplying only `type` / `item_code` / `qty` / `cost_allocation_per` is enough - ERPNext derives `uom`, `conversion_factor`, and the costs, and reduces the finished good's own `cost_allocation_per` so the total stays 100% (e.g. secondaries at 20/5/2% ⇒ finished good auto-set to 73%).

## Changes

- **Parser** (`file_source.py`): capture `ADDLCOSTALLOCPERC` alongside the existing component tags.
- **Importer** (`bom.py`): split rows by `NATUREOFITEM`; `Component` → raw materials (`items`), secondaries → `secondary_items` with type + `cost_allocation_per`. Existing per-row guards (item exists, not the finished item, has quantity, uom-mismatch warning) apply to both. A BOM still needs at least one raw material to post; an unrecognised type is skipped with a warning.

## Tests

- Extraction asserts `ADDLCOSTALLOCPERC` is captured (real tag shape).
- Classifier test: component/secondary split, all guards, and an unrecognised type.
- **Bench-tier integration test**: builds a real submitted BOM with all three secondary types and asserts the rows, allocations, and the auto-reduced finished-good share.
- Full suite green (661). Docs + README updated.