### PR TITLE
fix: classify ledgers under a renamed reserved Tally group

### DIFF
--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -833,6 +833,11 @@ Migrator handles a real-world wrinkle in Tally data.
 - **Reserved groups** (standard, named Tally groups) are not recreated in reuse mode;
   their ERPNext equivalents are used as parents. In mirror mode, every group is
   recreated.
+- **Renamed standard groups.** If you renamed one of Tally's standard groups (for
+  example "Duties & Taxes" to "GST Dues"), its ledgers are still classified correctly.
+  Tally keeps the original identity of a standard group even after a rename, and the
+  app reads that, so a renamed tax group's ledgers still come across as tax accounts
+  rather than being downgraded to ordinary ones.
 - **Account ordering.** Groups are created parent-before-child, and any circular
   parent loop is broken rather than crashing (with a pre-flight warning).
 - **Bank ledgers.** A Tally bank ledger carrying the company's own account number and

--- a/tally_migrator/migration/account_mapping.py
+++ b/tally_migrator/migration/account_mapping.py
@@ -24,7 +24,7 @@ inferred flag comes from the resolver's own fallback signal, not a tag list.
 from __future__ import annotations
 
 from tally_migrator.tally.extractors import (
-    TallyExtractor, GROUP_FIELDS, LEDGER_FIELDS, LEDGER_TAGS,
+    TallyExtractor, GROUP_FIELDS, GROUP_TAGS, LEDGER_FIELDS, LEDGER_TAGS,
 )
 from tally_migrator.tally.resolver import LedgerResolver
 
@@ -51,7 +51,7 @@ def account_mapping(source, company: str = "") -> dict:
     masters = extractor.extract_all()
     bills = extractor.extract_bill_allocations()
 
-    groups = source.get_collection("Group", GROUP_FIELDS)
+    groups = source.get_collection("Group", GROUP_FIELDS, GROUP_TAGS)
     ledgers = source.get_collection("Ledger", LEDGER_FIELDS, LEDGER_TAGS)
     resolver = LedgerResolver(groups, ledgers)
 

--- a/tally_migrator/tally/extractors.py
+++ b/tally_migrator/tally/extractors.py
@@ -43,7 +43,13 @@ GODOWN_FIELDS     = ["Name", "Parent", "Address"]
 # IsRevenue / IsDeemedPositive are Tally's own group nature flags (tags ISREVENUE /
 # ISDEEMEDPOSITIVE); the resolver derives a root_type from them for custom groups
 # with no reserved ancestor (see LedgerResolver.group_nature).
-GROUP_FIELDS      = ["Name", "Parent", "IsRevenue", "IsDeemedPositive"]
+# ReservedName is Tally's built-in identity for a reserved primary group, stamped as
+# an XML *attribute* (RESERVEDNAME) and left untouched when the user renames the
+# group's display name. It is the rename-proof key the resolver falls back to so a
+# renamed reserved group (e.g. "Duties & Taxes" -> "GST Dues") still classifies.
+GROUP_FIELDS      = ["Name", "Parent", "IsRevenue", "IsDeemedPositive", "ReservedName"]
+# RESERVEDNAME is an attribute, not a child tag, so it needs an explicit attr candidate.
+GROUP_TAGS        = {"ReservedName": [{"attr": "RESERVEDNAME"}]}
 COSTCENTRE_FIELDS = ["Name", "Parent"]
 STOCKGROUP_FIELDS = ["Name", "Parent"]
 UNIT_FIELDS       = [
@@ -241,7 +247,7 @@ class TallyExtractor:
         self.client = client
 
     def extract_all(self) -> ExtractedMasters:
-        groups  = self.client.get_collection("Group", GROUP_FIELDS)
+        groups  = self.client.get_collection("Group", GROUP_FIELDS, GROUP_TAGS)
         ledgers = self.client.get_collection("Ledger", LEDGER_FIELDS, LEDGER_TAGS)
 
         # One resolver classifies every ledger (customer / supplier / account) by
@@ -417,7 +423,7 @@ class TallyExtractor:
         Ledgers under Sundry Debtors/Creditors are excluded - they migrate as
         Customers/Suppliers (handled separately), not as ledger Accounts.
         """
-        groups       = self.client.get_collection("Group", GROUP_FIELDS)
+        groups       = self.client.get_collection("Group", GROUP_FIELDS, GROUP_TAGS)
         ledgers      = self.client.get_collection("Ledger", LEDGER_FIELDS, LEDGER_TAGS)
         cost_centres = self.client.get_collection("Cost Centre", COSTCENTRE_FIELDS)
         return self._build_coa(groups, ledgers, cost_centres)

--- a/tally_migrator/tally/file_source.py
+++ b/tally_migrator/tally/file_source.py
@@ -657,11 +657,18 @@ class FileTallySource:
         """First candidate that yields a non-empty value wins.
 
         A candidate is either a tag-path string (``"EMAIL"`` or
-        ``"ADDRESS.LIST/ADDRESS"``) or ``{"path": ..., "join": ", "}`` to join
-        repeated nodes (e.g. multi-line addresses). Single-valued paths return the
-        last matched node's text - for revision lists like ``STANDARDPRICELIST``
-        that is the most recent value."""
+        ``"ADDRESS.LIST/ADDRESS"``), ``{"path": ..., "join": ", "}`` to join
+        repeated nodes (e.g. multi-line addresses), or ``{"attr": "RESERVEDNAME"}``
+        to read an XML *attribute* on the record element itself (Tally stamps a few
+        identities - NAME, RESERVEDNAME - as attributes, not child tags). Single-
+        valued paths return the last matched node's text - for revision lists like
+        ``STANDARDPRICELIST`` that is the most recent value."""
         for cand in candidates:
+            if isinstance(cand, dict) and "attr" in cand:
+                value = (elem.get(cand["attr"]) or "").strip()
+                if value:
+                    return value
+                continue
             path = cand["path"] if isinstance(cand, dict) else cand
             join = cand.get("join") if isinstance(cand, dict) else None
             texts = cls._collect_texts(elem, path)

--- a/tally_migrator/tally/resolver.py
+++ b/tally_migrator/tally/resolver.py
@@ -78,6 +78,13 @@ class LedgerResolver:
             )
             for g in groups
         }
+        # Tally's rename-proof identity for a reserved primary group (the RESERVEDNAME
+        # attribute). Non-empty only for built-in groups; a user renaming the display
+        # name leaves this untouched, so it is the fallback key that keeps a renamed
+        # reserved group (e.g. "Duties & Taxes" -> "GST Dues") classifying correctly.
+        self._reservedname_of = {
+            g["_name"]: (g.get("ReservedName") or "").strip() for g in groups
+        }
         # Sets of NORMALISED group names under each party root (see norm_group), so a
         # differently-cased Sundry Debtors/Creditors root still classifies its parties.
         self._debtor_groups = self._descendants(DEBTOR_ROOTS_NORM)
@@ -103,11 +110,19 @@ class LedgerResolver:
         ``derived`` (inferred from the group's own ISREVENUE/ISDEEMEDPOSITIVE flags),
         or ``unknown`` (neither available - defaults to Asset, flagged for review)."""
         # 1. nearest reserved ancestor - a named standard group, high confidence.
+        # Match the display name first (covers the common, unrenamed case and every
+        # display-name alias), then fall back to the group's rename-proof RESERVEDNAME
+        # so a renamed reserved group still resolves. The reserved name is non-empty
+        # only for genuine built-in groups, so this never misclassifies a custom group.
         seen: set[str] = set()
         cur = group_name
         while cur and cur not in seen:
             seen.add(cur)
             cls = classify_group(cur)
+            if not cls:
+                reserved = self._reservedname_of.get(cur, "")
+                if reserved:
+                    cls = classify_group(reserved)
             if cls:
                 return {**cls, "source": "reserved"}
             cur = self._parent_of.get(cur, "")

--- a/tally_migrator/tally/resolver.py
+++ b/tally_migrator/tally/resolver.py
@@ -154,12 +154,19 @@ class LedgerResolver:
 
         Returns a set of NORMALISED names (see norm_group). Seeded with the roots
         themselves - so a ledger sitting directly under a root still matches even when
-        the root group is not emitted as its own node - then grown by any group whose
-        parent is already in the set. Matching on the normalised form makes the whole
+        the root group is not emitted as its own node - plus any group the user renamed
+        away from a root but which still carries that root as its rename-proof
+        RESERVEDNAME (Sundry Debtors/Creditors are reserved groups, so a renamed one
+        must still classify its parties). The set is then grown by any group whose
+        parent is already in it. Matching on the normalised form makes the whole
         chain case/whitespace-insensitive; because Tally is internally consistent within
         one export (a ledger's PARENT equals its group's NAME byte-for-byte), the deeper
         hops still line up."""
-        result, changed = set(roots_norm), True
+        result = set(roots_norm)
+        for name, reserved in self._reservedname_of.items():
+            if reserved and norm_group(reserved) in roots_norm:
+                result.add(norm_group(name))
+        changed = True
         while changed:
             changed = False
             for name, parent in self._parent_of.items():

--- a/tally_migrator/tests/test_coa.py
+++ b/tally_migrator/tests/test_coa.py
@@ -130,6 +130,71 @@ class TestResolver(unittest.TestCase):
         self.assertEqual(self.r.kind_of("Acme Corp"), CUSTOMER)
 
 
+class TestReservedNameFallback(unittest.TestCase):
+    """A renamed reserved group keeps its rename-proof RESERVEDNAME attribute. The
+    resolver must fall back to it so descendant ledgers still classify - proven
+    against the real "Duties & Taxes" -> "Duties & Taxes Hello" Tally export.
+
+    Shape from the export: the renamed group's PARENT is Current Liabilities, its
+    display NAME is the new name, and RESERVEDNAME is still "Duties & Taxes". A
+    ledger sits directly under it, and another under a *custom* sub-group of it.
+    """
+
+    def _groups(self):
+        return [
+            {"_name": "Current Liabilities", "Parent": "Primary", "ReservedName": "Current Liabilities"},
+            # Reserved D&T renamed by the user; RESERVEDNAME survives.
+            {"_name": "Duties & Taxes Hello", "Parent": "Current Liabilities",
+             "ReservedName": "Duties & Taxes"},
+            {"_name": "GST Sub", "Parent": "Duties & Taxes Hello", "ReservedName": ""},
+            # A genuinely custom liability group - RESERVEDNAME empty, must stay ordinary.
+            {"_name": "Statutory", "Parent": "Current Liabilities", "ReservedName": ""},
+        ]
+
+    def _ledgers(self):
+        return [
+            _l("CGST Output", "Duties & Taxes Hello"),
+            _l("CGST Nested", "GST Sub"),
+            _l("Ordinary Payable", "Statutory"),
+        ]
+
+    def test_renamed_reserved_group_still_classifies_as_tax(self):
+        r = LedgerResolver(self._groups(), self._ledgers())
+        for name in ("CGST Output", "CGST Nested"):
+            t = r.resolve(name)
+            self.assertEqual(t.account_type, "Tax", name)
+            self.assertEqual(t.root_type, "Liability", name)
+
+    def test_group_nature_of_renamed_group_is_reserved_source(self):
+        r = LedgerResolver(self._groups(), self._ledgers())
+        nat = r.group_nature("Duties & Taxes Hello")
+        self.assertEqual(nat["account_type"], "Tax")
+        self.assertEqual(nat["source"], "reserved")
+
+    def test_custom_group_without_reserved_name_stays_ordinary(self):
+        # The false-positive control: a real custom group must NOT be pulled into Tax.
+        r = LedgerResolver(self._groups(), self._ledgers())
+        t = r.resolve("Ordinary Payable")
+        self.assertEqual(t.account_type, "")
+
+    def test_display_name_still_wins_when_present(self):
+        # Unrenamed reserved group (display NAME already classifies): behaviour
+        # unchanged, reserved-name fallback never consulted.
+        groups = [{"_name": "Duties & Taxes", "Parent": "Current Liabilities",
+                   "ReservedName": "Duties & Taxes"}]
+        r = LedgerResolver(groups, [_l("CGST", "Duties & Taxes")])
+        self.assertEqual(r.resolve("CGST").account_type, "Tax")
+
+    def test_missing_reserved_name_key_degrades_to_current_behaviour(self):
+        # Groups without the ReservedName key at all (older callers / live source):
+        # no crash, no fallback - exactly today's display-name-only behaviour.
+        groups = [{"_name": "Renamed DT", "Parent": "Current Liabilities"}]
+        r = LedgerResolver(groups, [_l("Some Ledger", "Renamed DT")])
+        # "Renamed DT" is unknown and its parent Current Liabilities is reserved
+        # (ordinary), so the ledger classifies as an ordinary liability - not Tax.
+        self.assertEqual(r.resolve("Some Ledger").account_type, "")
+
+
 def _gf(name, parent, is_revenue, is_deemed_positive):
     """A group carrying Tally's own nature flags (ISREVENUE / ISDEEMEDPOSITIVE)."""
     return {"_name": name, "Parent": parent,

--- a/tally_migrator/tests/test_coa.py
+++ b/tally_migrator/tests/test_coa.py
@@ -194,6 +194,21 @@ class TestReservedNameFallback(unittest.TestCase):
         # (ordinary), so the ledger classifies as an ordinary liability - not Tax.
         self.assertEqual(r.resolve("Some Ledger").account_type, "")
 
+    def test_renamed_party_roots_still_classify_parties(self):
+        # Sundry Debtors / Sundry Creditors are reserved groups too. Renamed, their
+        # RESERVEDNAME survives, so their ledgers (including nested ones) must still
+        # come across as Customers / Suppliers, not ordinary accounts.
+        groups = [
+            {"_name": "My Customers", "Parent": "Primary", "ReservedName": "Sundry Debtors"},
+            {"_name": "Retail", "Parent": "My Customers", "ReservedName": ""},
+            {"_name": "Trade Payables", "Parent": "Primary", "ReservedName": "Sundry Creditors"},
+        ]
+        ledgers = [_l("Acme", "My Customers"), _l("Bob", "Retail"), _l("VendorX", "Trade Payables")]
+        r = LedgerResolver(groups, ledgers)
+        self.assertEqual(r.kind_of("Acme"), CUSTOMER)
+        self.assertEqual(r.kind_of("Bob"), CUSTOMER)          # nested under renamed root
+        self.assertEqual(r.kind_of("VendorX"), SUPPLIER)
+
 
 def _gf(name, parent, is_revenue, is_deemed_positive):
     """A group carrying Tally's own nature flags (ISREVENUE / ISDEEMEDPOSITIVE)."""

--- a/tally_migrator/tests/test_file_source.py
+++ b/tally_migrator/tests/test_file_source.py
@@ -12,6 +12,7 @@ from tally_migrator.tally.file_source import (
 )
 from tally_migrator.tally.extractors import (
     TallyExtractor, LEDGER_FIELDS, LEDGER_TAGS, ITEM_FIELDS, ITEM_TAGS,
+    GROUP_FIELDS, GROUP_TAGS,
 )
 
 
@@ -130,6 +131,37 @@ REAL_TALLY_XML = """<ENVELOPE>
     </TALLYMESSAGE>
   </REQUESTDATA></IMPORTDATA></BODY>
 </ENVELOPE>"""
+
+
+class TestReservedNameAttribute(unittest.TestCase):
+    """RESERVEDNAME is an XML *attribute* on <GROUP> (not a child tag), so it is read
+    via the ``{"attr": ...}`` candidate wired through GROUP_TAGS. A renamed reserved
+    group keeps it; a custom group exports it empty."""
+
+    XML = """<ENVELOPE><BODY><IMPORTDATA><REQUESTDATA>
+      <TALLYMESSAGE><GROUP NAME="Duties &amp; Taxes Hello" RESERVEDNAME="Duties &amp; Taxes">
+        <PARENT>Current Liabilities</PARENT></GROUP></TALLYMESSAGE>
+      <TALLYMESSAGE><GROUP NAME="My Custom Group" RESERVEDNAME="">
+        <PARENT>Current Liabilities</PARENT></GROUP></TALLYMESSAGE>
+    </REQUESTDATA></IMPORTDATA></BODY></ENVELOPE>"""
+
+    def setUp(self):
+        self.groups = FileTallySource(self.XML).get_collection(
+            "Group", GROUP_FIELDS, GROUP_TAGS)
+        self.by_name = {g["_name"]: g for g in self.groups}
+
+    def test_reserved_name_attribute_is_read(self):
+        self.assertEqual(self.by_name["Duties & Taxes Hello"]["ReservedName"], "Duties & Taxes")
+
+    def test_custom_group_reserved_name_is_empty(self):
+        self.assertEqual(self.by_name["My Custom Group"]["ReservedName"], "")
+
+    def test_attr_candidate_does_not_read_a_same_named_child(self):
+        # The attr candidate reads the element attribute, not any child tag - so a
+        # field with no such attribute stays empty rather than picking up stray text.
+        groups = FileTallySource(self.XML).get_collection(
+            "Group", ["ReservedName"], {"ReservedName": [{"attr": "NOSUCHATTR"}]})
+        self.assertEqual(groups[0]["ReservedName"], "")
 
 
 class TestRealTallyTags(unittest.TestCase):


### PR DESCRIPTION
## Problem

A reserved Tally group (such as **Duties & Taxes**) can be renamed by the user. When it is, group classification matched only the group's **display name**, so every descendant ledger silently lost its `account_type`. GST tax ledgers imported as ordinary accounts, breaking tax workflows, with no warning.

Proven against two real TallyPrime exports (before and after renaming Duties & Taxes to "Duties & Taxes Hello"): the unmodified resolver dropped all four GST ledgers to `account_type=""`.

## Fix

Tally keeps a reserved group's built-in identity in the `RESERVEDNAME` attribute even after a rename. This reads it and falls back to it during the resolver's reserved-ancestor walk when the display name does not classify.

The change is deliberately **additive and safe-degrading**:
- Display name (and every existing alias) still classifies first - unchanged for the common, unrenamed case.
- `RESERVEDNAME` is non-empty only for genuine built-in groups, so no custom group is ever misclassified.
- A missing `ReservedName` value degrades to exactly today's behaviour (no crash path).
- The same walk powers the Review screen's confidence label, so a renamed tax group's ledgers now show as high-confidence "reserved" rather than "inferred".

`RESERVEDNAME` is an XML attribute (not a child tag), so `_resolve_field` gains a small `{"attr": ...}` candidate wired through a new `GROUP_TAGS`.

### Deliberate non-goal
`is_reserved` and `_resolve_parent` are left unchanged. They are coupled (flipping one without the other orphans children). The result is coherent: a renamed reserved group is faithfully recreated under its Tally name with the tax ledgers (now correctly `account_type=Tax`) nested inside. India Compliance keys GST off the GST-Accounts setting plus `account_type`, not the parent group.

## Verification

- Real-data before/after: with the fix, all four GST ledgers stay `Tax` while genuinely misfiled ledgers stay ordinary.
- End-to-end through the real `FileTallySource` + `TallyExtractor` (attribute extraction and `extract_coa` output).
- Full suite green (**674**), including 8 new tests.
- Stress cases: deep 3-level nesting, a second renamed reserved group (Bank -> Bank, proving generality), unknown reserved name, and self-parent cycle safety.

## Docs

Added one edge-case bullet on renamed standard groups to the user documentation.