### PR TITLE
feat: let users correct an inferred account's classification on the Preview step

### DIFF
--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -402,15 +402,22 @@ Three summary cards:
   cleanly using Tally's standard, named groups. No guessing was needed.
 - **We had to infer** (blue, "please check") - ledgers that sit under a *custom*
   Tally group, so we worked out their type (asset, liability, income, expense) from
-  the group's own nature. These are the rows worth your eye. A type shown as "--"
-  is one we genuinely could not determine; set it in ERPNext after import, or fix
-  the group in Tally and re-upload.
+  the group's own nature. These are the rows worth your eye. A type shown as
+  "- select -" is one we genuinely could not determine.
 - **Opening balances** - shows **Balanced (Dr = Cr)** when your opening balances net
   to zero on their own, or the amount held in **Temporary Opening** when they do not.
 
 When there are inferred accounts, a table lists each one with the type we assigned
-and its opening balance, largest balance first. When there are none, you get a green
-confirmation that all accounts mapped using Tally's standard groups.
+and its opening balance, largest balance first. Each inferred account's type is a
+**dropdown you can correct**: pick the right root type (Asset, Liability, Equity,
+Income, or Expense) if our guess is wrong, and the preview - including the opening
+balances plug - updates to match before you import. Only the root type is editable;
+the finer account type (Bank, Tax, and so on) is set automatically and not exposed,
+because it drives bank-account creation and GST behaviour and must come from a
+precise signal rather than a manual pick. Your correction is applied to the import
+and recorded in the Migration Log's list of edits. When there are no inferred
+accounts, you get a green confirmation that all accounts mapped using Tally's
+standard groups.
 
 A **"Show all ... mapped accounts"** disclosure expands the full chart of accounts,
 grouped by class, with each ledger's account type, parent group, and opening

--- a/tally_migrator/api.py
+++ b/tally_migrator/api.py
@@ -429,7 +429,7 @@ def run_masters_migration_from_file(file_url: str, erpnext_company: str = "", uo
     source = _source_from_file(file_url)[1]
     config = _build_masters_config(
         file_url, file_doc.file_name, erpnext_company, source,
-        validation_report, coa_mode, posting_date)
+        validation_report, coa_mode, posting_date, records)
     return _run_and_summarize(config, source, uom, records, created)
 
 
@@ -452,6 +452,11 @@ def rerun_from_log(log_name: str):
         )
 
     _, source = _source_from_file(log.source_file)
+    # Replay the user's original pre-flight choices, or the re-run silently reverts
+    # custom UOMs to defaults and drops every inline GST/state/HSN/classification fix
+    # that made the first run viable.
+    uom = json.loads(log.uom_overrides) if log.get("uom_overrides") else {}
+    records = json.loads(log.record_overrides) if log.get("record_overrides") else {}
     config = TallyConfig(
         erpnext_company=log.company,
         tally_company=log.tally_company,
@@ -459,17 +464,13 @@ def rerun_from_log(log_name: str):
         validation_report=log.validation_report or "",
         # Recomputed from the (unchanged) source so the new log's coverage is current.
         coverage_report=frappe.as_json(coverage_report(source)),
-        mapping_report=frappe.as_json(account_mapping(source, log.company)),
+        # Fold the replayed edits in, so the stored mapping matches what re-runs.
+        mapping_report=frappe.as_json(account_mapping(source, log.company, records)),
         # Repeat the original run's options rather than silently reverting to
         # defaults (reuse / fiscal-year start).
         coa_mode=log.coa_mode or "reuse",
         posting_date=str(log.posting_date or ""),
     )
-    # Replay the user's original pre-flight choices, or the re-run silently reverts
-    # custom UOMs to defaults and drops every inline GST/state/HSN fix that made the
-    # first run viable.
-    uom = json.loads(log.uom_overrides) if log.get("uom_overrides") else {}
-    records = json.loads(log.record_overrides) if log.get("record_overrides") else {}
     return _run_and_summarize(config, source, uom, records)
 
 
@@ -954,8 +955,14 @@ def _assert_within_size_limit(num_bytes: int) -> None:
 
 
 def _build_masters_config(file_url, file_name, erpnext_company, source,
-                          validation_report, coa_mode, posting_date) -> TallyConfig:
-    """Assemble the TallyConfig for a masters run (shared by sync + background)."""
+                          validation_report, coa_mode, posting_date,
+                          record_overrides: dict | None = None) -> TallyConfig:
+    """Assemble the TallyConfig for a masters run (shared by sync + background).
+
+    ``record_overrides`` (the pre-flight edits) are folded into the stored mapping
+    report so the Log's accounts-mapping snapshot shows the same classification that
+    was imported - including any root_type a user corrected on Preview - rather than
+    the original inferred guess."""
     return TallyConfig(
         erpnext_company=erpnext_company,
         tally_company=f"File: {file_name or file_url}",
@@ -964,7 +971,8 @@ def _build_masters_config(file_url, file_name, erpnext_company, source,
         # Computed server-side from the actual file so the stored audit record of
         # un-migrated fields is authoritative, not client-supplied.
         coverage_report=frappe.as_json(coverage_report(source)),
-        mapping_report=frappe.as_json(account_mapping(source, erpnext_company)),
+        mapping_report=frappe.as_json(
+            account_mapping(source, erpnext_company, record_overrides)),
         coa_mode=coa_mode if coa_mode in ("reuse", "mirror") else "reuse",
         posting_date=posting_date or "",
     )
@@ -1045,7 +1053,7 @@ def _run_masters_job(file_url, erpnext_company, uom_overrides, validation_report
     file_doc, source = _source_from_file(file_url)
     config = _build_masters_config(
         file_url, file_doc.file_name, erpnext_company, source,
-        validation_report, coa_mode, posting_date)
+        validation_report, coa_mode, posting_date, records)
     log = frappe.get_doc("Tally Migration Log", log_name)
     # Backfill the source-derived reports the (deferred) web request left empty, so an
     # enqueued run's log shows the same coverage/mapping a synchronous run would. Only

--- a/tally_migrator/api.py
+++ b/tally_migrator/api.py
@@ -14,7 +14,8 @@ from tally_migrator.erpnext.uom_resolver import UomResolver
 from tally_migrator.validation.engine import (
     validate_extraction, group_report, records_by_key, erpnext_states,
 )
-from tally_migrator.migration.overrides import apply_record_overrides
+from tally_migrator.migration.overrides import (
+    apply_record_overrides, apply_account_overrides)
 from tally_migrator.migration.coverage import coverage_report
 from tally_migrator.migration.account_mapping import account_mapping
 from tally_migrator.migration.readiness import check_readiness
@@ -239,13 +240,15 @@ def _compute_preflight(file_url, record_overrides, erpnext_company, posting_date
     extractor = TallyExtractor(source)
     masters = apply_record_overrides(extractor.extract_all(), overrides)
     # COA is extracted too so hierarchy checks (cycles) can cover accounts and cost
-    # centres, not just the inventory masters carried on ``masters``.
-    coa = extractor.extract_coa()
+    # centres, not just the inventory masters carried on ``masters``. Account
+    # re-classifications (root_type) are applied so validation sees the same COA the
+    # import will, matching how account_mapping below reflects the edits.
+    coa = apply_account_overrides(extractor.extract_coa(), overrides)
     payload = group_report(
         validate_extraction(masters=masters, coa=coa), records_by_key(masters))
     payload["states"] = erpnext_states()
     payload["coverage"] = coverage_report(source)
-    payload["account_mapping"] = account_mapping(source, erpnext_company)
+    payload["account_mapping"] = account_mapping(source, erpnext_company, overrides)
     if erpnext_company:
         payload["readiness"] = check_readiness(erpnext_company, posting_date)
     items = source.get_collection("Stock Item", ITEM_FIELDS, ITEM_TAGS)

--- a/tally_migrator/migration/account_mapping.py
+++ b/tally_migrator/migration/account_mapping.py
@@ -27,6 +27,8 @@ from tally_migrator.tally.extractors import (
     TallyExtractor, GROUP_FIELDS, GROUP_TAGS, LEDGER_FIELDS, LEDGER_TAGS,
 )
 from tally_migrator.tally.resolver import LedgerResolver
+from tally_migrator.migration.overrides import (
+    apply_record_overrides, apply_account_overrides)
 
 # ERPNext's canonical root-type order - how an accountant reads a trial balance.
 _ROOT_ORDER = ["Asset", "Liability", "Equity", "Income", "Expense"]
@@ -39,16 +41,21 @@ _PLUG_EPSILON = 0.01
 _PARTY_PLUG_THRESHOLD = 1.0
 
 
-def account_mapping(source, company: str = "") -> dict:
+def account_mapping(source, company: str = "", overrides: dict | None = None) -> dict:
     """Build the accounts-mapping preview for an uploaded Tally masters file.
 
     ``company`` (the chosen ERPNext target, when known) lets the opening plug reflect the
     company's inventory mode, so the Review-screen plug matches the post-import
     reconciliation. Blank when no company is chosen yet - the plug then counts stock, as
-    before."""
+    before.
+
+    ``overrides`` are the pre-flight edits made so far (same JSON the import uses), so the
+    inferred-accounts table and the opening plug reflect the user's own re-classifications
+    (root_type) exactly as they will import - otherwise a recompute would show the account
+    back under its original guess and appear to discard the edit."""
     extractor = TallyExtractor(source)
-    coa = extractor.extract_coa()
-    masters = extractor.extract_all()
+    coa = apply_account_overrides(extractor.extract_coa(), overrides)
+    masters = apply_record_overrides(extractor.extract_all(), overrides)
     bills = extractor.extract_bill_allocations()
 
     groups = source.get_collection("Group", GROUP_FIELDS, GROUP_TAGS)

--- a/tally_migrator/migration/master_migrator.py
+++ b/tally_migrator/migration/master_migrator.py
@@ -7,7 +7,8 @@ import frappe
 from tally_migrator.tally.config import TallyConfig
 from tally_migrator.tally.extractors import TallyExtractor, ExtractedMasters
 from tally_migrator.erpnext.importers import ERPNextImporter, ImportResult
-from tally_migrator.migration.overrides import apply_record_overrides, uom_edits
+from tally_migrator.migration.overrides import (
+    apply_record_overrides, apply_account_overrides, uom_edits)
 from tally_migrator.migration import record_guard
 
 
@@ -347,6 +348,10 @@ class MasterMigrator:
             apply_record_overrides(masters, self.record_overrides, self.applied_edits)
             self._record_uom_edits()
             coa = self.extractor.extract_coa()
+            # Account re-classifications the user confirmed on the Preview screen
+            # (root_type only) are applied to the freshly-extracted COA, before it is
+            # imported or reported on. Same audit trail as the record edits above.
+            apply_account_overrides(coa, self.record_overrides, self.applied_edits)
             # Bill-wise party opening detail (BILLALLOCATIONS) - empty when the
             # source can't supply child lists, so party openings then degrade to a
             # single lump opening invoice per party (no bill breakdown).

--- a/tally_migrator/migration/overrides.py
+++ b/tally_migrator/migration/overrides.py
@@ -61,6 +61,69 @@ def apply_record_overrides(masters, overrides: dict | None, changelog: list | No
     return masters
 
 
+# The account_type that goes with each root_type when a user re-classifies an
+# account, mirroring the resolver's derived-nature table (see resolver._DERIVED_NATURE):
+# only Income/Expense accounts carry a special account_type; Asset/Liability/Equity are
+# ordinary (""). Overriding the root must reset the account_type to match, or an account
+# moved to (say) Income would keep a stale "Stock"/"" tag inconsistent with its new root.
+_ROOT_ACCOUNT_TYPE = {
+    "Asset": "", "Liability": "", "Equity": "",
+    "Income": "Income Account", "Expense": "Expense Account",
+}
+# The only root_types a user may pick on the Preview screen (the five ERPNext roots).
+EDITABLE_ROOT_TYPES = tuple(_ROOT_ACCOUNT_TYPE)
+
+
+def apply_account_overrides(coa, overrides: dict | None, changelog: list | None = None):
+    """Patch account classification in ``coa`` in place from the "Account" override
+    bucket. Returns ``coa`` for chaining.
+
+    Only ``root_type`` is user-editable (Asset/Liability/Equity/Income/Expense) - the
+    finer ``account_type`` (Bank/Tax/Receivable/…) is deliberately NOT exposed, because
+    it drives bank-account creation and India Compliance's GST behaviour and must come
+    from a precise signal, never a free-form pick. When a root_type is changed we also:
+
+      * reset ``account_type`` to the derived default for the new root, so an account
+        moved to Income/Expense carries the right tag and one moved to a balance-sheet
+        root drops any P&L tag; and
+      * clear the node's ``parent`` so the account importer re-homes it directly under
+        the new root's group (``_resolve_parent`` falls back to the root group when
+        parent is blank). Without this the account would keep a parent belonging to its
+        OLD root, and ERPNext rejects a child whose root_type differs from its parent's.
+
+    Only leaf accounts (``not is_group``) are editable, so clearing the parent never
+    strands child accounts. Overrides come from the Preview screen; the uploaded XML is
+    never touched. Blank / unknown / unchanged values are ignored. When ``changelog`` is
+    given, every effective change is appended in the same shape as the field-edit trail.
+    """
+    if not overrides:
+        return coa
+    by_name = overrides.get("Account") or {}
+    if not by_name:
+        return coa
+    for node in getattr(coa, "accounts", []):
+        if node.is_group:
+            continue
+        patch = by_name.get(node.name)
+        if not patch:
+            continue
+        new_root = (patch.get("root_type") or "").strip()
+        if new_root not in _ROOT_ACCOUNT_TYPE or new_root == node.root_type:
+            continue  # blank, unrecognised, or no effective change
+        if changelog is not None:
+            changelog.append({
+                "entity_type": "Account",
+                "record_name": node.name,
+                "field": "root_type",
+                "old": node.root_type,
+                "new": new_root,
+            })
+        node.root_type = new_root
+        node.account_type = _ROOT_ACCOUNT_TYPE[new_root]
+        node.parent = ""   # re-home under the new root's group (see docstring)
+    return coa
+
+
 def uom_edits(uom_overrides: dict | None,
               created_uoms: list | None = None) -> list[dict]:
     """Audit-trail rows for the pre-flight UOM resolutions, in the same shape as the

--- a/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
+++ b/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
@@ -1376,6 +1376,11 @@ class TallyMigratorPage {
 	static get STAT_BG() {
 		return { green: "green", blue: "blue", gray: "gray" };
 	}
+	// The five ERPNext root types a user may choose when correcting an inferred
+	// account's classification on the Preview step. Order matches a trial balance.
+	static get ROOT_TYPES() {
+		return ["Asset", "Liability", "Equity", "Income", "Expense"];
+	}
 	// `tone` is a tm-pill colour keyword (green / blue / gray). For back-compat a raw
 	// CSS colour value still works via an inline fallback.
 	static pill(text, tone) {
@@ -1663,6 +1668,29 @@ class TallyMigratorPage {
 		this.saveDraft();          // persist each inline fix as it's made
 	}
 
+	// The Preview step's inferred-accounts dropdown: record (or clear) a root_type
+	// override for one account, persist it, then recompute so the whole Review - the
+	// table AND the opening-balances plug card - reflects the new classification, the
+	// same recompute the Check step uses. Clearing back to "- select -" removes the
+	// override so the account reverts to our inferred guess.
+	captureAccountEdit(el) {
+		const $el = $(el);
+		const name = $el.data("name");
+		const val = $el.val();
+		const bucket = (this.recordOverrides["Account"] = this.recordOverrides["Account"] || {});
+		const forName = (bucket[name] = bucket[name] || {});
+		if (val) {
+			forName.root_type = val;
+		} else {
+			delete forName.root_type;
+			if (!Object.keys(forName).length) delete bucket[name];
+		}
+		if (!Object.keys(bucket).length) delete this.recordOverrides["Account"];
+		this.saveDraft();
+		this._rerenderReviewAfterRecheck = true;
+		this.recheck();
+	}
+
 	// Re-validate with the in-memory edits applied - fixes are confirmed by the same
 	// engine, so resolved issues drop off and any remaining ones stay visible.
 	recheck() {
@@ -1707,6 +1735,13 @@ class TallyMigratorPage {
 				this.renderDataQuality();
 				this.renderCoverage();
 				this._updateCheckContinue();
+				// When the recheck was triggered by an account re-classification on the
+				// Preview step, re-render that step too so the inferred table and the
+				// opening-balances plug reflect the new classification immediately.
+				if (this._rerenderReviewAfterRecheck) {
+					this._rerenderReviewAfterRecheck = false;
+					if (this.hasAccounts()) this.renderAccountMapping();
+				}
 			},
 			error: () => {
 				frappe.dom.unfreeze();
@@ -1899,6 +1934,29 @@ class TallyMigratorPage {
 				? `<span class="text-muted">--</span>`
 				: esc(r.root_type) + (r.account_type ? ` · ${esc(r.account_type)}` : "");
 
+		// The inferred rows are editable: the user can correct our guess of the root
+		// type (the big Asset/Liability/Equity/Income/Expense bucket) before importing.
+		// The finer account_type is intentionally NOT editable - it drives bank-account
+		// creation and GST behaviour and must come from a precise signal, not a pick.
+		const currentRoot = (name) => {
+			const b = (this.recordOverrides["Account"] || {})[name] || {};
+			return b.root_type || "";
+		};
+		const classSelect = (r) => {
+			const cur = currentRoot(r.name) || (r.uncertain ? "" : r.root_type);
+			const opts = ['<option value="">- select -</option>']
+				.concat(
+					TallyMigratorPage.ROOT_TYPES.map(
+						(t) => `<option value="${t}" ${t === cur ? "selected" : ""}>${t}</option>`
+					)
+				)
+				.join("");
+			const tag = r.account_type && cur && !r.uncertain && cur === r.root_type
+				? ` <span class="text-muted">· ${esc(r.account_type)}</span>`
+				: "";
+			return `<select class="acct-class-edit form-control input-xs" data-name="${esc(r.name)}" style="display:inline-block; width:auto; min-width:120px;">${opts}</select>${tag}`;
+		};
+
 		// ── Summary cards ──────────────────────────────────────────────────────
 		// Same card language as Step 3: regular-black number, status carried by a
 		// soft background pill (green = good, amber = worth a look, grey = none).
@@ -1950,14 +2008,14 @@ class TallyMigratorPage {
 					(r) => `
 					<tr>
 						<td><strong>${esc(r.name)}</strong></td>
-						<td class="text-muted">${classifiedAs(r)}</td>
+						<td>${classSelect(r)}</td>
 						<td class="tm-num">${ob(r)}</td>
 					</tr>`
 				)
 				.join("");
 			$("#review-exceptions").html(
 				TallyMigratorPage.callout("info", `
-					${TallyMigratorPage.iconRow("info", `<strong>${fmt(inferred)} account${inferred === 1 ? "" : "s"} we inferred - please confirm.</strong> These ledgers sit under a custom Tally group, so we inferred each type from the group's own nature (income/expense/asset/liability). A type shown as "--" is one we couldn't determine. Confirm these, or fix the group in Tally and re-upload.`)}
+					${TallyMigratorPage.iconRow("info", `<strong>${fmt(inferred)} account${inferred === 1 ? "" : "s"} we inferred - please confirm or correct.</strong> These ledgers sit under a custom Tally group, so we inferred each type from the group's own nature (income/expense/asset/liability). A type shown as "- select -" is one we couldn't determine. Pick the correct type here, or fix the group in Tally and re-upload.`)}
 					<div class="tm-card" style="margin-top:var(--margin-sm);">
 						<table class="table table-condensed tm-table" style="table-layout:fixed;">
 							${REVIEW_COLGROUP}
@@ -1972,6 +2030,9 @@ class TallyMigratorPage {
 						</table>
 					</div>
 				`)
+			);
+			$("#review-exceptions .acct-class-edit").on("change", (e) =>
+				this.captureAccountEdit(e.currentTarget)
 			);
 		} else {
 			$("#review-exceptions").html(

--- a/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
+++ b/tally_migrator/tally_migration/page/tally_migrator/tally_migrator.js
@@ -966,6 +966,9 @@ class TallyMigratorPage {
 
 	_onPreflightFailed(msg) {
 		this._checkLoading = false;
+		// A failed recheck must clear this one-shot flag, or a later successful recheck
+		// (e.g. a plain data-quality re-check) would stray-render the Preview step.
+		this._rerenderReviewAfterRecheck = false;
 		this.qualityError = msg || __("The file could not be validated.");
 		this.qualityReport = null;
 		$("#check-loading").hide();

--- a/tally_migrator/tests/test_account_mapping.py
+++ b/tally_migrator/tests/test_account_mapping.py
@@ -213,5 +213,38 @@ class TestAccountMapping(unittest.TestCase):
         self.assertEqual(row["documents"], 2)
 
 
+class TestAccountMappingReflectsOverrides(unittest.TestCase):
+    """The Preview screen must show a user's root_type correction (and its knock-on to
+    the opening plug), so a recompute after an edit doesn't discard it - the contract
+    the wizard's inferred-accounts dropdown relies on."""
+
+    def _override(self, root):
+        return {"Account": {"Weird Ledger": {"root_type": root}}}
+
+    def test_inferred_row_shows_the_overridden_root_type(self):
+        m = account_mapping(_Src(GROUPS, LEDGERS), overrides=self._override("Income"))
+        row = next(r for r in m["inferred"] if r["name"] == "Weird Ledger")
+        self.assertEqual(row["root_type"], "Income")
+        self.assertEqual(row["account_type"], "Income Account")
+
+    def test_overridden_account_moves_to_its_new_root_group_in_the_book(self):
+        m = account_mapping(_Src(GROUPS, LEDGERS), overrides=self._override("Income"))
+        income = next((g for g in m["groups"] if g["root_type"] == "Income"), None)
+        self.assertIsNotNone(income)
+        self.assertIn("Weird Ledger", [r["name"] for r in income["accounts"]])
+
+    def test_reclassifying_to_pl_shifts_the_opening_plug(self):
+        # Weird Ledger carries a 2000 Dr opening. As an Asset it counts in the class
+        # totals; reclassified to Income (a P&L root ERPNext can't open on an opening
+        # entry) it leaves the class totals and folds into the Temporary Opening
+        # residual, so the plug moves by exactly that opening amount. This proves the
+        # edit reaches the plug, not only the classification table.
+        base = account_mapping(_Src(GROUPS, LEDGERS))["opening"]["temporary_opening_plug"]
+        moved = account_mapping(
+            _Src(GROUPS, LEDGERS),
+            overrides=self._override("Income"))["opening"]["temporary_opening_plug"]
+        self.assertEqual(round(abs(moved - base), 2), 2000.0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tally_migrator/tests/test_account_overrides.py
+++ b/tally_migrator/tests/test_account_overrides.py
@@ -1,0 +1,114 @@
+"""Tests for user-corrected account classification (the Preview-step root_type edit).
+
+Two layers:
+  * ``apply_account_overrides`` - the pure patch on the extracted COA (offline).
+  * the consistency contract - an overridden account must re-home under a parent that
+    matches its NEW root_type, so ERPNext never rejects a child/parent root mismatch.
+    Verified at the ``AccountImporter._resolve_parent`` seam (the code that places each
+    account), with the DB-touching root-group lookup stubbed.
+"""
+import types
+import unittest
+from unittest import mock
+
+from tally_migrator.tally.extractors import AccountNode, ExtractedCOA
+from tally_migrator.migration.overrides import apply_account_overrides
+from tally_migrator.erpnext.importers import AccountImporter
+
+
+def _acct(name, root, parent="Custom Group", account_type="", is_group=False,
+          amount=1000.0, dr_cr="Dr"):
+    return AccountNode(name=name, parent=parent, is_group=is_group, root_type=root,
+                       account_type=account_type, is_reserved=False,
+                       opening_balance=amount, opening_dr_cr=dr_cr)
+
+
+def _coa(accounts):
+    return ExtractedCOA(accounts=accounts, cost_centres=[])
+
+
+class TestApplyAccountOverrides(unittest.TestCase):
+    def test_reclassify_updates_root_account_type_and_rehomes(self):
+        coa = _coa([_acct("Weird Ledger", "Liability", parent="Suspense",
+                          account_type="")])
+        log = []
+        apply_account_overrides(
+            coa, {"Account": {"Weird Ledger": {"root_type": "Income"}}}, log)
+        node = coa.accounts[0]
+        self.assertEqual(node.root_type, "Income")
+        # account_type reset to the derived default for the new root...
+        self.assertEqual(node.account_type, "Income Account")
+        # ...and the parent cleared so the importer re-homes it under the new root.
+        self.assertEqual(node.parent, "")
+        self.assertEqual(log, [{
+            "entity_type": "Account", "record_name": "Weird Ledger",
+            "field": "root_type", "old": "Liability", "new": "Income"}])
+
+    def test_move_to_balance_sheet_root_clears_pl_account_type(self):
+        coa = _coa([_acct("Misclassified", "Income", account_type="Income Account")])
+        apply_account_overrides(
+            coa, {"Account": {"Misclassified": {"root_type": "Asset"}}})
+        self.assertEqual(coa.accounts[0].account_type, "")
+
+    def test_group_account_is_never_touched(self):
+        coa = _coa([_acct("Some Group", "Asset", is_group=True)])
+        apply_account_overrides(
+            coa, {"Account": {"Some Group": {"root_type": "Income"}}})
+        self.assertEqual(coa.accounts[0].root_type, "Asset")
+
+    def test_no_op_and_blank_and_unknown_are_ignored(self):
+        coa = _coa([
+            _acct("A", "Asset"), _acct("B", "Asset"), _acct("C", "Asset")])
+        log = []
+        apply_account_overrides(coa, {"Account": {
+            "A": {"root_type": "Asset"},     # same value - no effective change
+            "B": {"root_type": ""},          # blank - ignored
+            "C": {"root_type": "Bogus"},     # not a real root - ignored
+        }}, log)
+        self.assertEqual([a.root_type for a in coa.accounts], ["Asset"] * 3)
+        # Untouched accounts keep their real parent (no accidental re-home).
+        self.assertEqual([a.parent for a in coa.accounts], ["Custom Group"] * 3)
+        self.assertEqual(log, [])
+
+    def test_other_buckets_and_empty_overrides_ignored(self):
+        coa = _coa([_acct("A", "Asset")])
+        # Record-override buckets for parties/items must not affect the COA.
+        apply_account_overrides(coa, {"Customer": {"A": {"root_type": "Income"}}})
+        apply_account_overrides(coa, {})
+        apply_account_overrides(coa, None)
+        self.assertEqual(coa.accounts[0].root_type, "Asset")
+
+    def test_unknown_account_name_is_a_no_op(self):
+        coa = _coa([_acct("Real", "Asset")])
+        apply_account_overrides(
+            coa, {"Account": {"Ghost": {"root_type": "Income"}}})
+        self.assertEqual(coa.accounts[0].root_type, "Asset")
+
+
+class TestReclassifiedAccountRehomesToNewRoot(unittest.TestCase):
+    """The consistency contract: after an override the account must be placed under a
+    group whose root matches the NEW root_type. ``_resolve_parent`` returns the new
+    root's group for a blank parent, so the re-home apply_account_overrides performs is
+    exactly what the importer needs to avoid a root mismatch."""
+
+    def _importer(self, root_group_for):
+        imp = AccountImporter.__new__(AccountImporter)
+        imp._redirect = {}
+        imp.mode = "reuse"
+        # Stub the DB-touching root-group lookup: return a sentinel group per root_type.
+        imp._root_group = lambda root_type: root_group_for.get(root_type)
+        return imp
+
+    def test_blank_parent_after_override_routes_to_new_root_group(self):
+        coa = _coa([_acct("Weird Ledger", "Liability", parent="Suspense")])
+        apply_account_overrides(
+            coa, {"Account": {"Weird Ledger": {"root_type": "Income"}}})
+        node = coa.accounts[0]
+        imp = self._importer({"Income": "Indirect Incomes - X",
+                              "Liability": "Current Liabilities - X"})
+        # It must resolve to the INCOME group (the new root), never the old liability one.
+        self.assertEqual(imp._resolve_parent(node), "Indirect Incomes - X")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

On the Preview step, each account whose type the tool had to **infer** (a ledger under a custom Tally group) is now an editable dropdown. The user can correct the root type (Asset / Liability / Equity / Income / Expense) before importing, and the preview - including the opening-balances plug - updates to match.

## Why

Account classification is derived, not stored: for a ledger under a custom group, the tool infers the root type from the group's own nature. When that guess is wrong there was previously no way to fix it before importing - the user had to correct it in ERPNext afterwards, and a wrong root type distorts the balance sheet.

## How

- New `apply_account_overrides(coa, overrides, changelog)` patches `AccountNode.root_type` for the `Account` override bucket. It also:
  - resets `account_type` to the derived default for the new root (so an account moved to Income/Expense carries the right tag and one moved to a balance-sheet root drops any P&L tag);
  - clears the account's parent so the importer re-homes it under the new root's group - otherwise ERPNext would reject a child whose root_type differs from its parent's.
- Applied right after `extract_coa()` in both the import path (`MasterMigrator.run`, so sync and background runs alike) and the pre-flight preview, and folded into the stored mapping report so the Log matches what was imported.
- Only the root type is editable. The finer `account_type` (Bank / Tax / …) stays derived and is not exposed, because it drives bank-account creation and India Compliance's GST behaviour and must come from a precise signal, not a manual pick.
- The wizard writes the choice into the existing record-overrides structure (persisted, replayed on re-run, recorded in the applied-edits audit trail).

## Tests

Unit tests for the override (root/account_type/parent re-home, group and no-op guards, other buckets ignored); a consistency test that a re-classified account resolves to a parent under the new root; and end-to-end tests that the preview and the opening plug reflect the edit. Full suite green.
