### PR TITLE
fix: keep a BOM when its Tally secondary allocations exceed 100%

### DIFF
--- a/tally_migrator/erpnext/importers/bom.py
+++ b/tally_migrator/erpnext/importers/bom.py
@@ -65,6 +65,24 @@ class BomImporter:
             # (or no usable component) can't post, so skip it (its warnings are recorded).
             result.add_warning(item_name, "BOM skipped - no usable Component rows.")
             return
+        if secondary_rows:
+            # ERPNext derives the finished good's own cost allocation as 100% minus the
+            # secondaries' total, and rejects the whole BOM if that goes negative ("% Cost
+            # Allocation cannot be negative" - verified live). Tally's per-row Rate (%) are
+            # independent recoveries and are NOT constrained to sum to <=100, so a real book
+            # can exceed it. Rather than lose the entire BOM (components included), drop the
+            # secondaries, keep the BOM, and say so - scaling the percentages would silently
+            # misrepresent the source figures. Exactly 100% is allowed (finished good = 0),
+            # so only a genuine overage trips this (epsilon guards float noise).
+            total_alloc = sum(s["cost_allocation_per"] for s in secondary_rows)
+            if total_alloc > 100 + 1e-6:
+                result.add_warning(
+                    item_name,
+                    f"BOM {bom.get('name')}: its co-product/by-product/scrap cost "
+                    f"allocations add up to {total_alloc:g}%, over 100%, which ERPNext will "
+                    "not accept - the BOM was imported with its components only. Add the "
+                    "secondary items manually in ERPNext if you need them.")
+                secondary_rows = []
         qty, uom = self._parse_qty_uom(bom.get("basic_qty"))
         doc = {
             "doctype": "BOM", "item": code, "company": self.company,

--- a/tally_migrator/tests/test_bom.py
+++ b/tally_migrator/tests/test_bom.py
@@ -179,5 +179,54 @@ class TestBomImporterRun(unittest.TestCase):
         self.assertEqual(res.skipped, 1)
 
 
+class TestSecondaryAllocationGuard(unittest.TestCase):
+    """Tally's per-row Rate (%) are independent and NOT constrained to sum to <=100.
+    ERPNext rejects the whole BOM when the secondaries' total cost allocation exceeds 100%
+    (the finished good's share would go negative - verified live). The importer must then
+    keep the BOM with its components only (never lose it) and warn; exactly 100% is fine."""
+
+    def _run(self, secondaries):
+        with mock.patch("frappe.get_cached_value", return_value="INR"):
+            imp = BomImporter("Frappe Tech", "FT")
+        comps = [{"natureofitem": "Component", "stockitemname": "RM", "actualqty": "2 Nos"}]
+        comps += secondaries
+        items = [{"_name": "FG", "Boms": [{"name": "FG BOM", "basic_qty": "1 Nos",
+                                           "components": comps}]}]
+        captured = {}
+
+        def fake_get_doc(d):
+            captured["doc"] = d
+            return types.SimpleNamespace(name="BOM-FG-001",
+                                         insert=lambda **k: None, submit=lambda: None)
+
+        def fake_exists(dt, filt=None):
+            if dt == "BOM":
+                return False
+            return True                       # Item + UOM exist
+        with mock.patch("frappe.db.exists", side_effect=fake_exists), \
+                mock.patch("frappe.db.get_value", return_value="Nos"), \
+                mock.patch("frappe.get_doc", side_effect=fake_get_doc), \
+                mock.patch("frappe.db.commit"):
+            res = imp.run(items)
+        return captured.get("doc"), res
+
+    def _sec(self, pct):
+        return {"natureofitem": "Co-Product", "stockitemname": f"S{pct}",
+                "actualqty": "1 Nos", "addlcostallocperc": str(pct)}
+
+    def test_over_100_drops_secondaries_keeps_bom_and_warns(self):
+        doc, res = self._run([self._sec(60), self._sec(30), self._sec(20)])  # 110%
+        self.assertEqual(res.created, 1)                       # BOM still created
+        self.assertNotIn("secondary_items", doc)               # secondaries dropped
+        self.assertEqual(doc["items"], [{"item_code": "RM", "qty": 2.0, "uom": "Nos"}])
+        self.assertTrue(any("over 100%" in w["reason"] for w in res.warnings))
+
+    def test_exactly_100_keeps_secondaries(self):
+        doc, res = self._run([self._sec(50), self._sec(50)])   # 100%
+        self.assertEqual(res.created, 1)
+        self.assertEqual(len(doc["secondary_items"]), 2)
+        self.assertFalse(any("over 100%" in w["reason"] for w in res.warnings))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

Follow-up to #69 (BOM co-product/by-product/scrap import). ERPNext derives a BOM's finished-good cost allocation as `100% - sum(secondary allocations)` and rejects the whole BOM if that goes negative (`% Cost Allocation cannot be negative`).

Tally's per-row **Rate (%)** on a co-product/by-product/scrap are *independent* cost recoveries and are **not** constrained to sum to <=100, so a real book can exceed it. The importer passed them straight through, so such a BOM failed to insert and was dropped **entirely as an error** - losing its raw-material components too, not just the secondaries.

## Fix

When the secondaries' cost allocations sum to **more than 100%**, drop the secondary rows, import the BOM with its components, and warn with the actual total so the user can add them manually. The percentages are **not scaled** (that would silently misrepresent the Tally figures). Exactly 100% is allowed (finished good = 0), so only a genuine overage trips the guard; a `1e-6` epsilon absorbs float noise.

## Validation

- ERPNext behaviour confirmed **live**: `cost_allocation_per` default is 100; a total of 100% is accepted (finished good = 0); 100.5% / 110% are rejected.
- Salvage path proven **end-to-end** against ERPNext: a 110% BOM now imports with `created=1, errors=0`, component kept, secondaries dropped, warning raised (same input pre-fix gave `created=0, errors=1`).
- Unit tests: sum>100 drops secondaries + keeps the BOM + warns; sum==100 keeps them. Negative-checked (the over-100 test fails without the guard).
- Full suite green (663). No regression - the guard only activates when secondaries exist and exceed 100%.