### PR TITLE
fix: leading business-type word no longer collapses unrelated firms in dedup

### DIFF
--- a/tally_migrator/tests/test_validation.py
+++ b/tally_migrator/tests/test_validation.py
@@ -175,10 +175,13 @@ class TestDedupFalsePositives(unittest.TestCase):
         self.assertEqual(self._names("ABC Traders", "XYZ Traders"), [])
         self.assertEqual(self._names("Sunrise Agency", "Sunset Agency"), [])
 
-    def test_singular_and_plural_entity_forms_still_group(self):
-        # Enterprise/Enterprises and Industry/Industries are the same firm.
-        self.assertEqual(len(self._names("Shah Enterprise", "Shah Enterprises")), 1)
-        self.assertEqual(len(self._names("Patel Industry", "Patel Industries")), 1)
+    def test_leading_entity_word_does_not_collapse_unrelated_firms(self):
+        # A business-type word as a *leading* token must not strip a name down to a
+        # shared core and manufacture an exact duplicate (regression: the exact tier
+        # once stripped singular "enterprise"/"industry", grouping these).
+        self.assertEqual(self._names("Enterprise Solutions", "The Solutions Co"), [])
+        self.assertEqual(self._names("Industry Motors", "Motors"), [])
+        self.assertEqual(self._names("Enterprise Traders", "Traders Co"), [])
 
     def test_typo_inside_the_distinctive_core_still_groups(self):
         # The distinctive-core check uses a ratio, not exact tokens, so a typo in

--- a/tally_migrator/validation/engine.py
+++ b/tally_migrator/validation/engine.py
@@ -211,21 +211,29 @@ def pin_state_conflict(pin: str, state: str) -> str | None:
 
 # Legal-form / connector noise, stripped from the name before the *exact* dedupe
 # tier. Keep this set conservative: whatever is dropped here makes two names collapse
-# to the same key, so anything but true entity-form noise (Pvt/Ltd/Enterprise...) would
-# manufacture false "exact duplicate" matches. Singular and plural are both listed so a
-# ledger written either way normalizes the same.
+# to the same key, so only unambiguous legal forms (Pvt/Ltd/LLP/Inc/Corp...) and
+# connectors belong here. Business-type descriptors (Enterprise, Industry, Traders...)
+# are deliberately NOT here: as a *leading* word they would strip down to a shared core
+# and manufacture false exact-duplicates - "Enterprise Solutions" and "The Solutions Co"
+# would both collapse to "solutions". The plural "enterprises"/"industries" are the one
+# exception, kept only because the fuzzy tier relies on them to group an abbreviation
+# like "Reliance Ind." with "Reliance Industries"; their singular forms live in
+# _GENERIC_TOKENS (fuzzy-only) instead.
 _SUFFIXES = {
     "pvt", "private", "ltd", "limited", "llp", "inc", "co", "company",
     "corporation", "corp", "and", "the", "&",
-    "industries", "industry", "enterprises", "enterprise",
+    "industries", "enterprises",
 }
 
-# Generic trade descriptors shared by unrelated firms ("X Traders", "Y Traders"). These
-# are NOT stripped for exact matching (that would over-collapse - "Kumar Traders" and
-# "Kumar Agency" are different businesses). They are removed only when isolating a name's
-# *distinctive* part for the fuzzy look-alike tier, so a shared generic word can no longer
-# inflate the similarity ratio between two otherwise-different names.
+# Generic trade / business-type descriptors shared by unrelated firms ("X Traders",
+# "Y Traders"). These are NOT stripped for exact matching (that would over-collapse -
+# "Kumar Traders" and "Kumar Agency" are different businesses). They are removed only
+# when isolating a name's *distinctive* part for the fuzzy look-alike tier, so a shared
+# generic word can no longer inflate the similarity ratio between two otherwise-different
+# names. Includes the singular entity forms whose plurals sit in _SUFFIXES, so both read
+# as generic when computing the distinctive core.
 _GENERIC_TOKENS = _SUFFIXES | {
+    "industry", "enterprise",
     "traders", "trader", "trading", "agency", "agencies", "store", "stores",
     "sons", "brothers", "bros", "associates", "associate", "group",
     "marketing", "sales", "distributors", "distributor",


### PR DESCRIPTION
## Problem (found by independent review of the develop branch)

The party de-dup **exact** tier strips company-suffix tokens before hashing a name into a duplicate bucket. A recent dedup change added the singular `enterprise` / `industry` to that suffix set. But the exact tier strips a token **wherever it appears**, not just as a trailing suffix - so a name *led* by one of those words collapsed to its trailing core and matched an unrelated firm:

- `"Enterprise Solutions"` + `"The Solutions Co"` → both normalize to `"solutions"` → flagged duplicate
- `"Industry Motors"` + `"Motors"` → both `"motors"` → flagged duplicate

Ironically this was a *new* false positive introduced by the PR whose goal was to reduce them. Impact is bounded (de-dup is a warning-only pre-flight list, never an auto-merge), hence low severity.

## Fix

Move the singular forms to the **fuzzy-only** generic set. The exact tier now strips only unambiguous legal forms and connectors, plus the **plurals** `enterprises`/`industries` (kept because the fuzzy tier relies on them to group an abbreviation like `"Reliance Ind."` with `"Reliance Industries"`).

This restores the exact tier to its pre-change behaviour, so **no genuine duplicate that grouped by an exact key is lost** - verified `"Shah Enterprise"`/`"Shah Enterprises"` were already separate on `main` too.

## Verification (16-case matrix, real code)

- F1 false positives → now separate ✓
- Prior fuzzy fixes (`Ramesh/Ganesh Traders`, `ABC/XYZ Traders`, `National Traders/Agency`) → still separate ✓
- True positives (`Reliance Industries`/`Reliance Ind.`, `Kumar Traders`/`... Pvt Ltd`, `Kumar`/`Kumr` typo, `ABC Enterprises`/`ABC`) → still group ✓
- Replaced the test that asserted the reverted behaviour with a leading-entity-word regression test.
- Full suite: **748 pass**. No em-dashes.