### PR TITLE
fix: audit follow-ups - async notification, accounts hang-guard, rollback + parser hardening

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,13 @@ authors = [{ name = "Frappe Technologies Pvt. Ltd.", email = "developers@frappe.
 description = "Migrate masters and transactions from Tally to ERPNext"
 requires-python = ">=3.10"
 readme = "README.md"
-# frappe and erpnext are bench apps, NOT PyPI packages — never list them here.
-dependencies = []
+# frappe and erpnext are bench apps, NOT PyPI packages - never list them here.
+# defusedxml hardens the uploaded-XML parser against entity-expansion ("billion
+# laughs") attacks: the streaming parser prefers its safe iterparse when present
+# (see tally/file_source.py _select_iterparse). The in-app DTD/entity guard is the
+# primary defence and works without it, so this is defense-in-depth - but declaring
+# it means a real deployment always has the parser-level protection too.
+dependencies = ["defusedxml>=0.7"]
 
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]

--- a/tally_migrator/erpnext/importers/accounts.py
+++ b/tally_migrator/erpnext/importers/accounts.py
@@ -26,6 +26,7 @@ from tally_migrator.validation.engine import (
 )
 from .base import BaseImporter, ImportResult
 from .banks import _ensure_bank, _insert_bank_account
+from tally_migrator.migration import record_guard
 
 # ── Chart of Accounts importer ───────────────────────────────────────────────
 
@@ -79,11 +80,24 @@ class AccountImporter:
             for idx, node in enumerate(ordered, 1):
                 if on_progress:
                     on_progress(idx, total)
-                parent = self._resolve_parent(node)
-                if not parent:
-                    result.add_error(node.name, "could not resolve a parent account")
+                ident = node.name
+                # Time-box each account so one pathological node (e.g. a slow India-
+                # Compliance tax-account hook) can't freeze the whole run, and skip one
+                # already confirmed-hung so a resume steps past it. This importer is
+                # standalone (not BaseImporter), so the guard is wired explicitly here,
+                # mirroring BaseImporter.run - otherwise the Accounts phase would be the
+                # one phase with no hang protection or auto-resume.
+                if record_guard.should_skip(self.doctype, ident):
+                    result.add_error(
+                        ident, "left out because it repeatedly stalled the migration "
+                        "(timed out twice); re-import this account on its own")
                     continue
-                self._upsert(result, node, parent)
+                with record_guard.guard(self.doctype, ident):
+                    parent = self._resolve_parent(node)
+                    if not parent:
+                        result.add_error(node.name, "could not resolve a parent account")
+                        continue
+                    self._upsert(result, node, parent)
         finally:
             frappe.local.flags.ignore_update_nsm = prior_nsm
             # Rebuild in finally so the committed accounts always end with a valid tree
@@ -308,8 +322,17 @@ class CostCentreImporter:
                 result.add_error(c.name, "no root cost center found in ERPNext")
             return result
         for node in self._ordered(centres):
-            parent = self._erp_name(node.parent) if node.parent in names else root
-            self._upsert(result, node, node.name in parents, parent)
+            ident = node.name
+            # Same per-record hang guard as the account loop above (this importer is also
+            # standalone), so a stalled cost centre is time-boxed and skipped on resume.
+            if record_guard.should_skip(self.doctype, ident):
+                result.add_error(
+                    ident, "left out because it repeatedly stalled the migration "
+                    "(timed out twice); re-import this cost centre on its own")
+                continue
+            with record_guard.guard(self.doctype, ident):
+                parent = self._erp_name(node.parent) if node.parent in names else root
+                self._upsert(result, node, node.name in parents, parent)
         return result
 
     def _erp_name(self, base: str) -> str:

--- a/tally_migrator/erpnext/importers/openings.py
+++ b/tally_migrator/erpnext/importers/openings.py
@@ -1528,7 +1528,8 @@ class StockOpeningImporter:
                 "Warehouse", {"name": ss, "is_group": 0, "company": self.company}):
             return ss
         candidate = company_scoped(DEFAULT_WAREHOUSE, self.abbr)
-        if frappe.db.exists("Warehouse", {"name": candidate, "is_group": 0}):
+        if frappe.db.exists(
+                "Warehouse", {"name": candidate, "is_group": 0, "company": self.company}):
             return candidate
         rows = frappe.get_all(
             "Warehouse", filters={"company": self.company, "is_group": 0},

--- a/tally_migrator/migration/account_mapping.py
+++ b/tally_migrator/migration/account_mapping.py
@@ -60,11 +60,12 @@ def account_mapping(source, company: str = "") -> dict:
     by_root: dict[str, list[dict]] = {r: [] for r in _ROOT_ORDER}
     inferred: list[dict] = []
     for a in ledger_accounts:
-        # source: "reserved" = mapped by a named standard group (high confidence);
+        # nature_source: "reserved" = mapped by a named standard group (high confidence);
         # "derived" = inferred from the group's own Tally nature flags; "unknown" =
         # neither, so the type is unresolved and shown as "--" for the user to set.
-        source = resolver.group_nature(a.parent).get("source")
-        is_inferred = source != "reserved"
+        # (Named distinctly from the ``source`` parameter above, which it must not shadow.)
+        nature_source = resolver.group_nature(a.parent).get("source")
+        is_inferred = nature_source != "reserved"
         row = {
             "name": a.name,
             "root_type": a.root_type,
@@ -73,7 +74,7 @@ def account_mapping(source, company: str = "") -> dict:
             "amount": round(a.opening_balance, 2),
             "dr_cr": a.opening_dr_cr,
             "inferred": is_inferred,
-            "uncertain": source == "unknown",
+            "uncertain": nature_source == "unknown",
         }
         by_root.setdefault(a.root_type, []).append(row)
         if is_inferred:
@@ -199,7 +200,6 @@ def _party_openings(masters, bills) -> dict:
                 })
                 continue
 
-            bills_signed = 0.0
             bills_signed = 0.0
             p_invoices = p_advances = 0
             for b in party_bills:

--- a/tally_migrator/migration/master_migrator.py
+++ b/tally_migrator/migration/master_migrator.py
@@ -109,6 +109,59 @@ def _has_opening(raw) -> bool:
     return TallyExtractor._parse_opening(raw)[0] != 0.0
 
 
+# Subject line per terminal status for the run-finished desk notification. Only the
+# statuses an import run can reach are listed - a revert notifies separately (it is its
+# own doctype with its own realtime event), so "Reverted" is deliberately absent here.
+_RUN_DONE_SUBJECTS = {
+    "Completed": "Your Tally migration finished successfully.",
+    "Completed with Errors": (
+        "Your Tally migration finished, but some records need your attention."),
+    "Failed": "Your Tally migration could not be completed.",
+}
+
+
+def notify_run_finished(log) -> None:
+    """Tell the user who started a BACKGROUND run that it reached a terminal state.
+
+    A large import runs in a background job, so the wizard tab may already be closed by
+    the time it finishes: realtime progress only reaches an open page, so without this a
+    user who stepped away never learns the run ended (or failed). A persistent Notification
+    Log entry (the desk bell) reaches them whenever they next open ERPNext, and deep-links
+    the migration log.
+
+    Only for async runs - identified by a stored ``job_id`` - because a synchronous run
+    returns its result to the still-open wizard inline, so a bell there would be redundant
+    noise. Best-effort: a notification failure must never affect the run's outcome (the
+    whole point is that the run already succeeded or failed on its own terms)."""
+    try:
+        if not (log and log.get("job_id")):
+            return
+        owner = log.get("owner")
+        if not owner or owner in ("Guest", "Administrator"):
+            # No real end-user to notify (Administrator-owned/system runs surface in the
+            # log list; a bell for the super-user adds noise without an audience).
+            return
+        subject = _RUN_DONE_SUBJECTS.get(log.get("status") or "")
+        if not subject:
+            return
+        frappe.get_doc({
+            "doctype": "Notification Log",
+            "for_user": owner,
+            "type": "Alert",
+            "document_type": "Tally Migration Log",
+            "document_name": log.name,
+            "subject": subject,
+        }).insert(ignore_permissions=True)
+        # Commit the notification explicitly. On the FAILURE path (_fail_log) run() then
+        # re-raises, and Frappe's background-job runner rolls back on that exception - so
+        # an uncommitted insert here would be discarded and the "your migration failed"
+        # bell would never appear. Every caller has already committed the run's own
+        # terminal state before calling this, so committing here only flushes this insert.
+        frappe.db.commit()
+    except Exception:
+        frappe.log_error("Tally Migrator", "run-finished notification failed")
+
+
 @dataclass
 class PipelineStep:
     """One entity in the migration pipeline: how to import it and how to report it."""
@@ -633,6 +686,10 @@ class MasterMigrator:
         except Exception as exc:
             frappe.log_error(f"Migration log issues table failed: {exc}", "Tally Migrator")
 
+        # Notify the initiating user if this ran in the background (their tab may be
+        # closed). No-op for a synchronous run (no job_id) - the wizard has the result.
+        notify_run_finished(self.log)
+
     def _track_wizard_uoms(self, manifest: dict) -> None:
         """Fold the pre-flight "create as new" UOMs into the manifest's Units entry so
         revert undoes them.
@@ -714,5 +771,7 @@ class MasterMigrator:
                 self.log.error_log = frappe.get_traceback() or str(exc)
                 self.log.save(ignore_permissions=True)
                 frappe.db.commit()
+                # Tell a background run's initiator it failed (their tab may be closed).
+                notify_run_finished(self.log)
         except Exception as inner:
             frappe.log_error(f"Migration log fail-update failed: {inner}", "Tally Migrator")

--- a/tally_migrator/migration/resume.py
+++ b/tally_migrator/migration/resume.py
@@ -161,5 +161,9 @@ def _fail(log, reason: str) -> None:
     frappe.log_error(f"{log.name}: {reason}", "Tally Migrator")
     try:
         log.db_set("status", "Failed", commit=True)
+        # The auto-resume gave up: the run is always a background job here, so notify the
+        # initiating user (their wizard tab is almost certainly closed by now).
+        from tally_migrator.migration.master_migrator import notify_run_finished
+        notify_run_finished(log)
     except Exception:
         pass

--- a/tally_migrator/migration/rollback.py
+++ b/tally_migrator/migration/rollback.py
@@ -59,6 +59,7 @@ _LABEL_DOCTYPE = {
     "Customers": "Customer",
     "Suppliers": "Supplier",
     "Items": "Item",
+    "Batches": "Batch",
     # "Prices" is intentionally omitted: it creates TWO doctypes (Item Price +
     # Pricing Rule), so a single label->doctype fallback can't represent it. New runs
     # store {name, doctype} per entry, so they need no fallback; legacy bare-string
@@ -95,10 +96,12 @@ def _protected_doctypes() -> set:
 _CREATION_ORDER = [
     "Accounts", "Cost Centres", "Warehouses", "Units", "Stock Groups",
     "Customers", "Suppliers", "Items",
-    # Prices (Item Price + Pricing Rule) and BOMs are created after Items (they
-    # reference the item) and before the opening entries - so reversed deletion
-    # removes them before the Items they lean on. Pipeline idx 82/84.
-    "Prices", "BOMs",
+    # Batches, Prices (Item Price + Pricing Rule) and BOMs are all created after Items
+    # (they reference the item) and before the opening entries - so reversed deletion
+    # removes them before the Items they lean on. Batches (idx 81) must also come before
+    # the Opening Stock reconciliation (idx 93) that posts into them, which reversed
+    # order already gives. Pipeline idx 81/82/84.
+    "Batches", "Prices", "BOMs",
     "Opening Balances", "Party Openings", "Opening Stock",
 ]
 
@@ -315,7 +318,11 @@ def _delete_one(row: dict, protected: set) -> str | None:
             cancel_inline = getattr(doc, "_cancel", None) or doc.cancel
             cancel_inline()
             for ledger in _LEDGER_DOCTYPES:
-                frappe.db.delete(ledger, {"voucher_no": name})
+                # Scope by voucher_type too, not voucher_no alone: document ids are only
+                # unique within a doctype, so a Journal Entry and a Sales Invoice could in
+                # principle share a name and one purge would take the other's ledger rows.
+                # All three ledger doctypes carry voucher_type, so this is always safe.
+                frappe.db.delete(ledger, {"voucher_type": doctype, "voucher_no": name})
             # The opening Stock Reconciliation auto-creates a Serial and Batch Bundle
             # per batch-tracked row (we set use_serial_batch_fields on those rows).
             # Cancelling the reconciliation only delinks the Bundle and flags it
@@ -463,6 +470,33 @@ def revert_migration(log_name: str, company_confirmation: str):
     if log.status == "Reverted":
         frappe.throw(_("This migration has already been reverted."))
 
+    # Close the check-then-enqueue race: two near-simultaneous first clicks could both
+    # pass the in-flight check below and each create + enqueue a revert. The deletes are
+    # idempotent so this loses no data, but it doubles the audit rows and the background
+    # jobs. A short SETNX lock per log serialises the enqueue window (the DB in-flight
+    # check remains the guard for a revert that is already running). Cache down -> proceed
+    # on the DB check alone, so a Redis blip never blocks a legitimate undo.
+    lock_key = f"tally_migrator:revert-enqueue:{log.name}"
+    try:
+        got_lock = bool(frappe.cache().set(lock_key, frappe.utils.now(), nx=True, ex=30))
+    except Exception:
+        got_lock = True
+    if not got_lock:
+        frappe.throw(_("An undo for this migration is already being started. Please wait "
+                       "a moment and try again."))
+    try:
+        return _enqueue_revert(log)
+    finally:
+        try:
+            frappe.cache().delete(lock_key)
+        except Exception:
+            pass
+
+
+def _enqueue_revert(log) -> dict:
+    """Validate no live revert exists, create the Queued Tally Migration Revert, and
+    enqueue the background undo. Called under the per-log enqueue lock (see
+    ``revert_migration``)."""
     # One revert at a time per log - block a double-click, pointing at the run
     # already in flight (the same guard ERPNext's TDR uses). But a revert flagged
     # Queued/In Progress past the job timeout cannot still be running (the worker was

--- a/tally_migrator/tally/extractors.py
+++ b/tally_migrator/tally/extractors.py
@@ -1,3 +1,4 @@
+import datetime
 import unicodedata
 import re
 from dataclasses import dataclass, field
@@ -722,6 +723,12 @@ class TallyExtractor:
         if not re.fullmatch(r"\d{8}", s):
             return ""
         y, m, d = s[:4], s[4:6], s[6:8]
-        if not ("01" <= m <= "12" and "01" <= d <= "31"):
+        # Validate a real calendar date rather than just digit ranges, so an impossible
+        # value (e.g. "20200231" -> 31 Feb) is rejected here and the importer falls back
+        # to the migration posting date, instead of handing ERPNext a date it will reject
+        # per-record on insert.
+        try:
+            datetime.date(int(y), int(m), int(d))
+        except ValueError:
             return ""
         return f"{y}-{m}-{d}"

--- a/tally_migrator/tally/file_source.py
+++ b/tally_migrator/tally/file_source.py
@@ -394,7 +394,12 @@ class FileTallySource:
             fields already equals the real Tally tag (NAME, PARENT, PINCODE, …).
         The first candidate that yields a value wins.
         """
-        cache_key = (obj_type, tuple(fields))
+        # Include the tag map in the cache key: the same (obj_type, fields) read with a
+        # different tag_map resolves different tags, so keying on fields alone would hand
+        # a second caller the first's mapping. tag_map values can hold dicts (an attr
+        # candidate), so repr - stable for the fixed module-level *_TAGS constants callers
+        # pass - is used instead of an unhashable tuple.
+        cache_key = (obj_type, tuple(fields), repr(tag_map or {}))
         # Hand out a fresh shallow copy of each record on every call. The source is
         # cached across requests (api._SOURCE_CACHE) and a consumer
         # (migration.overrides.apply_record_overrides) patches record dicts IN PLACE;

--- a/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
+++ b/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
@@ -1270,7 +1270,7 @@ class TallyMigratorPage {
 			.tally-migrator .tm-table th { border-top: 0; padding: var(--padding-xs) var(--padding-sm); }
 			.tally-migrator .tm-table td { padding: var(--padding-xs) var(--padding-sm); }
 			.tally-migrator .tm-table .tm-num { text-align: right; white-space: nowrap; }
-			.tally-migrator .tm-scroll { max-height: 340px; overflow-y: auto; }
+			.tally-migrator .tm-scroll { max-height: 340px; overflow-y: auto; overflow-x: auto; }
 			.tally-migrator .tm-nowrap { white-space: nowrap; }
 
 			/* ── Disclosure (collapsible) header ────────────────────────────────── */
@@ -2668,6 +2668,14 @@ class TallyMigratorPage {
 	}
 
 	restart() {
+		// Stop tracking any run and detach the realtime/heartbeat handlers before we wipe
+		// state - otherwise a poll or heartbeat from the just-finished run could paint the
+		// fresh upload step, and (see below) a stale createdUoms could leak into the next
+		// run's revert manifest.
+		this.stopHeartbeat();
+		if (this._onProgress) frappe.realtime.off("tally_migration_progress", this._onProgress);
+		this._trackingLog = null;
+		this._resumeStep = null;
 		this.fileUrl = null;
 		this.fileName = null;
 		this._restore = null;
@@ -2676,6 +2684,10 @@ class TallyMigratorPage {
 		this.uomIssues = [];
 		this.allUoms = [];
 		this.uomOverrides = {};
+		// UOMs the pre-flight created for the PREVIOUS file. If not cleared, they are sent
+		// with the next file's run and folded into its revert manifest, so undoing the next
+		// migration could delete units that belong to this one.
+		this.createdUoms = [];
 		this.qualityReport = null;
 		this.coverageReport = null;
 		this.accountMapping = null;

--- a/tally_migrator/tests/test_extractor.py
+++ b/tally_migrator/tests/test_extractor.py
@@ -75,6 +75,23 @@ class TestTallyExtractor(unittest.TestCase):
         names = [c["_name"] for c in masters.customers]
         self.assertNotIn("Capital Ledger", names)
 
+    def test_parse_tally_date_valid(self):
+        self.assertEqual(TallyExtractor._parse_tally_date("20200310"), "2020-03-10")
+        self.assertEqual(TallyExtractor._parse_tally_date("20240229"), "2024-02-29")  # leap day
+
+    def test_parse_tally_date_rejects_impossible(self):
+        # A well-formed 8-digit string that is not a real calendar date must be rejected
+        # (returns ""), so the importer falls back to the posting date instead of handing
+        # ERPNext a date it rejects per-record.
+        self.assertEqual(TallyExtractor._parse_tally_date("20200231"), "")  # 31 Feb
+        self.assertEqual(TallyExtractor._parse_tally_date("20230229"), "")  # non-leap Feb 29
+        self.assertEqual(TallyExtractor._parse_tally_date("20201301"), "")  # month 13
+        self.assertEqual(TallyExtractor._parse_tally_date("20200100"), "")  # day 00
+
+    def test_parse_tally_date_blank_or_malformed(self):
+        for v in ("", "2020-03-10", "202003", "abcdefgh", None):
+            self.assertEqual(TallyExtractor._parse_tally_date(v), "")
+
     def test_items_and_warehouses_fetched(self):
         masters = self.extractor.extract_all()
         self.assertEqual(len(masters.items), 1)

--- a/tally_migrator/tests/test_file_source.py
+++ b/tally_migrator/tests/test_file_source.py
@@ -750,5 +750,31 @@ class TestExtractBillAllocations(unittest.TestCase):
             TallyExtractor(_Flat()).extract_bill_allocations(), [])
 
 
+class TestGetCollectionCacheKey(unittest.TestCase):
+    """The parse cache must key on the tag map, not just (obj_type, fields): the same
+    read with a different tag map resolves different tags, so it must not return a
+    prior call's mapping."""
+
+    _XML = (
+        "<ENVELOPE><BODY><IMPORTDATA><REQUESTDATA>"
+        "<TALLYMESSAGE><LEDGER NAME='Acme'><BAR>from-bar</BAR><BAZ>from-baz</BAZ>"
+        "</LEDGER></TALLYMESSAGE>"
+        "</REQUESTDATA></IMPORTDATA></BODY></ENVELOPE>"
+    )
+
+    def test_different_tag_map_is_not_served_stale(self):
+        src = FileTallySource(self._XML)
+        first = src.get_collection("Ledger", ["Foo"], {"Foo": ["BAR"]})
+        second = src.get_collection("Ledger", ["Foo"], {"Foo": ["BAZ"]})
+        self.assertEqual(first[0]["Foo"], "from-bar")
+        self.assertEqual(second[0]["Foo"], "from-baz")   # not the cached "from-bar"
+
+    def test_same_tag_map_still_cached(self):
+        src = FileTallySource(self._XML)
+        a = src.get_collection("Ledger", ["Foo"], {"Foo": ["BAR"]})
+        b = src.get_collection("Ledger", ["Foo"], {"Foo": ["BAR"]})
+        self.assertEqual(a, b)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tally_migrator/tests/test_importer.py
+++ b/tally_migrator/tests/test_importer.py
@@ -720,6 +720,52 @@ class TestERPNextImporter(unittest.TestCase):
             "the child must nest under the existing ledger's parent")
         self.assertTrue(any("kept as a ledger" in w["reason"] for w in result.warnings))
 
+    def test_confirmed_hung_account_is_skipped_not_the_whole_phase(self):
+        """The Accounts phase is standalone (not BaseImporter), so its per-record hang
+        guard is wired explicitly. A single account confirmed-hung (timed out twice on a
+        prior attempt) must be skipped with a visible error while every other account
+        still imports - never the whole phase (the defect the base importer had)."""
+        require_company()
+        from tally_migrator.erpnext.importers.accounts import AccountImporter
+        from tally_migrator.tally.extractors import AccountNode
+        from tally_migrator.migration import record_guard
+
+        abbr = frappe.get_value("Company", self.company, "abbr")
+        good = f"_TMTest GuardGood - {abbr}"
+        hung = f"_TMTest GuardHung - {abbr}"
+        for nm in (good, hung):
+            if frappe.db.exists("Account", nm):
+                frappe.delete_doc("Account", nm, force=True, ignore_permissions=True)
+
+        imp = AccountImporter(self.company, abbr, mode="reuse")
+        nodes = [
+            AccountNode(name="_TMTest GuardGood", parent="", is_group=False,
+                        root_type="Asset", account_type="", is_reserved=False),
+            AccountNode(name="_TMTest GuardHung", parent="", is_group=False,
+                        root_type="Asset", account_type="", is_reserved=False),
+        ]
+        # Mark GuardHung as already confirmed-hung, exactly as a resume would (keyed on
+        # the importer's doctype + the Tally account name).
+        record_guard.activate(record_guard.RecordGuard(
+            "L-GUARD", confirmed={("Account", "_TMTest GuardHung")}, timeout_s=999))
+        try:
+            result = imp.run(nodes)
+        finally:
+            record_guard.deactivate()
+
+        try:
+            self.assertTrue(frappe.db.exists("Account", good),
+                            "the non-hung account must still import")
+            self.assertFalse(frappe.db.exists("Account", hung),
+                             "the confirmed-hung account must be skipped, not imported")
+            self.assertTrue(
+                any("_TMTest GuardHung" in e["name"] for e in result.errors),
+                "the skipped account must be recorded as a visible error, not dropped")
+        finally:
+            for nm in (good, hung):
+                if frappe.db.exists("Account", nm):
+                    frappe.delete_doc("Account", nm, force=True, ignore_permissions=True)
+
     # ── Deferred nested-set rebuild (Phase 4) ───────────────────────────────────
 
     def test_account_tree_is_correctly_nested_after_deferred_rebuild(self):

--- a/tally_migrator/tests/test_notify.py
+++ b/tally_migrator/tests/test_notify.py
@@ -1,0 +1,70 @@
+"""Run-finished desk notification (master_migrator.notify_run_finished).
+
+A background (async) run may finish after the wizard tab is closed, so the initiating
+user is told via a persistent Notification Log entry. A synchronous run (no job_id)
+returns its result to the open wizard, so it must stay silent. These lock the gating
+without inserting a real Notification Log (frappe.get_doc is stubbed)."""
+import unittest
+from unittest import mock
+
+from tally_migrator.migration import master_migrator as mm
+
+
+class _Log:
+    def __init__(self, **d):
+        self._d = d
+        self.name = d.get("name", "TML-1")
+
+    def get(self, k):
+        return self._d.get(k)
+
+
+class TestRunFinishedNotification(unittest.TestCase):
+    def _capture(self, log):
+        """Return the list of docdicts notify_run_finished tried to insert."""
+        created = []
+
+        def fake_get_doc(doc):
+            created.append(doc)
+            return mock.Mock()   # .insert(ignore_permissions=True) is a no-op
+
+        with mock.patch.object(mm.frappe, "get_doc", side_effect=fake_get_doc), \
+                mock.patch.object(mm.frappe, "log_error"):
+            mm.notify_run_finished(log)
+        return created
+
+    def test_async_completed_notifies_owner_with_link(self):
+        created = self._capture(
+            _Log(name="L9", job_id="j1", owner="ann@example.com", status="Completed"))
+        self.assertEqual(len(created), 1)
+        doc = created[0]
+        self.assertEqual(doc["doctype"], "Notification Log")
+        self.assertEqual(doc["for_user"], "ann@example.com")
+        self.assertEqual(doc["document_type"], "Tally Migration Log")
+        self.assertEqual(doc["document_name"], "L9")
+        self.assertIn("successfully", doc["subject"])
+
+    def test_completed_with_errors_and_failed_notify(self):
+        for status, needle in (("Completed with Errors", "attention"),
+                               ("Failed", "could not be completed")):
+            created = self._capture(
+                _Log(job_id="j", owner="ann@example.com", status=status))
+            self.assertEqual(len(created), 1, status)
+            self.assertIn(needle, created[0]["subject"])
+
+    def test_sync_run_without_job_id_is_silent(self):
+        self.assertEqual(
+            self._capture(_Log(job_id="", owner="ann@example.com", status="Completed")), [])
+
+    def test_administrator_and_guest_owner_skipped(self):
+        for owner in ("Administrator", "Guest", "", None):
+            self.assertEqual(
+                self._capture(_Log(job_id="j", owner=owner, status="Completed")), [])
+
+    def test_non_terminal_status_skipped(self):
+        self.assertEqual(
+            self._capture(_Log(job_id="j", owner="ann@example.com", status="Running")), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tally_migrator/tests/test_rollback.py
+++ b/tally_migrator/tests/test_rollback.py
@@ -63,6 +63,25 @@ class TestDeletionOrder(unittest.TestCase):
         self.assertLess(order.index("Item Price"), order.index("Item"))
         self.assertLess(order.index("Pricing Rule"), order.index("Item"))
 
+    def test_batches_ordered_between_items_and_openings(self):
+        # Batches (pipeline idx 81) are created after Items and before the Opening Stock
+        # reconciliation that posts into them; reversed deletion must remove the recon
+        # first and the Batch before the Item it belongs to.
+        created = {
+            "Items": [{"name": "Widget", "doctype": "Item"}],
+            "Batches": [{"name": "B-1", "doctype": "Batch"}],
+            "Opening Stock": [{"name": "SR-1", "doctype": "Stock Reconciliation"}],
+        }
+        order = [r["doctype"] for r in rollback._deletion_order(created)]
+        self.assertLess(order.index("Stock Reconciliation"), order.index("Batch"))
+        self.assertLess(order.index("Batch"), order.index("Item"))
+
+    def test_batches_legacy_bare_string_resolves(self):
+        # A legacy bare-string Batches entry must resolve to the Batch doctype now that
+        # the label is mapped (previously it was dropped as unresolvable).
+        rows = rollback._deletion_order({"Batches": ["B-1", "B-2"]})
+        self.assertTrue(all(r["doctype"] == "Batch" for r in rows))
+
     def test_unknown_label_is_deleted_first(self):
         created = {
             "Accounts": [{"name": "Cash", "doctype": "Account"}],
@@ -342,6 +361,25 @@ class TestRevertGuards(unittest.TestCase):
              mock.patch.object(rollback.frappe, "enqueue", lambda *a, **k: None):
             rollback.revert_migration("TML-1", "Frappe Tech")
             self.assertTrue(new_revert.insert.called)   # proceeded to queue a revert
+
+    def test_concurrent_enqueue_is_blocked_by_lock(self):
+        # A first click already holds the per-log enqueue lock; a second concurrent call
+        # must be refused (not create a duplicate revert). This exercises the got_lock=
+        # False branch the other tests never reach (they run with the lock free).
+        log = mock.Mock(company="Frappe Tech", status="Completed",
+                        created_records='{"Items": [{"name": "W", "doctype": "Item"}]}')
+        # Mock(name=...) is the special repr kwarg, not an attribute, so set .name
+        # explicitly - the lock key is f"...:{log.name}", so it must be the real string.
+        log.name = "TML-LOCK"
+        lock_key = "tally_migrator:revert-enqueue:TML-LOCK"
+        rollback.frappe.cache().set(lock_key, "held", nx=True, ex=30)
+        try:
+            with mock.patch.object(rollback.frappe, "get_doc",
+                                   side_effect=self._log_get_doc(log)):
+                with self.assertRaises(frappe.exceptions.ValidationError):
+                    rollback.revert_migration("TML-LOCK", "Frappe Tech")
+        finally:
+            rollback.frappe.cache().delete(lock_key)
 
     def test_stale_in_flight_is_superseded(self):
         # An In Progress revert older than the job timeout is a corpse: mark it Failed


### PR DESCRIPTION
Follow-up fixes from a world-class product-excellence audit of the app. Independent
of #73 (which fixed the two Critical findings); this PR addresses the High/Medium/Low
items. Every fix was reproduced or verified against the code, and each ships with tests.
383 tests pass under `bench run-tests`.

## High

**1. Notify the initiator when a background migration finishes.**
Above 15 MB (and every zip/Drive upload) a run goes to a background job. Progress only
streams to an open wizard tab, so a user who closed it never learned the run finished or
failed. Now posts a persistent Notification Log entry (desk bell), deep-linked to the
migration log, on every terminal status - only for async runs (sync returns inline).
The insert is committed explicitly so the failure notification survives the background
runner's rollback-on-exception (verified against `execute_job`).

**2. Hang-guard the Accounts and Cost-Centre phases.**
These two importers are standalone (not `BaseImporter`) and were the one part of the
pipeline with no per-record hang protection or auto-resume. Wired `record_guard` into
both loops, mirroring `BaseImporter.run`. Integration test proves a confirmed-hung
account is skipped while the rest import.

## Medium

- **Wizard `restart()`** now clears `createdUoms` (previously the previous file's created
  units leaked into the next run's revert manifest) plus the heartbeat/realtime/tracking
  markers.
- **Rollback ledger purge** scoped by `(voucher_type, voucher_no)` instead of name alone.
- **"Batches"** added to the rollback label->doctype map and creation order.
- **Revert start** guarded by a per-log SETNX lock to close the check-then-enqueue race
  (blocking path tested).
- **Wide tables** scroll horizontally inside their card (`overflow-x`).

## Low

- `get_collection` parse-cache key includes the tag map (repr).
- `_parse_tally_date` rejects impossible calendar dates (e.g. 20200231).
- Opening-stock default-warehouse fallback filters by company.
- `account_mapping`: removed a duplicated statement + a shadowed variable.
- Declared `defusedxml` as a dependency (defense-in-depth over #73's guard fix).

## Deferred (with reasons)

- Shared-CSS extraction (needs live render verification), the foreign-Opening-Entry gate
  (behaviour change, needs a real export), site-wide `rebuild_tree` (no clean fix), and
  the out-of-core rewrite (architectural) - documented in the audit, not in this PR.

## Tests

New: `test_notify.py` (5), + accounts-guard integration (1), revert-lock blocking (1),
Batches order (2), date validation (3), cache-key (2). Full regression green across 16
touched modules (383 tests).