### PR TITLE
fix: import equity accounts on charts with no equity root (India COA)

### DIFF
--- a/docs/tally-migrator-documentation.md
+++ b/docs/tally-migrator-documentation.md
@@ -858,6 +858,11 @@ Migrator handles a real-world wrinkle in Tally data.
 - **Reserved groups** (standard, named Tally groups) are not recreated in reuse mode;
   their ERPNext equivalents are used as parents. In mirror mode, every group is
   recreated.
+- **Capital and reserves (equity).** ERPNext's standard chart has no separate equity
+  root, so proprietor / partner capital and reserves are placed on the funding side,
+  under **Source of Funds (Liabilities)** - the same place ERPNext keeps its own
+  "Capital Account". They import with their opening balances intact; only their spot in
+  the tree differs from Tally's.
 - **Renamed standard groups.** If you renamed one of Tally's standard groups (for
   example "Duties & Taxes" to "GST Dues"), its ledgers are still classified correctly.
   Tally keeps the original identity of a standard group even after a rename, and the

--- a/tally_migrator/erpnext/importers/accounts.py
+++ b/tally_migrator/erpnext/importers/accounts.py
@@ -30,6 +30,13 @@ from tally_migrator.migration import record_guard
 
 # ── Chart of Accounts importer ───────────────────────────────────────────────
 
+# Root types that, when absent from the target chart, fall back to another root's
+# group so the account still imports instead of failing for want of a parent. Equity
+# has no dedicated root in ERPNext's standard chart - capital sits on the Liabilities
+# (funding) side - so it falls back there. See AccountImporter._root_group.
+_ROOT_TYPE_FALLBACK = {"Equity": "Liability"}
+
+
 class AccountImporter:
     """Creates the Chart of Accounts (groups + ledger accounts).
 
@@ -193,6 +200,24 @@ class AccountImporter:
         return resolved
 
     def _root_group(self, root_type: str) -> str | None:
+        resolved = self._root_group_for(root_type)
+        if resolved:
+            return resolved
+        # ERPNext's standard chart has no dedicated Equity root: proprietor/partner
+        # capital and reserves nest on the funding (Liabilities) side - the shipped
+        # "Capital Account" group is itself root_type Liability under "Source of Funds
+        # (Liabilities)". So an Equity account that has to fall back to its root - a
+        # custom equity group under Primary, or (in mirror mode) the recreated reserved
+        # Capital Account group - would otherwise find no root, fail to import, and
+        # silently divert its opening balance to Temporary Opening. Fall back to the
+        # Liability root for Equity. Never applied when an Equity root does exist (a
+        # custom chart that ships one), so those charts are unaffected.
+        fallback = _ROOT_TYPE_FALLBACK.get(root_type)
+        return self._root_group_for(fallback) if fallback else None
+
+    def _root_group_for(self, root_type: str) -> str | None:
+        if not root_type:
+            return None
         base = ERPNEXT_ROOT_GROUPS.get(root_type)
         if base:
             candidate = self._erp_name(base)

--- a/tally_migrator/tests/test_account_root_fallback.py
+++ b/tally_migrator/tests/test_account_root_fallback.py
@@ -1,0 +1,70 @@
+"""Equity accounts must still find a root when the chart has no Equity root (#3b).
+
+ERPNext's standard chart has no dedicated Equity root - proprietor/partner capital
+and reserves nest on the Liabilities (funding) side. Without a fallback, an Equity
+account that has to resolve to its root (a custom equity group under Primary, or the
+reserved Capital Account group recreated in mirror mode) found no parent, failed to
+import, and its opening balance silently diverted to Temporary Opening.
+
+These mock the Account lookups so the logic is exercised deterministically, without
+depending on any particular company's chart being present.
+"""
+import unittest
+from unittest import mock
+
+from tally_migrator.erpnext.importers.accounts import (
+    AccountImporter, _ROOT_TYPE_FALLBACK,
+)
+
+LIAB_ROOT = "Source of Funds (Liabilities) - TC"
+EQUITY_ROOT = "Equity - TC"
+
+
+class TestEquityRootFallback(unittest.TestCase):
+    def _imp(self):
+        return AccountImporter("Test Co", "TC", mode="reuse")
+
+    def _get_all(self, roots):
+        """Fake frappe.get_all returning a no-parent root row for each root_type in
+        ``roots`` (name -> row), and nothing for the rest."""
+        def _fake(dt, fields=None, filters=None, **kw):
+            name = roots.get(filters["root_type"])
+            return [{"name": name, "parent_account": None}] if name else []
+        return _fake
+
+    def test_equity_falls_back_to_liability_when_no_equity_root(self):
+        imp = self._imp()
+        # No mapped base account exists; only a Liability root group is present.
+        with mock.patch("frappe.db.exists", return_value=False), \
+                mock.patch("frappe.get_all",
+                           side_effect=self._get_all({"Liability": LIAB_ROOT})):
+            self.assertEqual(imp._root_group("Equity"), LIAB_ROOT)
+
+    def test_equity_root_used_directly_when_the_chart_ships_one(self):
+        # A custom chart that does have an Equity root must use it, never the fallback.
+        imp = self._imp()
+        with mock.patch("frappe.db.exists", return_value=False), \
+                mock.patch("frappe.get_all",
+                           side_effect=self._get_all({"Equity": EQUITY_ROOT,
+                                                      "Liability": LIAB_ROOT})):
+            self.assertEqual(imp._root_group("Equity"), EQUITY_ROOT)
+
+    def test_other_root_types_have_no_fallback_and_stay_none(self):
+        # Only Equity falls back; a genuinely missing Income root must not be silently
+        # rehomed onto some other root.
+        imp = self._imp()
+        with mock.patch("frappe.db.exists", return_value=False), \
+                mock.patch("frappe.get_all", side_effect=self._get_all({})):
+            self.assertIsNone(imp._root_group("Income"))
+        self.assertEqual(_ROOT_TYPE_FALLBACK, {"Equity": "Liability"})
+
+    def test_equity_returns_none_only_if_liability_also_absent(self):
+        # Degenerate chart with neither root: no regression, still None (never raises).
+        imp = self._imp()
+        with mock.patch("frappe.db.exists", return_value=False), \
+                mock.patch("frappe.get_all", side_effect=self._get_all({})):
+            self.assertIsNone(imp._root_group("Equity"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

On ERPNext's **India chart of accounts** (and any chart without a dedicated equity root), an account that resolves to `root_type = Equity` finds no root group. `AccountImporter._root_group("Equity")` returns `None`, the importer records **"could not resolve a parent account"**, and the account is skipped. Its opening balance then falls into **Temporary Opening** with no ledger of its own - a silent balance gap.

In **mirror mode** this hits the recreated **Capital Account** group and cascades to every capital ledger under it.

### Verified (no assumptions)
- Live company on the **India - Chart of Accounts** (ERPNext 16.22): roots are only Asset / Expense / Income / Liability - no Equity.
- Source template `in_standard_chart_of_accounts.json` and **upstream `develop`**: same four roots, no Equity anywhere; `Capital Account` lives under Source of Funds (Liabilities).
- The generic **Standard** chart *does* ship an Equity root - so the fallback must not touch it.

## Fix

`_root_group` falls back to the **Liability** root for Equity only when the chart ships no equity root. This matches how capital is already modelled everywhere it lands:
- ERPNext keeps its own `Capital Account` group under **Source of Funds (Liabilities)**.
- Tally itself presents capital on the **liabilities side** of the balance sheet (capital is treated as a liability of the business).

The fallback is **chart-aware**: a chart that has an equity root resolves it directly and never falls back, so those charts are unchanged. Placed accounts inherit `root_type = Liability` from the parent (exactly like the shipped Capital Account group) while keeping `account_type = Equity`.

## Verification

- Live: previously-failing mirror scenario now imports **2/2**, custom-equity-under-Primary **3/3**, openings intact, correctly nested under Source of Funds (Liabilities).
- Realistic `account_type="Equity"` on a Liability-root account creates cleanly (no validation error).
- New `test_account_root_fallback.py` (4 cases: fallback fires; direct equity root wins when present; other root types never fall back; degenerate chart stays `None` without raising).
- Full suite: **748 pass**.

Documentation note added on where capital and reserves land.