### PR TITLE
fix: don't flag different firms sharing a generic trade word as duplicates

### DIFF
--- a/tally_migrator/tests/test_validation.py
+++ b/tally_migrator/tests/test_validation.py
@@ -162,6 +162,51 @@ class TestDedup(unittest.TestCase):
         self.assertEqual(find_duplicate_groups(parties), [])
 
 
+class TestDedupFalsePositives(unittest.TestCase):
+    """Different firms that merely share a generic trade word must not group,
+    while genuine variants and typos still do (#1)."""
+
+    def _names(self, *names):
+        return find_duplicate_groups([_party(n) for n in names])
+
+    def test_shared_generic_word_does_not_group_different_firms(self):
+        # "... Traders" alone once inflated the whole-string ratio past 0.80.
+        self.assertEqual(self._names("Ramesh Traders", "Ganesh Traders"), [])
+        self.assertEqual(self._names("ABC Traders", "XYZ Traders"), [])
+        self.assertEqual(self._names("Sunrise Agency", "Sunset Agency"), [])
+
+    def test_singular_and_plural_entity_forms_still_group(self):
+        # Enterprise/Enterprises and Industry/Industries are the same firm.
+        self.assertEqual(len(self._names("Shah Enterprise", "Shah Enterprises")), 1)
+        self.assertEqual(len(self._names("Patel Industry", "Patel Industries")), 1)
+
+    def test_typo_inside_the_distinctive_core_still_groups(self):
+        # The distinctive-core check uses a ratio, not exact tokens, so a typo in
+        # the identifying word is still caught.
+        self.assertEqual(len(self._names("Kumar Traders", "Kumr Traders")), 1)
+
+    def test_same_core_with_extra_words_still_groups(self):
+        # Genuine variant: same distinctive core, differing only by entity form.
+        self.assertEqual(len(self._names("Kumar Traders", "Kumar Traders Pvt Ltd")), 1)
+
+    def test_all_generic_name_is_not_fuzzy_matched(self):
+        # Names whose distinctive core is empty have no anchor to match on.
+        self.assertEqual(self._names("Traders Agency", "Trading Agencies"), [])
+
+    def test_shared_distinctive_word_but_different_trade_stays_separate(self):
+        # These share a distinctive token ("national", "new india", "sri ram") so the
+        # distinctive-core ratio is 1.0 - but the whole-string ratio fails because the
+        # trade words differ. Requiring BOTH legs (not just core overlap) keeps them apart.
+        self.assertEqual(self._names("National Traders", "National Agency"), [])
+        self.assertEqual(self._names("New India Traders", "New India Agency"), [])
+        self.assertEqual(self._names("Sri Ram Traders", "Sri Ram Agency"), [])
+
+    def test_identical_all_generic_names_still_group_by_exact_tier(self):
+        # An empty distinctive core skips only the fuzzy tier; two parties with the
+        # exact same (all-generic) name are still an exact duplicate.
+        self.assertEqual(len(self._names("Traders", "Traders")), 1)
+
+
 # ── Master-level rules ────────────────────────────────────────────────────────
 
 class TestValidateMasters(unittest.TestCase):

--- a/tally_migrator/validation/engine.py
+++ b/tally_migrator/validation/engine.py
@@ -209,17 +209,49 @@ def pin_state_conflict(pin: str, state: str) -> str | None:
 
 # ── Party de-duplication (normalized name + GSTIN + phone) ────────────────────
 
+# Legal-form / connector noise, stripped from the name before the *exact* dedupe
+# tier. Keep this set conservative: whatever is dropped here makes two names collapse
+# to the same key, so anything but true entity-form noise (Pvt/Ltd/Enterprise...) would
+# manufacture false "exact duplicate" matches. Singular and plural are both listed so a
+# ledger written either way normalizes the same.
 _SUFFIXES = {
     "pvt", "private", "ltd", "limited", "llp", "inc", "co", "company",
-    "corporation", "corp", "and", "the", "&", "industries", "enterprises",
+    "corporation", "corp", "and", "the", "&",
+    "industries", "industry", "enterprises", "enterprise",
 }
+
+# Generic trade descriptors shared by unrelated firms ("X Traders", "Y Traders"). These
+# are NOT stripped for exact matching (that would over-collapse - "Kumar Traders" and
+# "Kumar Agency" are different businesses). They are removed only when isolating a name's
+# *distinctive* part for the fuzzy look-alike tier, so a shared generic word can no longer
+# inflate the similarity ratio between two otherwise-different names.
+_GENERIC_TOKENS = _SUFFIXES | {
+    "traders", "trader", "trading", "agency", "agencies", "store", "stores",
+    "sons", "brothers", "bros", "associates", "associate", "group",
+    "marketing", "sales", "distributors", "distributor",
+    "exports", "imports", "international", "works",
+}
+
+
+def _strip_tokens(name: str, drop: set) -> str:
+    """Lowercase, drop punctuation and any token in ``drop``, collapse whitespace."""
+    s = re.sub(r"[^a-z0-9 ]", " ", (name or "").lower())
+    return " ".join(t for t in s.split() if t and t not in drop)
 
 
 def normalize_party_name(name: str) -> str:
     """Lowercase, strip punctuation and common company suffixes, collapse spaces."""
-    s = re.sub(r"[^a-z0-9 ]", " ", (name or "").lower())
-    tokens = [t for t in s.split() if t and t not in _SUFFIXES]
-    return " ".join(tokens)
+    return _strip_tokens(name, _SUFFIXES)
+
+
+def _distinctive_name(name: str) -> str:
+    """The name with generic trade words also removed - its identifying core.
+
+    Used only by the fuzzy tier: comparing distinctive cores (not whole strings)
+    stops a shared generic word ("Traders", "Agency") from inflating the similarity
+    of two unrelated firms, while still tolerating typos within the core itself.
+    """
+    return _strip_tokens(name, _GENERIC_TOKENS)
 
 
 def _phone_digits(rec: dict) -> str:
@@ -244,9 +276,12 @@ def find_duplicate_groups(parties: list[dict], threshold: float = 0.80,
       OR same 10-digit phone. Grouped by hashing each key into buckets (blanks
       skipped, so empty-normalised names never clump together) - linear, runs at any
       file size.
-    - **Look-alike** (only when party count <= ``fuzzy_max``): fuzzy name ratio >=
-      ``threshold``, an O(n^2) pairwise pass. Skipped on very large files, where it is
-      both far too slow and dominated by false positives.
+    - **Look-alike** (only when party count <= ``fuzzy_max``): an O(n^2) pairwise pass
+      that groups two names when they clear ``threshold`` on both the whole normalized
+      name and its distinctive core (the name minus generic trade words). Requiring the
+      core to match too keeps unrelated firms that merely share a generic word ("X
+      Traders" / "Y Traders") apart. Skipped on very large files, where it is both far
+      too slow and dominated by false positives.
 
     Returns groups of size >= 2 (singletons are not duplicates).
     """
@@ -279,14 +314,22 @@ def find_duplicate_groups(parties: list[dict], threshold: float = 0.80,
                 first[k] = i
 
     # Look-alike tier: quadratic, so only for small enough party sets. Already-grouped
-    # pairs are skipped, and empty normalised names are never fuzzy-matched.
+    # pairs are skipped, and empty normalised names are never fuzzy-matched. A pair must
+    # clear the ratio on BOTH the whole name and the distinctive core - the second leg is
+    # what stops "Ramesh Traders" / "Ganesh Traders" (a shared generic word) from matching
+    # while still catching a typo inside the core ("Kumar" / "Kumr").
     if n <= fuzzy_max:
+        dist = [_distinctive_name(p["_name"]) for p in parties]  # only needed here
         for i in range(n):
             for j in range(i + 1, n):
                 if find(i) == find(j):
                     continue
-                if (norm[i] and norm[j]
-                        and SequenceMatcher(None, norm[i], norm[j]).ratio() >= threshold):
+                if not (norm[i] and norm[j] and dist[i] and dist[j]):
+                    continue
+                # Whole-string leg first (cheap short-circuit): the distinctive-core
+                # ratio is only computed for pairs that already look alike overall.
+                if (SequenceMatcher(None, norm[i], norm[j]).ratio() >= threshold
+                        and SequenceMatcher(None, dist[i], dist[j]).ratio() >= threshold):
                     union(i, j)
 
     groups: dict[int, list[str]] = {}


### PR DESCRIPTION
## Problem

The look-alike (fuzzy) tier of party de-duplication compared **whole** normalized names with `SequenceMatcher >= 0.80`. A shared generic word (`Traders`, `Agency`, ...) inflated the ratio past the threshold, so two unrelated firms got flagged as the same party:

| Pair | Ratio | Before |
|---|---|---|
| `Ramesh Traders` / `Ganesh Traders` | 0.857 | flagged duplicate |
| `ABC Traders` / `XYZ Traders` | 0.727* | flagged in some casings |

## Fix

A fuzzy pair must now clear the threshold on **both** the whole normalized name **and** its **distinctive core** (the name with generic trade words removed). The shared generic word can no longer carry the match:

- `Ramesh Traders` / `Ganesh Traders` -> core `ramesh` / `ganesh` = 0.667 -> **separate**
- `Kumar Traders` / `Kumr Traders` (typo) -> core `kumar` / `kumr` = 0.889 -> **still grouped** (core compared by ratio, so typos still catch)
- `Shah Enterprise` / `Shah Enterprises` -> **still grouped**
- `Kumar Traders` / `Kumar Traders Pvt Ltd` -> exact tier -> **still grouped**

### Why both legs

Requiring the core alone would wrongly group firms that share a distinctive word but do different trades (`National Traders` / `National Agency`, core ratio 1.0). The whole-string leg rejects those (0.710). Both legs together are what make it precise.

### Notes
- Generic trade words are kept in a **separate** set used only to isolate the distinctive core. They are deliberately **not** stripped for exact matching, which would over-collapse `Kumar Traders` and `Kumar Agency` into one key.
- The exact tiers (name / GSTIN / phone) are unchanged; anything that grouped by an exact key before still does.
- Remains a **warning**, never blocks the migration.
- Distinctive-core list built lazily inside the fuzzy gate; short-circuited behind the whole-string ratio, so overhead is within noise (measured 1.7% at the 2000-party cutoff).

## Tests

8 new cases in `test_validation.py` (false-positive separation, entity-form variants, typo-in-core, shared-distinctive-word-different-trade, identical all-generic via exact tier). Full suite: **744 pass**.