### PR TITLE
fix: address Greptile review findings on the recent PRs

### DIFF
--- a/tally_migrator/api.py
+++ b/tally_migrator/api.py
@@ -60,10 +60,18 @@ def preview_masters_file(file_url: str):
     # (not 'short'): a large-book parse can run for minutes, which the short queue
     # is not for.
     frappe.cache().set_value(key, {"status": "running"}, expires_in_sec=_PREFLIGHT_TTL)
-    frappe.enqueue(
-        "tally_migrator.api._run_preview_job", queue="default", timeout=30 * 60,
-        job_id=f"preview::{key}", deduplicate=True,
-        key=key, file_url=file_url)
+    try:
+        frappe.enqueue(
+            "tally_migrator.api._run_preview_job", queue="default", timeout=30 * 60,
+            job_id=f"preview::{key}", deduplicate=True,
+            key=key, file_url=file_url)
+    except Exception:
+        # The enqueue itself can fail (e.g. the background queue is saturated - a real,
+        # observed condition on big books). Don't strand the 'running' marker for its full
+        # TTL, or every later poll reads 'running' and the wizard shows a valid file as
+        # unreadable with no way to retry. Clear it so the next attempt re-enqueues.
+        frappe.cache().delete_value(key)
+        raise
     return {"status": "running"}
 
 
@@ -191,11 +199,18 @@ def validate_masters_data(file_url: str, record_overrides: str = "", erpnext_com
     # parking a long parse there would starve it. deduplicate + a key-derived job_id
     # closes the small window where two near-simultaneous first polls could both enqueue.
     frappe.cache().set_value(key, {"status": "running"}, expires_in_sec=_PREFLIGHT_TTL)
-    frappe.enqueue(
-        "tally_migrator.api._run_preflight_job", queue="default", timeout=30 * 60,
-        job_id=f"preflight::{key}", deduplicate=True,
-        key=key, file_url=file_url, record_overrides=record_overrides,
-        erpnext_company=erpnext_company, posting_date=posting_date)
+    try:
+        frappe.enqueue(
+            "tally_migrator.api._run_preflight_job", queue="default", timeout=30 * 60,
+            job_id=f"preflight::{key}", deduplicate=True,
+            key=key, file_url=file_url, record_overrides=record_overrides,
+            erpnext_company=erpnext_company, posting_date=posting_date)
+    except Exception:
+        # See preview_masters_file: a failed enqueue must not strand the 'running' marker,
+        # or the wizard polls a good file forever and reports it unreadable. Clear it so a
+        # retry re-enqueues.
+        frappe.cache().delete_value(key)
+        raise
     return {"status": "running"}
 
 

--- a/tally_migrator/erpnext/importers/bom.py
+++ b/tally_migrator/erpnext/importers/bom.py
@@ -73,9 +73,14 @@ class BomImporter:
             # can exceed it. Rather than lose the entire BOM (components included), drop the
             # secondaries, keep the BOM, and say so - scaling the percentages would silently
             # misrepresent the source figures. Exactly 100% is allowed (finished good = 0),
-            # so only a genuine overage trips this (epsilon guards float noise).
+            # so only a genuine overage trips this. ERPNext computes the finished good's
+            # share with the same float arithmetic we use here (100 - total), so matching
+            # its exact boundary means never keeping a set it will reject: any total above
+            # 100 - however small - fails there (verified: 100.0000001 is rejected), so a
+            # strict > 100 mirrors it. (An earlier epsilon here kept totals in (100, 100+eps]
+            # that ERPNext then rejected, losing the whole BOM.)
             total_alloc = sum(s["cost_allocation_per"] for s in secondary_rows)
-            if total_alloc > 100 + 1e-6:
+            if total_alloc > 100:
                 result.add_warning(
                     item_name,
                     f"BOM {bom.get('name')}: its co-product/by-product/scrap cost "
@@ -147,8 +152,12 @@ class BomImporter:
             else:
                 uom = stock_uom
             if sec_type:
+                # Pass uom like a component row (not stock_uom-only): ERPNext otherwise
+                # interprets the quantity in the item's stock unit and records the wrong
+                # output quantity. conversion_factor is left for ERPNext to default (1),
+                # the same 1:1 assumption components make - the mismatch above is warned.
                 secondary_rows.append({
-                    "type": sec_type, "item_code": ccode, "qty": qty,
+                    "type": sec_type, "item_code": ccode, "qty": qty, "uom": uom,
                     "cost_allocation_per": self._parse_percent(c.get("addlcostallocperc")),
                 })
             else:

--- a/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
+++ b/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
@@ -464,35 +464,36 @@ class TallyMigratorPage {
 			.show()
 			.html(`<span class="text-muted"><span class="tm-spin"></span> &nbsp;Reading your file...</span>`);
 		$("#btn-next-upload").prop("disabled", true);
-		// Capture the file this preview is for, so a slow poll for an earlier upload can
-		// never overwrite the box after the user has uploaded a different file. Reset the
-		// poll ceiling for this fresh preview.
+		// Tag this preview with a fresh generation. A superseded chain (an earlier upload
+		// whose 2s timer is still pending) carries an older generation and bails, so it
+		// can neither overwrite the box nor spawn a second chain that shares - and races
+		// down - the poll ceiling. Reset the ceiling for this fresh preview.
 		this._previewUrl = this.fileUrl;
 		this._previewPoll = 0;
-		this._pollPreview();
+		this._previewGen = (this._previewGen || 0) + 1;
+		this._pollPreview(this._previewGen);
 	}
 
-	_pollPreview() {
+	_pollPreview(gen) {
 		// preview_masters_file is status-wrapped like the Step-3 scan: a large file counts
 		// in the background and this endpoint returns 'running' until it is done. Poll
 		// until 'ready' or 'failed'. Reading counts never times the request out now.
-		const startedFor = this._previewUrl;
 		frappe.call({
 			method: "tally_migrator.api.preview_masters_file",
-			args: { file_url: startedFor },
+			args: { file_url: this._previewUrl },
 			callback: (r) => {
-				if (this._previewUrl !== startedFor) return;   // a newer upload took over
-				this._onPreview(r.message || {});
+				if (gen !== this._previewGen) return;   // a newer upload superseded this chain
+				this._onPreview(r.message || {}, gen);
 			},
 			// A transport/500 error IS a failed read - surface it honestly.
 			error: () => {
-				if (this._previewUrl !== startedFor) return;
+				if (gen !== this._previewGen) return;
 				this._onPreviewFailed();
 			},
 		});
 	}
 
-	_onPreview(p) {
+	_onPreview(p, gen) {
 		if (p.status === "running") {
 			// Still counting in the background - poll again, with a ceiling so a stuck
 			// scan surfaces as "couldn't read" rather than spinning forever.
@@ -500,7 +501,7 @@ class TallyMigratorPage {
 				return this._onPreviewFailed(
 					__("Reading your file is taking longer than expected. Please try again."));
 			}
-			return setTimeout(() => this._pollPreview(), 2000);
+			return setTimeout(() => this._pollPreview(gen), 2000);
 		}
 		if (p.status === "failed") {
 			return this._onPreviewFailed(p.error);

--- a/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
+++ b/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
@@ -475,6 +475,10 @@ class TallyMigratorPage {
 	}
 
 	_pollPreview(gen) {
+		// A superseded timer (an earlier upload's pending re-poll) bails here, BEFORE the
+		// request goes out, so it doesn't send a redundant preview call that re-parses a
+		// small file server-side only to be discarded.
+		if (gen !== this._previewGen) return;
 		// preview_masters_file is status-wrapped like the Step-3 scan: a large file counts
 		// in the background and this endpoint returns 'running' until it is done. Poll
 		// until 'ready' or 'failed'. Reading counts never times the request out now.

--- a/tally_migrator/tests/test_bom.py
+++ b/tally_migrator/tests/test_bom.py
@@ -112,12 +112,12 @@ class TestClassifyRows(unittest.TestCase):
             {"item_code": "A", "qty": 2.0, "uom": "Box"},
             {"item_code": "C", "qty": 1.0, "uom": "Nos"},     # kept, but warned
         ])
-        # Co-/By-/Scrap -> secondary_items with type + cost_allocation_per (no uom: ERPNext
-        # derives it), verbatim ERPNext type names.
+        # Co-/By-/Scrap -> secondary_items with type + qty + uom (passed like components so
+        # ERPNext does not force the stock unit) + cost_allocation_per; verbatim type names.
         self.assertEqual(secondary_rows, [
-            {"type": "Co-Product", "item_code": "CO", "qty": 1.0, "cost_allocation_per": 20.0},
-            {"type": "By-Product", "item_code": "BP", "qty": 1.0, "cost_allocation_per": 5.0},
-            {"type": "Scrap",      "item_code": "SC", "qty": 1.0, "cost_allocation_per": 2.0},
+            {"type": "Co-Product", "item_code": "CO", "qty": 1.0, "uom": "Nos", "cost_allocation_per": 20.0},
+            {"type": "By-Product", "item_code": "BP", "qty": 1.0, "uom": "Nos", "cost_allocation_per": 5.0},
+            {"type": "Scrap",      "item_code": "SC", "qty": 1.0, "uom": "Nos", "cost_allocation_per": 2.0},
         ])
         joined = " ".join(warns)
         self.assertIn("unrecognised type 'Mystery'", joined)  # unknown nature skipped
@@ -226,6 +226,14 @@ class TestSecondaryAllocationGuard(unittest.TestCase):
         self.assertEqual(res.created, 1)
         self.assertEqual(len(doc["secondary_items"]), 2)
         self.assertFalse(any("over 100%" in w["reason"] for w in res.warnings))
+
+    def test_hair_over_100_drops(self):
+        # A total just above 100 must drop, matching ERPNext's exact boundary: it rejects
+        # any overage (100.0000001 fails live), so a lenient epsilon here would keep a set
+        # ERPNext then rejects, losing the whole BOM. Strict > 100 mirrors ERPNext.
+        doc, res = self._run([self._sec(100.0000005)])
+        self.assertNotIn("secondary_items", doc)
+        self.assertTrue(any("over 100%" in w["reason"] for w in res.warnings))
 
 
 if __name__ == "__main__":

--- a/tally_migrator/tests/test_preflight.py
+++ b/tally_migrator/tests/test_preflight.py
@@ -29,6 +29,9 @@ class _FakeCache:
         self.store[k] = v
         self.sets.append((k, v, expires_in_sec))
 
+    def delete_value(self, k):
+        self.store.pop(k, None)
+
 
 class TestPreflightOrchestrator(unittest.TestCase):
     def setUp(self):
@@ -71,6 +74,15 @@ class TestPreflightOrchestrator(unittest.TestCase):
         enq.assert_called_once()
         # running marker was cached so concurrent polls don't re-enqueue
         self.assertTrue(any(v.get("status") == "running" for _, v, _ in cache.sets))
+
+    def test_enqueue_failure_clears_running_marker(self):
+        cache = _FakeCache()
+        with mock.patch.object(api, "_should_run_async", return_value=True), \
+             mock.patch.object(api.frappe, "cache", return_value=cache), \
+             mock.patch.object(api.frappe, "enqueue", side_effect=RuntimeError("queue full")):
+            with self.assertRaises(RuntimeError):
+                api.validate_masters_data("/files/big.xml")
+        self.assertNotIn(api._preflight_key(_file(), "", "", ""), cache.store)
 
     def test_large_file_returns_cached_ready_without_reenqueue(self):
         key = api._preflight_key(_file(), "", "", "")
@@ -154,6 +166,17 @@ class TestPreviewOrchestrator(unittest.TestCase):
         self.assertEqual(out["status"], "running")
         enq.assert_called_once()
         self.assertTrue(any(v.get("status") == "running" for _, v, _ in cache.sets))
+
+    def test_enqueue_failure_clears_running_marker(self):
+        # A failed enqueue must not strand the 'running' marker, or every later poll reads
+        # 'running' and the wizard reports a good file as unreadable with no retry.
+        cache = _FakeCache()
+        with mock.patch.object(api, "_should_run_async", return_value=True), \
+             mock.patch.object(api.frappe, "cache", return_value=cache), \
+             mock.patch.object(api.frappe, "enqueue", side_effect=RuntimeError("queue full")):
+            with self.assertRaises(RuntimeError):
+                api.preview_masters_file("/files/big.zip")
+        self.assertNotIn(api._preview_key(_file()), cache.store)
 
     def test_large_file_returns_cached_ready_without_reenqueue(self):
         key = api._preview_key(_file())


### PR DESCRIPTION
Follow-up to #66-#70 addressing the review bot's P1 comments. Each was re-validated (three live against ERPNext) before fixing.

## Fixes

- **BOM secondary allocation guard (#70)** - strict `> 100` instead of an epsilon. ERPNext computes the finished good's share as `100 - total` with the same float arithmetic and rejects **any** overage (verified: `100.0000001` fails). The epsilon kept totals in `(100, 100+eps]` that ERPNext then rejected, losing the whole BOM. A true 100 still passes (`33.34+33.33+33.33` sums to exactly `100.0`).
- **BOM secondary UOM (#69)** - pass the row's `uom` like a component row. Without it ERPNext interprets the quantity in the item's stock unit and records the wrong output quantity (the unit-mismatch warning already fires). Verified live that a non-stock uom inserts with `conversion_factor` defaulted to 1.
- **Preview / pre-flight enqueue failure (#67)** - wrap `frappe.enqueue` so a failed enqueue (e.g. a saturated background queue, a real observed condition) clears the `running` marker instead of stranding it for its full TTL, which otherwise makes the wizard report a valid file as unreadable with no retry. Applied to **both** endpoints.
- **Preview poll generation token (#67)** - a superseded poll chain (an earlier upload whose 2s timer is still pending) now bails on a generation check, so it can neither overwrite the box nor spawn a second chain that shares and races down the poll ceiling.

## Not changed (with reason)

- **Periodic/perpetual fail-safe (#66)** - defaulting to perpetual when the inventory flag can't be read is deliberate: posting a stock line under perpetual fails the whole opening batch, so skipping one line is the safe side, and reconciliation uses the same default so the trial balance stays consistent. The trigger (the flag read throwing) does not occur for a valid company.

## Validation

- Live probes confirmed: ERPNext rejects any allocation overage; a non-stock secondary uom inserts cleanly; a true-100 total is accepted.
- Tests: strict-boundary drop, secondary-uom passthrough (unit + live), enqueue-failure marker-clear (preview + pre-flight). Full suite green (666). JS builds clean.