### PR TITLE
feat: explain a Temporary Opening mismatch with an actionable account breakdown

### DIFF
--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -424,6 +424,15 @@ Tally opening that does not balance on its own, plus any income or expense openi
 balances that ERPNext does not allow on an opening entry. You clear it as you finish
 your opening entries.
 
+When the reconciliation needs review, the report also breaks down any part of
+Temporary Opening that came from **accounts that could not post their opening
+balance** - either the account was not created (its import failed earlier) or it
+exists as a group account (its Tally ledger had sub-accounts, and a group account
+cannot carry a balance). Each such account is listed with its amount and the reason,
+as a fix-list: correct those accounts and re-run the migration to clear the
+difference. Amounts from the normal income, expense and stock folds are only totalled,
+not listed, since they are expected and do not cause a mismatch.
+
 #### Customer and supplier opening balances
 
 This is where bill-wise detail shows up. Cards summarise how party balances will

--- a/tally_migrator/migration/reconciliation.py
+++ b/tally_migrator/migration/reconciliation.py
@@ -378,8 +378,104 @@ def is_perpetual(company: str) -> bool:
         return True
 
 
+# Why an opening balance did not post to its own account - the two reasons that
+# actually cause the trial balance to differ (as opposed to the harmless folds).
+_DIVERSION_REASON = {
+    "not_created": "the account was not created (its import failed earlier)",
+    "is_group": "the account exists as a group (its Tally ledger had sub-accounts)",
+}
+
+
+def opening_diversion_breakdown(coa, abbr: str, perpetual: bool) -> dict:
+    """Explain what folded into Temporary Opening, split into harmless vs actionable.
+
+    A non-zero Temporary Opening is normal, but when the trial balance does NOT
+    reconcile the cause is almost always an opening that could not post to its own
+    account and fell into Temporary Opening instead. This re-derives, per account,
+    the SAME four-way decision the importer makes in
+    ``OpeningBalanceImporter._account_lines`` - crucially by reading the identical
+    ``is_group`` signal off the Account the importer branched on, so the two cannot
+    disagree - and buckets each diverted opening:
+
+      * **expected** - income/expense openings (ERPNext forbids a P&L opening) and,
+        under perpetual inventory, stock-account openings (posted from items instead).
+        These are mirrored on both sides of the trial balance, so they never cause a
+        mismatch; only their total is reported, as reassurance.
+      * **actionable** - openings whose ERPNext account is missing or is a group.
+        These post on the Tally side but not the ERPNext side, so their total is
+        exactly the visible class gap. Each is listed by name, amount and reason so
+        the user has a fix-list.
+
+    Read-only and best-effort; the caller wraps the whole reconciliation in a guard.
+    """
+    import frappe
+
+    from tally_migrator.naming import company_scoped
+
+    expected_total = 0.0
+    candidates: list[tuple] = []   # (node, company-scoped ERPNext name, amount)
+    for a in coa.accounts:
+        if a.is_group or not a.opening_balance:
+            continue
+        amount = round(abs(a.opening_balance), 2)
+        # Mirrors _account_lines' skip order exactly: P&L first, then perpetual stock,
+        # then the created / group check. Anything that clears all three could post.
+        if a.root_type in ("Income", "Expense"):
+            expected_total += amount
+            continue
+        if perpetual and getattr(a, "account_type", "") == "Stock":
+            expected_total += amount
+            continue
+        candidates.append((a, company_scoped(a.name, abbr), amount))
+
+    # Resolve every candidate's ERPNext is_group in ONE query rather than a lookup per
+    # account: this only runs on a review verdict, but a large healthy COA can still
+    # have many opening accounts to check, and the importer already paid the per-record
+    # cost. Names absent from the result were never created; present ones carry the
+    # same is_group flag the importer branched on, so the two cannot disagree.
+    actionable: list[dict] = []
+    if candidates:
+        is_group_of = {
+            r["name"]: r["is_group"]
+            for r in frappe.get_all(
+                "Account",
+                filters={"name": ["in", [scoped for _, scoped, _ in candidates]]},
+                fields=["name", "is_group"])
+        }
+        for node, scoped, amount in candidates:
+            if scoped not in is_group_of:
+                reason = "not_created"
+            elif is_group_of[scoped]:
+                reason = "is_group"
+            else:
+                reason = ""       # created as a posting account - it posted fine
+            if reason:
+                actionable.append({"name": node.name, "amount": amount,
+                                   "reason": reason, "reason_text": _DIVERSION_REASON[reason]})
+    actionable.sort(key=lambda r: (-r["amount"], r["name"].lower()))
+    return {
+        "expected_total": round(expected_total, 2),
+        "actionable": actionable,
+        "actionable_total": round(sum(r["amount"] for r in actionable), 2),
+    }
+
+
 def build_reconciliation(company: str, abbr: str, coa, masters) -> dict:
-    """Compose the source trial balance, read the ERPNext side, and compare. Read-only."""
-    return compare(
-        source_totals(coa, masters, perpetual=is_perpetual(company)),
+    """Compose the source trial balance, read the ERPNext side, and compare. Read-only.
+
+    When the trial balance needs review, attach the Temporary Opening breakdown so the
+    Log can explain WHICH openings could not post (the usual cause) rather than only
+    showing the residual. Best-effort: a failure to build it never affects the summary.
+    """
+    perpetual = is_perpetual(company)
+    result = compare(
+        source_totals(coa, masters, perpetual=perpetual),
         erpnext_totals(company, abbr))
+    if result.get("verdict") == "review":
+        try:
+            breakdown = opening_diversion_breakdown(coa, abbr, perpetual)
+            if breakdown["actionable"]:
+                result["opening_diversion"] = breakdown
+        except Exception:
+            pass
+    return result

--- a/tally_migrator/tally_migration/doctype/tally_migration_log/tally_migration_log.js
+++ b/tally_migrator/tally_migration/doctype/tally_migration_log/tally_migration_log.js
@@ -681,6 +681,35 @@ function render_reconciliation(frm) {
 		? `<div class="text-muted small" style="margin-top:4px;">Opening value not migrated as stock: ${fmt(nonStock.value)} across ${nonStock.items} service / non-stock item(s) - ERPNext cannot hold stock for these; record their value as a ledger balance if needed.</div>`
 		: "";
 
+	// When the trial balance needs review, the backend attaches the accounts whose
+	// opening could not post to their own account and fell into Temporary Opening -
+	// the usual cause of the difference. Turn the bare residual into a fix-list.
+	const div = r.opening_diversion;
+	let diversionNote = "";
+	if (div && div.actionable && div.actionable.length) {
+		const items = div.actionable
+			.map(
+				(a) =>
+					`<li style="margin-bottom:2px;"><span style="font-weight:500;">${esc(a.name)}</span> - ${fmt(a.amount)} <span class="text-muted">(${esc(a.reason_text)})</span></li>`
+			)
+			.join("");
+		const n = div.actionable.length;
+		const list = collapsible(
+			n,
+			`Show ${n} account(s)`,
+			`<ul style="margin:6px 0 0 0; padding-left:18px; font-size:12px;">${items}</ul>`
+		);
+		diversionNote = callout(
+			"error",
+			iconRow(
+				"error",
+				`<div><span style="font-weight:500;">${fmt(div.actionable_total)} of the Temporary Opening is ${n} account(s) that could not post.</span> ` +
+					`Fix each account below and re-run the migration to clear the difference.</div>${list}`
+			),
+			"margin-top:8px;"
+		);
+	}
+
 	wrapper.html(section(`
 		<div style="${CARD} max-width:100%;">
 			${callout(v.kind, iconRow(v.kind, v.text), "margin-bottom:8px;")}
@@ -710,6 +739,7 @@ function render_reconciliation(frm) {
 			</table>
 			${stockNote}
 			${nonStockNote}
+			${diversionNote}
 		</div>
 	`));
 }

--- a/tally_migrator/tests/test_reconciliation.py
+++ b/tally_migrator/tests/test_reconciliation.py
@@ -324,5 +324,137 @@ class TestCumulativeOpeningsFlag(unittest.TestCase):
         self.assertTrue(rec.get("cumulative_openings"))
 
 
+def _acct2(name, root, amount, dr_cr, account_type="", is_group=False):
+    return AccountNode(name=name, parent="", is_group=is_group, root_type=root,
+                       account_type=account_type, is_reserved=False,
+                       opening_balance=amount, opening_dr_cr=dr_cr)
+
+
+class TestOpeningDiversionBreakdown(unittest.TestCase):
+    """opening_diversion_breakdown re-derives, per account, the same four-way fold the
+    importer makes, splitting what landed in Temporary Opening into harmless folds vs
+    accounts that could not post (the fix-list). The is_group lookup is mocked so the
+    logic is exercised offline, exactly the signal the importer branches on."""
+
+    def _run(self, coa, db_is_group, perpetual=True):
+        # db_is_group: account base name -> its ERPNext is_group value
+        #   (None or absent = account not created, 1 = group, 0 = ordinary account).
+        # The breakdown resolves all candidates in ONE frappe.get_all, so the stub
+        # returns a row only for accounts that exist (None/absent are simply omitted,
+        # exactly as a real query would).
+        from tally_migrator.migration import reconciliation as rc
+
+        def fake_get_all(doctype, filters=None, fields=None, **kw):
+            wanted = filters["name"][1]   # ("in", [scoped names])
+            rows = []
+            for scoped in wanted:
+                base = scoped.rsplit(" - ", 1)[0]   # strip the " - ABBR" suffix
+                val = db_is_group.get(base)
+                if val is not None:
+                    rows.append({"name": scoped, "is_group": val})
+            return rows
+
+        fake_frappe = SimpleNamespace(get_all=fake_get_all)
+        with mock.patch.dict("sys.modules", {"frappe": fake_frappe}):
+            return rc.opening_diversion_breakdown(coa, "ABBR", perpetual)
+
+    def test_not_created_and_group_are_actionable(self):
+        coa = _coa([
+            _acct2("Machinery", "Asset", 210000, "Dr"),   # missing in ERPNext
+            _acct2("Sundry Loans", "Liability", 130000, "Cr"),  # exists as group
+            _acct2("Cash", "Asset", 5000, "Dr"),          # posted fine
+        ])
+        b = self._run(coa, {"Machinery": None, "Sundry Loans": 1, "Cash": 0})
+        names = {a["name"]: a["reason"] for a in b["actionable"]}
+        self.assertEqual(names, {"Machinery": "not_created", "Sundry Loans": "is_group"})
+        self.assertEqual(b["actionable_total"], 340000.0)
+        # Sorted by amount desc, so the biggest offender is first.
+        self.assertEqual(b["actionable"][0]["name"], "Machinery")
+        self.assertEqual(b["expected_total"], 0.0)
+
+    def test_income_expense_and_perpetual_stock_are_expected_not_actionable(self):
+        coa = _coa([
+            _acct2("Sales", "Income", 1900, "Cr"),
+            _acct2("Rent", "Expense", 2000, "Dr"),
+            _acct2("Opening Stock", "Asset", 50000, "Dr", account_type="Stock"),
+            _acct2("Machinery", "Asset", 210000, "Dr"),   # the only real problem
+        ])
+        # Even if the DB says the P&L / stock accounts are missing, they must NOT be
+        # actionable: the importer folds them by design, so they are mirrored on both
+        # sides and never cause a mismatch.
+        b = self._run(coa, {"Machinery": None}, perpetual=True)
+        self.assertEqual([a["name"] for a in b["actionable"]], ["Machinery"])
+        self.assertEqual(b["expected_total"], 53900.0)   # 1900 + 2000 + 50000
+
+    def test_stock_is_actionable_under_periodic_inventory(self):
+        # Without perpetual inventory the stock opening IS posted to the JE, so a
+        # missing/group stock account is a genuine problem, not an expected fold.
+        coa = _coa([_acct2("Opening Stock", "Asset", 50000, "Dr", account_type="Stock")])
+        b = self._run(coa, {"Opening Stock": None}, perpetual=False)
+        self.assertEqual([a["name"] for a in b["actionable"]], ["Opening Stock"])
+        self.assertEqual(b["expected_total"], 0.0)
+
+    def test_actionable_total_ties_to_the_class_gap(self):
+        # The actionable total must equal the amount the class row reads short by, so
+        # the fix-list explains the whole visible difference. Machinery (Asset 210000)
+        # is absent, so ERPNext's Asset is short by exactly that.
+        coa = _coa([
+            _acct2("Cash", "Asset", 5000, "Dr"),
+            _acct2("Machinery", "Asset", 210000, "Dr"),
+        ])
+        b = self._run(coa, {"Cash": 0, "Machinery": None})
+        src_asset = _classes(source_totals(coa, _masters()))["Asset"]["amount"]  # 215000
+        posted_asset = src_asset - b["actionable_total"]                          # 5000
+        self.assertEqual(b["actionable_total"], 210000.0)
+        self.assertEqual(posted_asset, 5000.0)
+
+    def test_groups_and_zero_openings_skipped(self):
+        coa = _coa([
+            _acct2("Current Assets", "Asset", 0, "", is_group=True),  # group node
+            _acct2("Petty Cash", "Asset", 0, "Dr"),                   # no opening
+        ])
+        b = self._run(coa, {})
+        self.assertEqual(b["actionable"], [])
+        self.assertEqual(b["actionable_total"], 0.0)
+
+    def test_all_candidate_accounts_resolved_in_a_single_query(self):
+        # The lookup must be batched: one query for every opening account, not one per
+        # account (which on a large reviewed COA would be thousands of round-trips).
+        from tally_migrator.migration import reconciliation as rc
+        coa = _coa([_acct2(f"Ledger {i}", "Asset", 100 + i, "Dr") for i in range(50)])
+        calls = {"n": 0}
+
+        def counting_get_all(doctype, filters=None, fields=None, **kw):
+            calls["n"] += 1
+            # Every requested name resolves to a posting account (is_group 0).
+            return [{"name": s, "is_group": 0} for s in filters["name"][1]]
+
+        fake_frappe = SimpleNamespace(get_all=counting_get_all)
+        with mock.patch.dict("sys.modules", {"frappe": fake_frappe}):
+            rc.opening_diversion_breakdown(coa, "ABBR", True)
+        self.assertEqual(calls["n"], 1)
+
+    def test_build_reconciliation_attaches_only_on_review_with_actionable(self):
+        # reconciled verdict -> no breakdown; review with an actionable account -> attach.
+        from tally_migrator.migration import reconciliation as rc
+        coa = _coa([_acct2("Machinery", "Asset", 210000, "Dr")])
+
+        def fake_totals(company, abbr):
+            return {"available": True, "classes": {}, "receivables": None,
+                    "payables": None, "stock": {"amount": 0.0, "dr_cr": ""},
+                    "temporary_opening": {"amount": 0.0, "dr_cr": ""}}
+
+        # Machinery is absent from ERPNext (get_all returns no row) -> not_created.
+        fake_frappe = SimpleNamespace(get_all=lambda *a, **k: [])
+        with mock.patch.object(rc, "erpnext_totals", fake_totals), \
+             mock.patch.object(rc, "is_perpetual", lambda c: True), \
+             mock.patch.dict("sys.modules", {"frappe": fake_frappe}):
+            res = rc.build_reconciliation("Co", "ABBR", coa, _masters())
+        # ERPNext Asset is empty but Tally has 210000 -> mismatch -> review + attached.
+        self.assertEqual(res["verdict"], "review")
+        self.assertIn("opening_diversion", res)
+        self.assertEqual(res["opening_diversion"]["actionable"][0]["name"], "Machinery")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

When the post-import opening trial balance does not reconcile, the report now explains **which** opening balances could not post to their own account and fell into Temporary Opening, instead of showing only the residual figure.

## Why

A non-zero Temporary Opening is normal (it holds the income/expense openings ERPNext cannot carry, plus the stock openings posted from items). But when the trial balance genuinely differs, the cause is almost always an opening that could not post to its own account - the account was not created (an earlier import failure) or it exists as a group account. Those amounts fall into Temporary Opening too, so the residual alone could not tell the user what to fix.

## How

- `reconciliation.opening_diversion_breakdown()` re-derives, per account, the same four-way decision the opening importer makes (`OpeningBalanceImporter._account_lines`) - reading the identical `is_group` signal off the ERPNext account the importer branched on, so the two cannot disagree. It splits diverted openings into:
  - **expected** (income/expense, and perpetual-inventory stock) - mirrored on both sides, so only totalled;
  - **actionable** (account missing or is a group) - listed by name, amount and reason as a fix-list.
- Attached to the reconciliation report only when the verdict is "review" and there is something actionable, so reconciled runs stay clean.
- The Migration Log renders it as a fix-list under the trial balance.
- All candidate accounts are resolved in a single query (not one per account).

Read-only and best-effort; a failure to build the breakdown never affects the run or the rest of the summary.

## Tests

New unit tests: not-created and group accounts land in actionable; income/expense and perpetual-stock stay in expected; the actionable total ties to the class gap; single-query batching; attach-only-on-review wiring. Full suite green.
