### PR TITLE
fix: hang-guard record identity + XML DOCTYPE/entity bypass

### DIFF
--- a/tally_migrator/erpnext/importers/base.py
+++ b/tally_migrator/erpnext/importers/base.py
@@ -390,8 +390,17 @@ class BaseImporter:
         guard to mark the in-flight record and to recognise a confirmed-hung one on
         resume. Stable across runs because it derives from the source data (re-parsed
         identically), never from DB state. Overridable; defaults to the Tally ledger
-        name, which every masters record carries."""
-        return str(record.get("name") or record.get(self.key_field) or "")
+        name, which every masters record carries under ``_name``.
+
+        ``_name`` is the key ``FileTallySource.get_collection`` sets to the Tally name;
+        ``self.key_field`` is the ERPNext column (``customer_name`` / ``item_code`` / …)
+        and is NOT present on the source dict, so it must never be the primary identity -
+        relying on it (or a non-existent lowercase ``name``) yields "" for every record,
+        which collapses every record of a phase onto one confirmed-hung key and makes a
+        single genuine hang skip the whole phase on resume. ``_name`` first fixes that;
+        the later fallbacks stay only for oddly-shaped records a subclass might feed."""
+        return str(record.get("_name") or record.get("name")
+                   or record.get(self.key_field) or "")
 
     # ── Utilities ─────────────────────────────────────────────────────────────
     @staticmethod

--- a/tally_migrator/tally/file_source.py
+++ b/tally_migrator/tally/file_source.py
@@ -246,15 +246,6 @@ class _SanitizingReader:
             if self._first and text[:1] == "﻿":
                 text = text[1:]
             self._first = False
-            if _DTD_DECL.search(self._dtd_tail + text):
-                frappe.throw(
-                    "Uploaded file contains an XML DOCTYPE or entity declaration, which "
-                    "a genuine Tally Masters export never does. It was rejected as "
-                    "unsafe. Re-export the masters from Tally (XML format) and try again."
-                )
-            # Keep a rolling window of recent chars (not just this chunk's tail) so a
-            # DTD token split across several tiny reads is still seen whole next time.
-            self._dtd_tail = (self._dtd_tail + text)[-16:]
             if not final:
                 # Hold back a trailing partial char reference ("&#12" with no ";") so
                 # the next chunk completes it - only when the '&' is near the end, so a
@@ -267,6 +258,24 @@ class _SanitizingReader:
             else:
                 self._carry = ""
             out = _ILLEGAL_CHARS.sub("", _CHAR_REF.sub(_drop_illegal_ref, text))
+            # DTD/entity guard runs on the SANITISED output, exactly like the whole-
+            # document path (sanitize_tally_xml -> reject_unsafe_xml). Checking the raw
+            # decoded text instead let an illegal char hidden inside the token slip a
+            # declaration past the regex, which sanitisation then un-hid for the parser
+            # (e.g. "<!DOCT&#4;YPE" / "<!DOCT\x04YPE" -> "<!DOCTYPE"). With defusedxml
+            # absent the stdlib parser expands entities, so that bypass is a real
+            # entity-expansion ("billion laughs") DoS - checking post-sanitisation closes
+            # it regardless of which parser is active.
+            if _DTD_DECL.search(self._dtd_tail + out):
+                frappe.throw(
+                    "Uploaded file contains an XML DOCTYPE or entity declaration, which "
+                    "a genuine Tally Masters export never does. It was rejected as "
+                    "unsafe. Re-export the masters from Tally (XML format) and try again."
+                )
+            # Keep a rolling window of recent SANITISED chars (not just this chunk's
+            # tail) so a DTD token split across several tiny reads is still seen whole
+            # next time - the token is contiguous in the concatenation of the outputs.
+            self._dtd_tail = (self._dtd_tail + out)[-16:]
             if out or final:
                 return out
 

--- a/tally_migrator/tests/test_record_guard.py
+++ b/tally_migrator/tests/test_record_guard.py
@@ -230,6 +230,64 @@ class TestBaseRunWiring(unittest.TestCase):
         self.assertIn("B", [e["name"] for e in result.errors])
 
 
+class _RealShapedImporter(BaseImporter):
+    """Importer whose ``key_field`` is an ERPNext column (like the real Customer /
+    Item importers), fed records shaped like ``FileTallySource.get_collection`` output
+    (``_name`` + Tally field names, no lowercase ``name``, no ``key_field``)."""
+    doctype = "Customer"
+    key_field = "customer_name"     # ERPNext column - absent from a source record
+
+    def __init__(self):
+        super().__init__("Co", "C")
+        self.processed = []
+
+    def _prefetch_existing(self):
+        return None
+
+    def build_doc(self, record):
+        return {"customer_name": record["_name"]}
+
+    def _upsert(self, result, data):
+        self.processed.append(data["customer_name"])
+        result.add_created(data["customer_name"])
+        return data["customer_name"], True
+
+
+class TestRecordIdentity(unittest.TestCase):
+    """Regression: the hang guard must identify each record by its Tally ``_name``.
+
+    A record from ``get_collection`` is ``{"_name": <tally name>, "Name": ..., ...}`` -
+    there is no lowercase ``name`` key, and ``key_field`` is the ERPNext column, which the
+    source dict never carries. If ``_record_ident`` misses ``_name`` it returns "" for
+    every record, so a single confirmed hang collapses onto the ``(doctype, "")`` key and
+    skips the WHOLE phase on resume. These lock the identity to ``_name``.
+    """
+
+    def tearDown(self):
+        rg.deactivate()
+
+    def _rec(self, name):
+        # Mirrors FileTallySource.get_collection: _name + Tally field names only.
+        return {"_name": name, "Name": name, "Parent": "Sundry Debtors",
+                "OpeningBalance": "-100"}
+
+    def test_ident_is_the_tally_name_not_empty(self):
+        imp = _RealShapedImporter()
+        self.assertEqual(imp._record_ident(self._rec("Dhatu Industries")),
+                         "Dhatu Industries")
+
+    def test_confirmed_hang_skips_only_that_record_not_the_whole_phase(self):
+        imp = _RealShapedImporter()
+        # Only "Beta" is confirmed-hung; "Alpha"/"Gamma" must still import.
+        rg.activate(rg.RecordGuard(
+            "L", confirmed={("Customer", "Beta")}, timeout_s=999))
+        result = imp.run([self._rec("Alpha"), self._rec("Beta"), self._rec("Gamma")])
+        self.assertEqual(imp.processed, ["Alpha", "Gamma"])   # phase NOT wiped out
+        self.assertEqual(result.created, 2)
+        self.assertEqual(result.failed, 1)                    # only Beta failed
+        self.assertIn("Beta", [e["name"] for e in result.errors])
+
+
 class TestResumeSweep(unittest.TestCase):
     def _row(self):
         return {"name": "TML-R", "job_id": "j", "company": "Co"}

--- a/tally_migrator/tests/test_streaming_parse.py
+++ b/tally_migrator/tests/test_streaming_parse.py
@@ -61,6 +61,42 @@ class TestStreamingEqualsLegacy(unittest.TestCase):
             with self.assertRaises(Exception):
                 FileTallySource(("﻿" + evil).encode("utf-16-le"))
 
+    def test_streaming_rejects_dtd_obfuscated_by_illegal_char_ref(self):
+        # The DTD token is hidden behind an illegal numeric char ref (&#4;). Before the
+        # guard ran on the SANITISED output, this slipped a live DOCTYPE/ENTITY past the
+        # regex, which sanitisation then un-hid for the stdlib parser - an entity-
+        # expansion ("billion laughs") vector. The guard must now reject it.
+        evil = "<!DOCT&#4;YPE x [<!ENT&#4;ITY a 'b'>]>" + DOC
+        with self.assertRaises(Exception):
+            FileTallySource(("﻿" + evil).encode("utf-16-le"))
+
+    def test_streaming_rejects_dtd_obfuscated_by_raw_control_char(self):
+        # Same evasion via a raw illegal control byte (\x04) inside the token.
+        evil = "<!DOCT\x04YPE x [<!ENT\x04ITY a 'b'>]>" + DOC
+        with self.assertRaises(Exception):
+            FileTallySource(("﻿" + evil).encode("utf-16-le"))
+
+    def test_streaming_rejects_obfuscated_dtd_split_across_tiny_chunks(self):
+        # The hardest case: obfuscated token AND shattered across chunk boundaries, so the
+        # carry (partial char-ref), the sanitisation, and the rolling window must all
+        # cooperate. 3 raw bytes/read splits every token.
+        evil = "<!DOCT&#4;YPE x [<!ENT&#4;ITY a 'b'>]>" + DOC
+        with mock.patch.object(file_source._SanitizingReader, "_CHUNK", 3):
+            with self.assertRaises(Exception):
+                FileTallySource(("﻿" + evil).encode("utf-16-le"))
+
+    def test_obfuscated_bomb_does_not_reach_the_parser(self):
+        # End-to-end: a nested-entity bomb whose tokens are ref-obfuscated must be
+        # rejected up front, never expanded. Small fan-out keeps the test cheap even if
+        # the guard ever regressed (it would raise a parser error, not OOM the runner).
+        ents = " ".join(
+            [f"<!ENTITY a{i} '{'&a' + str(i - 1) + ';' * 0}{('&a%d;' % (i - 1)) * 5}'>"
+             for i in range(1, 5)])
+        bomb = ("<!DOCTYPE r [ <!ENTITY a0 'AAAA'> " + ents + " ]><r>&a4;</r>")
+        bomb = bomb.replace("<!DOCTYPE", "<!DOCT&#4;YPE").replace("<!ENTITY", "<!ENT&#4;ITY")
+        with self.assertRaises(Exception):
+            FileTallySource(("﻿" + bomb).encode("utf-16-le"))
+
     def test_utf8_bom_bytes_stream(self):
         src = FileTallySource(("﻿" + DOC).encode("utf-8"))
         self.assertEqual(collections(src), collections(FileTallySource(DOC)))


### PR DESCRIPTION
Two independent fixes surfaced by a full-application audit. Both were reproduced
against the code before fixing, and both ship with regression tests.

## 1. Hang-guarded records were identified as "" (P1, data loss on resume)

`BaseImporter._record_ident` read `record.get("name") or record.get(self.key_field)`,
but a record from `FileTallySource.get_collection` is keyed `_name` plus the Tally
field names. There is no lowercase `name`, and `key_field` is the ERPNext column
(`customer_name` / `item_code` / ...), absent from the source dict. So the identity
was `""` for every customer, supplier, item, warehouse, unit and stock group.

Impact on the hang-and-resume path: once any record in a phase hangs twice, the
confirmed-skip set becomes `{(doctype, "")}`, and on the resumed run
`should_skip(doctype, "")` is true for **every** record of that doctype. The whole
phase is then reported "repeatedly stalled" and skipped instead of just the culprit,
and the run finishes "Completed with Errors" so the loss looks intentional. This is
exactly the scenario the guard exists for (a genuine per-record hang).

Fix: read `_name` first (old lookups kept as fallbacks). The previous test fixture
used `key_field="name"` with `{"name": ...}` records, which is why the defect was
masked; new tests feed a record shaped like real `get_collection` output.

## 2. XML DOCTYPE/entity guard was bypassable (P2, entity-expansion DoS)

`_SanitizingReader.read` ran the DTD guard on the raw decoded text, *before*
per-chunk sanitisation stripped illegal characters and numeric char references. A
token hidden behind an illegal char (`<!DOCT&#4;YPE`, `<!DOCT\x04YPE`) passed the
regex and was then un-hidden by sanitisation into a live `<!DOCTYPE ... <!ENTITY ...>`
handed to the parser. `defusedxml` is not a dependency of frappe/erpnext/
india_compliance, so the stdlib parser (which expands entities) is used - making this
a working billion-laughs DoS on the UTF-16 streaming path every real Tally export
takes. The whole-document path was never affected (it sanitises before the guard).

Fix: run the guard on the sanitised output, mirroring the whole-document path, with
the rolling split-token window also on sanitised text. Only the check location moves;
emitted bytes are unchanged, so the streaming parse stays byte-identical to the
whole-document parse. Tests cover both obfuscation vectors, a nested bomb, and the
token shattered across tiny chunks.

## Tests

New: 2 in `test_record_guard.py`, 4 in `test_streaming_parse.py`.
Passing under `bench run-tests`: `test_record_guard` (25), `test_streaming_parse`
(10), `test_importer` (117), `test_file_source` (55), `test_raw_file_bytes` (3),
`test_zip_and_drive` (30).