### PR TITLE
feat: resolve item HSN from a shared GST Classification master

### DIFF
--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -826,6 +826,12 @@ Migrator handles a real-world wrinkle in Tally data.
   because GST invoices for it will not be compliant until you add one. If India
   Compliance rejects a specific HSN as invalid, the item is retried with the HSN
   cleared so it still lands, and you are told to set a correct one.
+- **HSN defined on a shared GST Classification.** Many Tally books set an HSN/SAC once
+  on a "GST Classification" master and point several items at it, instead of typing it
+  on each item. Those items are read as having the classification's HSN, so they import
+  with the correct code rather than blank. An item's own HSN, when it has one, always
+  takes precedence; slab-rate classifications are handled the same way (only the HSN is
+  taken from them). An item genuinely without any HSN still imports blank and is warned.
 - **Batch and expiry.** An item marked batch-wise in Tally gets batch tracking turned
   on; if it is also perishable, expiry tracking is enabled too.
 - **Opening stock value.** Every item with opening stock is imported with its quantity

--- a/tally_migrator/tally/extractors.py
+++ b/tally_migrator/tally/extractors.py
@@ -6,6 +6,13 @@ from .mappings import TALLY_ROOT_PARENT, classify_group, is_system_ledger
 from .resolver import ACCOUNT, CUSTOMER, SUPPLIER, LedgerResolver
 
 
+def _norm_hsn_class_name(name: str) -> str:
+    """Match key for a GST Classification name: whitespace collapsed and casefolded,
+    so an item's reference matches the master's name despite trivial spacing/case
+    drift (Tally is normally byte-consistent, but this costs nothing and is safe)."""
+    return re.sub(r"\s+", " ", (name or "")).strip().casefold()
+
+
 # ── Field lists sent to Tally via TDL FETCH ───────────────────────────────────
 
 LEDGER_FIELDS = [
@@ -29,6 +36,11 @@ ITEM_FIELDS = [
     "Name", "Parent", "BaseUnits", "StandardCost", "StandardPrice",
     "OpeningBalance", "OpeningRate", "OpeningValue", "Description",
     "HSNCode", "GSTTaxability", "TypeOfSupply",
+    # HSN can be defined once on a shared GST Classification master and referenced by
+    # the item (HSNDETAILS.LIST/HSNCLASSIFICATIONNAME, with SRCOFHSNDETAILS = "Use GST
+    # Classification"). These two carry that link so _attach_item_hsn_from_classification
+    # can fill the item's HSN from the master when the item has none of its own.
+    "HSNClassificationName", "SrcOfHsnDetails",
     # Inventory valuation method (→ Item.valuation_method) and the flat item-level
     # GST flag (→ India-Compliance is_non_gst). Both have real ERPNext targets.
     "ValuationMethod", "GstApplicable",
@@ -117,6 +129,10 @@ ITEM_TAGS = {
     # is nested per duty-head and usually inherited via SRCOFGSTDETAILS, so the
     # item-level value is 0/unreliable; ERPNext models rate as a tax template.)
     "HSNCode":       ["HSNDETAILS.LIST/HSNCODE", "HSNCODE"],
+    # The classification an item points at, and Tally's HSN source flag - both nested
+    # in the item's HSNDETAILS.LIST alongside HSNCODE (verified against a real export).
+    "HSNClassificationName": ["HSNDETAILS.LIST/HSNCLASSIFICATIONNAME"],
+    "SrcOfHsnDetails":       ["HSNDETAILS.LIST/SRCOFHSNDETAILS"],
     "GSTTaxability": ["GSTDETAILS.LIST/TAXABILITY"],
     "TypeOfSupply":  ["GSTDETAILS.LIST/SUPPLYTYPE", "TYPEOFSUPPLY", "GSTTYPEOFSUPPLY"],
     # Tally exposes the costing/market valuation under either tag; "Avg. Cost"/
@@ -274,6 +290,9 @@ class TallyExtractor:
             units        = self._dedup_by_name(
                 self.client.get_collection("Unit", UNIT_FIELDS, UNIT_TAGS)),
         )
+        # Fill an item's HSN from the shared GST Classification it points at, when it
+        # has none of its own. No-op when the book defines no such masters (common).
+        self._attach_item_hsn_from_classification(masters.items)
         # Attach each item's combined GST rate (IGST), read per duty head from the
         # nested rate list. No-op for a live client that can't supply it.
         self._attach_item_gst_rates(masters.items)
@@ -340,6 +359,59 @@ class TallyExtractor:
         godowns = self.client.item_godown_openings()
         for it in items:
             it.setdefault("GodownOpenings", godowns.get(it.get("_name", ""), []))
+
+    def _gst_classification_hsn(self) -> dict:
+        """``{normalised classification name -> HSN/SAC code}`` from the GST
+        Classification masters.
+
+        The classification stores its HSN at ``HSNDETAILS.LIST/HSNCODE`` - the very
+        path an item's own HSN uses - so the same reader applies. The name is matched
+        case- and whitespace-insensitively (see ``_norm_hsn_class_name``). Returns an
+        empty map when the book has no such masters, or the source can't supply them
+        (a live client). Best-effort: it never raises into extraction."""
+        try:
+            rows = self.client.get_collection(
+                "GST Classification", ["HSNCode"],
+                {"HSNCode": ["HSNDETAILS.LIST/HSNCODE", "HSNCODE"]})
+        except Exception:
+            return {}
+        out: dict[str, str] = {}
+        for r in rows:
+            hsn = (r.get("HSNCode") or "").strip()
+            if hsn:
+                out[_norm_hsn_class_name(r.get("_name", ""))] = hsn
+        return out
+
+    def _attach_item_hsn_from_classification(self, items: list[dict]) -> None:
+        """Fill an item's HSN from the shared GST Classification it points at, when the
+        item carries no HSN of its own.
+
+        Tally lets a book define an HSN once on a GST Classification master and have
+        many items reference it by name (``HSNDETAILS.LIST/HSNCLASSIFICATIONNAME``, with
+        ``SRCOFHSNDETAILS = "Use GST Classification"``); without this those items would
+        import with a blank HSN. Rules, in order:
+
+          * the item's OWN HSN always wins (never overridden);
+          * a blank own-HSN whose ``SRCOFHSNDETAILS`` is explicitly "Specify Details
+            Here" is left blank - the user chose to type their own and left it empty,
+            so a stale classification name must not be pulled in;
+          * otherwise, if the item names a classification, use that classification's
+            HSN - staying blank when the master is absent or itself carries no HSN.
+
+        No-op (and no per-item work) when the book has no GST Classification masters -
+        the common case - so a normal import pays nothing for this."""
+        cmap = self._gst_classification_hsn()
+        if not cmap:
+            return
+        for it in items:
+            if (it.get("HSNCode") or "").strip():
+                continue
+            if (it.get("SrcOfHsnDetails") or "").strip().casefold() == "specify details here":
+                continue
+            name = _norm_hsn_class_name(it.get("HSNClassificationName") or "")
+            hsn = cmap.get(name) if name else None
+            if hsn:
+                it["HSNCode"] = hsn
 
     @staticmethod
     def _dedup_by_name(records: list[dict]) -> list[dict]:

--- a/tally_migrator/tally/file_source.py
+++ b/tally_migrator/tally/file_source.py
@@ -22,6 +22,10 @@ _ZIP_MAGIC = b"PK\x03\x04"
 MASTER_RECORD_TAGS = (
     "GROUP", "LEDGER", "STOCKITEM", "GODOWN",
     "COSTCENTRE", "STOCKGROUP", "UNIT", "CURRENCY",
+    # GST Classification masters carry a shared HSN/SAC that stock items point at
+    # (HSNDETAILS.LIST/HSNCLASSIFICATIONNAME); indexed so the extractor can resolve an
+    # item's HSN from its classification. Few per book, so retaining them costs ~nothing.
+    "GSTCLASSIFICATION",
 )
 
 

--- a/tally_migrator/tests/test_hsn_classification.py
+++ b/tally_migrator/tests/test_hsn_classification.py
@@ -1,0 +1,183 @@
+"""HSN resolved from a shared GST Classification master (#4).
+
+Tally lets a book define an HSN once on a GST Classification master and have many
+stock items reference it by name (``HSNDETAILS.LIST/HSNCLASSIFICATIONNAME``, with
+``SRCOFHSNDETAILS = "Use GST Classification"``). Those items carry no HSN of their
+own, so without resolution they import blank. All values here are illustrative.
+
+Two layers:
+  * end-to-end through ``FileTallySource`` (proves GSTCLASSIFICATION is indexed by the
+    streamer and the nested tag paths resolve), and
+  * ``_attach_item_hsn_from_classification`` / ``_gst_classification_hsn`` logic against
+    a mock client (every edge case, isolated).
+"""
+import unittest
+
+from tally_migrator.tally.extractors import TallyExtractor, _norm_hsn_class_name
+from tally_migrator.tally.file_source import FileTallySource
+from tally_migrator.validation.engine import validate_masters
+
+
+# ── End-to-end through the real parser ────────────────────────────────────────
+
+def _item_xml(name, inner):
+    return (f'<TALLYMESSAGE><STOCKITEM NAME="{name}"><NAME>{name}</NAME>'
+            f'<BASEUNITS>Nos</BASEUNITS>{inner}</STOCKITEM></TALLYMESSAGE>')
+
+
+_XML = (
+    '<ENVELOPE><BODY><IMPORTDATA><REQUESTDATA>'
+    # A GST Classification master carrying the HSN once.
+    '<TALLYMESSAGE><GSTCLASSIFICATION NAME="HSN 8471 - Computers">'
+    '<HSNDETAILS.LIST><HSNCODE>8471</HSNCODE>'
+    '<SRCOFHSNDETAILS>Specify Details Here</SRCOFHSNDETAILS></HSNDETAILS.LIST>'
+    '</GSTCLASSIFICATION></TALLYMESSAGE>'
+    # Item that points at the classification (no HSN of its own).
+    + _item_xml("Laptop",
+                '<HSNDETAILS.LIST>'
+                '<HSNCLASSIFICATIONNAME>HSN 8471 - Computers</HSNCLASSIFICATIONNAME>'
+                '<SRCOFHSNDETAILS>Use GST Classification</SRCOFHSNDETAILS></HSNDETAILS.LIST>')
+    # Item with its own HSN (control - must win / be untouched).
+    + _item_xml("Mouse",
+                '<HSNDETAILS.LIST><HSNCODE>8544</HSNCODE>'
+                '<SRCOFHSNDETAILS>Specify Details Here</SRCOFHSNDETAILS></HSNDETAILS.LIST>')
+    # Item with no HSN at all - must stay blank.
+    + _item_xml("Pencil", "")
+    + '</REQUESTDATA></IMPORTDATA></BODY></ENVELOPE>'
+)
+
+
+class TestHsnFromClassificationEndToEnd(unittest.TestCase):
+    def setUp(self):
+        self.items = {it["_name"]: it
+                      for it in TallyExtractor(FileTallySource(_XML)).extract_all().items}
+
+    def test_item_hsn_resolved_from_classification(self):
+        # Laptop had no HSN of its own; it inherits 8471 from the classification it names.
+        self.assertEqual(self.items["Laptop"]["HSNCode"], "8471")
+
+    def test_item_own_hsn_is_preserved(self):
+        self.assertEqual(self.items["Mouse"]["HSNCode"], "8544")
+
+    def test_item_with_no_hsn_stays_blank(self):
+        self.assertEqual((self.items["Pencil"].get("HSNCode") or ""), "")
+
+    def test_streamer_indexes_gst_classification(self):
+        # If GSTCLASSIFICATION were not in MASTER_RECORD_TAGS the map would be empty
+        # and Laptop would be blank - this is the guard against that wiring regressing.
+        cmap = TallyExtractor(FileTallySource(_XML))._gst_classification_hsn()
+        self.assertEqual(cmap, {"hsn 8471 - computers": "8471"})
+
+    def test_validation_no_false_hsn_warning_for_resolved_item(self):
+        masters = TallyExtractor(FileTallySource(_XML)).extract_all()
+        codes = [(i.entity_name, i.code) for i in validate_masters(masters).issues]
+        missing = {name for name, code in codes if code == "HSN_MISSING"}
+        self.assertNotIn("Laptop", missing)   # resolved -> no warning
+        self.assertNotIn("Mouse", missing)    # own HSN -> no warning
+        self.assertIn("Pencil", missing)      # genuinely blank -> still warned
+
+
+# ── Logic edge cases against a mock client ────────────────────────────────────
+
+class _ClsClient:
+    """Minimal client: serves GST Classification rows to get_collection, nothing else."""
+    def __init__(self, classifications=(), raise_on_read=False):
+        self._c = classifications           # iterable of (name, hsn)
+        self._raise = raise_on_read
+
+    def get_collection(self, obj_type, fields, tag_map=None):
+        if self._raise:
+            raise RuntimeError("source cannot supply this collection")
+        if obj_type == "GST Classification":
+            return [{"_name": n, "HSNCode": h} for n, h in self._c]
+        return []
+
+
+def _ext(classifications=(), raise_on_read=False):
+    return TallyExtractor(_ClsClient(classifications, raise_on_read))
+
+
+def _item(name, hsn="", cls="", src=""):
+    return {"_name": name, "HSNCode": hsn,
+            "HSNClassificationName": cls, "SrcOfHsnDetails": src}
+
+
+class TestAttachHsnFromClassification(unittest.TestCase):
+    CLS = [("HSN 8471 - Computers", "8471"), ("SAC 9983 - Consulting", "9983")]
+
+    def _run(self, items, classifications=None):
+        ext = _ext(self.CLS if classifications is None else classifications)
+        ext._attach_item_hsn_from_classification(items)
+        return items
+
+    def test_blank_item_inherits_classification_hsn(self):
+        it = self._run([_item("A", cls="HSN 8471 - Computers", src="Use GST Classification")])[0]
+        self.assertEqual(it["HSNCode"], "8471")
+
+    def test_own_hsn_always_wins(self):
+        it = self._run([_item("A", hsn="1234", cls="HSN 8471 - Computers",
+                              src="Use GST Classification")])[0]
+        self.assertEqual(it["HSNCode"], "1234")
+
+    def test_specify_details_here_with_blank_own_stays_blank(self):
+        # User chose to type their own HSN and left it empty: a stale link name must
+        # not be pulled in.
+        it = self._run([_item("A", hsn="", cls="HSN 8471 - Computers",
+                              src="Specify Details Here")])[0]
+        self.assertEqual(it["HSNCode"], "")
+
+    def test_missing_classification_leaves_item_blank(self):
+        it = self._run([_item("A", cls="HSN 9999 - Unknown", src="Use GST Classification")])[0]
+        self.assertEqual(it["HSNCode"], "")
+
+    def test_item_without_a_classification_name_is_untouched(self):
+        it = self._run([_item("A")])[0]
+        self.assertEqual(it["HSNCode"], "")
+
+    def test_name_match_is_case_and_space_insensitive(self):
+        it = self._run([_item("A", cls="  hsn   8471 - COMPUTERS ",
+                              src="Use GST Classification")])[0]
+        self.assertEqual(it["HSNCode"], "8471")
+
+    def test_sac_classification_resolves_too(self):
+        it = self._run([_item("A", cls="SAC 9983 - Consulting", src="Use GST Classification")])[0]
+        self.assertEqual(it["HSNCode"], "9983")
+
+    def test_no_classifications_is_a_noop(self):
+        items = [_item("A", cls="HSN 8471 - Computers", src="Use GST Classification"),
+                 _item("B", hsn="5555")]
+        self._run(items, classifications=[])
+        self.assertEqual([i["HSNCode"] for i in items], ["", "5555"])
+
+
+class TestGstClassificationHsnMap(unittest.TestCase):
+    def test_map_normalises_names_and_drops_hsnless(self):
+        ext = _ext([("HSN 8471 - Computers", "8471"),
+                    ("Rate Only Class", ""),           # no HSN -> excluded
+                    ("SAC 9983 - Consulting", " 9983 ")])
+        self.assertEqual(ext._gst_classification_hsn(),
+                         {"hsn 8471 - computers": "8471",
+                          "sac 9983 - consulting": "9983"})
+
+    def test_duplicate_names_last_wins(self):
+        ext = _ext([("Dup", "1111"), ("Dup", "2222")])
+        self.assertEqual(ext._gst_classification_hsn(), {"dup": "2222"})
+
+    def test_source_error_yields_empty_map_not_raise(self):
+        # A live client that can't supply the collection must degrade to a no-op,
+        # never break extraction.
+        self.assertEqual(_ext(raise_on_read=True)._gst_classification_hsn(), {})
+
+
+class TestNormaliseHsnClassName(unittest.TestCase):
+    def test_collapses_space_and_casefolds(self):
+        self.assertEqual(_norm_hsn_class_name("  HSN   8471 - Computers "),
+                         "hsn 8471 - computers")
+
+    def test_blank_and_none_safe(self):
+        self.assertEqual(_norm_hsn_class_name(""), "")
+        self.assertEqual(_norm_hsn_class_name(None), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

An item's HSN/SAC can be resolved from a shared **GST Classification** master when the item does not carry an HSN of its own.

## Why

Tally lets a book define an HSN/SAC once on a GST Classification master and have many stock items reference it by name, instead of typing it on each item. The migrator only read an item's own HSN, so every item pointing at a classification imported with a **blank HSN**.

## How

- The streaming parser now indexes `GSTCLASSIFICATION` masters.
- The extractor reads the item's `HSNDETAILS.LIST/HSNCLASSIFICATIONNAME` link (and `SRCOFHSNDETAILS`), and builds a `{name -> HSN}` map from the classification masters. The classification stores its HSN at the same `HSNDETAILS.LIST/HSNCODE` path an item's own HSN uses, so the existing reader is reused.
- A new post-extraction step fills an item's HSN from its classification when it has none of its own.

**Resolution rules (in order):**
- the item's own HSN always wins (never overridden);
- a blank own-HSN explicitly marked "Specify Details Here" is left blank, so a stale link name is not pulled in;
- otherwise, if the item names a classification, use that classification's HSN, staying blank when the master is absent or itself carries no HSN.

Slab-rate classifications are handled the same way (only the HSN is taken; the rate is india_compliance's model). Name matching is case- and whitespace-insensitive.

## Performance

No per-item work when a book defines no such masters (the common case) - the step early-returns. The link fields are resolved once inside the cached collection read (no per-re-check cost), and the retained classification elements are a handful.

## Tests

18 new tests: end-to-end through the real parser (proves the streamer indexing + nested tag paths + no false HSN warning) plus mock-client edge cases (own wins, stale-name gate, missing/HSN-less master, case/space match, SAC, duplicates, source-error no-op, no-classification no-op). Full suite green.
